### PR TITLE
Commission manager fixes

### DIFF
--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -435,16 +435,22 @@ contract CommissionManager is Ownable {
 
     /**
      * @notice Receive token commission from bridge
+     * @dev Credits the actual ERC-20 balance increase since the last recorded pool for this token.
+     *      The bridge must transfer tokens to this contract before calling; the `amount` is not taken
+     *      from calldata so accounting matches real transfers (including fee-on-transfer tokens).
      * @param token Token address
-     * @param amount Commission amount
      */
-    function receiveTokenCommission(
-        address token,
-        uint256 amount
-    ) external onlyBridge {
-        require (amount > 0, "CommissionManager: Amount must be positive");
-        tokenCommissionPool[token] += amount;
-        emit TokenCommissionReceived(token, amount);
+    function receiveTokenCommission(address token) external onlyBridge {
+        uint256 newBalance = IERC20(token).balanceOf(address(this));
+        uint256 priorPool = tokenCommissionPool[token];
+        require(
+            newBalance >= priorPool,
+            "CommissionManager: balance below recorded pool"
+        );
+        uint256 recorded = newBalance - priorPool;
+        require(recorded > 0, "CommissionManager: nothing received");
+        tokenCommissionPool[token] = newBalance;
+        emit TokenCommissionReceived(token, recorded);
     }
 
     /**

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -7,6 +7,13 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+import {
+    CommissionConfig,
+    CommissionCurrency,
+    CommissionSide,
+    ICommissionManager
+} from "./interfaces/ICommissionManager.sol";
+
 /**
  * @title CommissionManager
  * @author UTEXO bridge stack
@@ -25,76 +32,8 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
  *      `owner` configures rules and withdraws accumulated pools. `renounceOwnership` is disabled.
  *      Withdrawals use `nonReentrant` against reentrancy via ERC-20 hooks or native recipients.
  */
-contract CommissionManager is Ownable, ReentrancyGuard {
+contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
     using SafeERC20 for IERC20;
-
-    // ============ Structs ============
-
-    /**
-     * @notice Stored commission parameters for one route (see `buildRouteKey`).
-     * @dev `isSet` distinguishes an explicit `commissionRules` entry from unset storage (all zeros).
-     */
-    struct CommissionConfig {
-        /// @notice Fee percent × 100 (e.g. 400 = 4%). Must be ≤ 9000 and > 0 when validated.
-        uint256 stablePercent;
-        /// @notice Divisor in `calculateStableFee`; typically 100.
-        uint8 multiplier;
-        /// @notice Whether this route’s fee applies to funds-in or funds-out quotes.
-        CommissionSide side;
-        /// @notice Fee in token units, or native (via mock rate) when `NATIVE`.
-        CommissionCurrency currency;
-        /// @notice True when this struct is an active per-route override; false for a cleared raw slot.
-        bool isSet;
-    }
-
-    // ============ Enums ============
-
-    /// @notice Which bridge operation this route’s fee is tied to (must match the calculator used).
-    enum CommissionSide {
-        FUNDS_IN,
-        FUNDS_OUT
-    }
-
-    /// @notice Take fee from bridged token amount or express it in native wei.
-    enum CommissionCurrency {
-        TOKEN,
-        NATIVE
-    }
-
-    // ============ Errors ============
-
-    /// @notice Caller is not `bridgeAddress`.
-    error OnlyBridge();
-    /// @notice Bridge address argument is zero.
-    error InvalidBridgeAddress();
-    /// @notice Token address is zero where forbidden.
-    error InvalidToken();
-    /// @notice Recipient address is zero.
-    error InvalidRecipient();
-    /// @notice `stablePercent` exceeds maximum (90%).
-    error StablePercentTooHigh();
-    /// @notice `stablePercent` is zero where forbidden.
-    error StablePercentZero();
-    /// @notice `multiplier` is zero.
-    error MultiplierZero();
-    /// @notice NATIVE currency configured but resolved mock rate is zero.
-    error MockTokenToNativeRateNotSet();
-    /// @notice `IERC20Metadata.decimals()` reverted or missing.
-    error TokenDecimalsUnavailable();
-    /// @notice ERC-20 balance is below recorded pool.
-    error BalanceBelowRecordedPool();
-    /// @notice No net tokens received since last pool snapshot.
-    error NothingReceived();
-    /// @notice Native `receive()` with zero value.
-    error ZeroNativeAmount();
-    /// @notice Withdrawal exceeds accrued pool.
-    error InsufficientBalance();
-    /// @notice Native transfer to recipient failed.
-    error NativeTransferFailed();
-    /// @notice Full withdrawal with zero accrued balance.
-    error NoBalance();
-    /// @notice `renounceOwnership` is disabled.
-    error RenounceOwnershipBlocked();
 
     // ============ State Variables ============
 
@@ -126,56 +65,6 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     /// @notice Per-token mock rate; zero means use `mockTokenToNativeRate`.
     mapping(address => uint256) public mockTokenToNativeRateForToken;
 
-    // ============ Events ============
-
-    /// @notice Emitted when `setBridgeAddress` runs.
-    /// @param newBridge New bridge address.
-    event BridgeAddressUpdated(address indexed newBridge);
-
-    /// @notice Emitted when global defaults change.
-    event GlobalDefaultsUpdated(
-        uint256 stablePercent,
-        uint8 multiplier,
-        CommissionSide side,
-        CommissionCurrency currency
-    );
-
-    /// @notice Emitted when a route rule is stored.
-    event CommissionRuleUpdated(
-        string sourceChain,
-        string destChain,
-        address indexed token,
-        CommissionConfig config
-    );
-
-    /// @notice Emitted when a route rule is removed (globals apply again).
-    event CommissionRuleCleared(
-        string sourceChain,
-        string destChain,
-        address indexed token
-    );
-
-    /// @notice Token commission credited from the bridge.
-    /// @param token ERC-20 token.
-    /// @param amount Net increase credited this call.
-    event TokenCommissionReceived(address indexed token, uint256 amount);
-    /// @notice Native commission received from the bridge.
-    event NativeCommissionReceived(uint256 amount);
-
-    /// @notice Global mock rate updated.
-    event MockTokenToNativeRateUpdated(uint256 rate);
-    /// @notice Per-token mock rate updated.
-    event MockTokenToNativeRateForTokenUpdated(address indexed token, uint256 rate);
-
-    /// @notice Owner withdrew token commission.
-    event TokenCommissionWithdrawn(
-        address indexed token,
-        address indexed to,
-        uint256 amount
-    );
-    /// @notice Owner withdrew native commission.
-    event NativeCommissionWithdrawn(address indexed to, uint256 amount);
-
     // ============ Modifiers ============
 
     /// @dev Restricts call to `bridgeAddress`.
@@ -197,7 +86,7 @@ contract CommissionManager is Ownable, ReentrancyGuard {
 
     /// @inheritdoc Ownable
     /// @notice Always reverts. Use `transferOwnership` to change admin.
-    function renounceOwnership() public view override onlyOwner {
+    function renounceOwnership() public view override(Ownable) onlyOwner {
         revert RenounceOwnershipBlocked();
     }
 

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -8,7 +8,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 /**
  * @title CommissionManager
  * @notice Non-upgradeable commission calculation, configuration, and fee collection for the EVM bridge
- * @dev Aligns with blueprint v3.2: global defaults + per-route overrides, full on-chain stable/native math
+ * @dev Aligns with blueprint v3: global defaults + per-route overrides, full on-chain stable/native math
  */
 contract CommissionManager is Ownable {
     using SafeERC20 for IERC20;

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.20;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -11,7 +12,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
  * @notice Non-upgradeable commission calculation, configuration, and fee collection for the EVM bridge
  * @dev Aligns with blueprint v3: global defaults + per-route overrides, full on-chain stable/native math
  */
-contract CommissionManager is Ownable {
+contract CommissionManager is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     // ============ Structs ============
@@ -509,7 +510,7 @@ contract CommissionManager is Ownable {
         address token,
         address to,
         uint256 amount
-    ) external onlyOwner {
+    ) external onlyOwner nonReentrant {
         if (token == address(0)) revert InvalidToken();
         if (to == address(0)) revert InvalidRecipient();
         if (tokenCommissionPool[token] < amount) revert InsufficientBalance();
@@ -528,7 +529,7 @@ contract CommissionManager is Ownable {
     function withdrawNativeCommission(
         address payable to,
         uint256 amount
-    ) external onlyOwner {
+    ) external onlyOwner nonReentrant {
         if (to == address(0)) revert InvalidRecipient();
         if (nativeCommissionPool < amount) revert InsufficientBalance();
 
@@ -542,7 +543,7 @@ contract CommissionManager is Ownable {
     /**
      * @notice Withdraw entire token commission balance for one token
      */
-    function withdrawAllTokenCommission(address token, address to) external onlyOwner {
+    function withdrawAllTokenCommission(address token, address to) external onlyOwner nonReentrant {
         if (token == address(0)) revert InvalidToken();
         if (to == address(0)) revert InvalidRecipient();
         uint256 balance = tokenCommissionPool[token];
@@ -557,7 +558,7 @@ contract CommissionManager is Ownable {
     /**
      * @notice Withdraw entire native commission balance
      */
-    function withdrawAllNativeCommission(address payable to) external onlyOwner {
+    function withdrawAllNativeCommission(address payable to) external onlyOwner nonReentrant {
         if (to == address(0)) revert InvalidRecipient();
         uint256 balance = nativeCommissionPool;
         if (balance == 0) revert NoBalance();

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -48,7 +48,6 @@ contract CommissionManager is Ownable {
 
     // Constants
     uint256 private constant _MAX_STABLE_PERCENT = 9000; // 90%
-    uint256 private constant _HUNDRED_PERCENT = 10000;
 
     // Per-route overrides
     // key = keccak256(abi.encodePacked(sourceChain, destChain, tokenAddress))
@@ -100,7 +99,7 @@ contract CommissionManager is Ownable {
 
     // ============ Constructor ============
 
-    constructor(address _bridgeAddress) {
+    constructor(address _bridgeAddress) Ownable(msg.sender) {
         require(
             _bridgeAddress != address(0),
             "CommissionManager: Invalid bridge address"
@@ -131,7 +130,7 @@ contract CommissionManager is Ownable {
         uint256 tokenDecimals
     )
         external
-        pure
+        view
         returns (
             uint256 tokenCommission,
             uint256 nativeCommission,
@@ -187,7 +186,7 @@ contract CommissionManager is Ownable {
         uint256 tokenDecimals
     )
         external
-        pure
+        view
         returns (
             uint256 tokenCommission,
             uint256 nativeCommission,
@@ -428,7 +427,7 @@ contract CommissionManager is Ownable {
         string calldata sourceChain,
         string calldata destChain,
         address token
-    ) external pure returns (bytes32) {
+    ) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(sourceChain, destChain, token));
     }
 

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -50,7 +50,7 @@ contract CommissionManager is Ownable {
     uint256 private constant _MAX_STABLE_PERCENT = 9000; // 90%
 
     // Per-route overrides
-    // key = keccak256(abi.encodePacked(sourceChain, destChain, tokenAddress))
+    // key = keccak256(abi.encode(sourceChain, destChain, tokenAddress))
     mapping(bytes32 => CommissionConfig) public commissionRules;
 
     // Accumulated fees
@@ -421,14 +421,15 @@ contract CommissionManager is Ownable {
     }
 
     /**
-     * @notice keccak256(abi.encodePacked(sourceChain, destChain, token))
+     * @notice keccak256(abi.encode(sourceChain, destChain, token))
+     * @dev Uses abi.encode (not encodePacked) so dynamic string arguments cannot be concatenated ambiguously.
      */
     function buildRouteKey(
         string calldata sourceChain,
         string calldata destChain,
         address token
     ) public pure returns (bytes32) {
-        return keccak256(abi.encodePacked(sourceChain, destChain, token));
+        return keccak256(abi.encode(sourceChain, destChain, token));
     }
 
     // ============ Commission Collection Functions ============

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
@@ -57,6 +58,11 @@ contract CommissionManager is Ownable {
     mapping(address => uint256) public tokenCommissionPool;
     uint256 public nativeCommissionPool;
 
+    /// @dev Mock wei-per-token-unit rate for NATIVE commission; used when `mockTokenToNativeRateForToken[token]` is zero.
+    uint256 public mockTokenToNativeRate;
+    /// @dev Optional per-token mock; zero means use `mockTokenToNativeRate`.
+    mapping(address => uint256) public mockTokenToNativeRateForToken;
+
     // ============ Events ============
 
     event BridgeAddressUpdated(address indexed newBridge);
@@ -83,6 +89,10 @@ contract CommissionManager is Ownable {
 
     event TokenCommissionReceived(address indexed token, uint256 amount);
     event NativeCommissionReceived(uint256 amount);
+
+    event MockTokenToNativeRateUpdated(uint256 rate);
+    event MockTokenToNativeRateForTokenUpdated(address indexed token, uint256 rate);
+
     event TokenCommissionWithdrawn(
         address indexed token,
         address indexed to,
@@ -115,19 +125,16 @@ contract CommissionManager is Ownable {
      * @param destChain Destination chain identifier
      * @param token Token address
      * @param amount Amount being bridged
-     * @param tokenToNativeRate Oracle rate: wei per token unit
-     * @param tokenDecimals Token decimals
      * @return tokenCommission Commission in token units
      * @return nativeCommission Commission in native units (wei)
      * @return netAmount Amount after commission deduction
+     * @dev Token decimals are read from the token via ERC-20 metadata. Native commission uses owner-set mock rates.
      */
     function calculateFundsInCommission(
         string calldata sourceChain,
         string calldata destChain,
         address token,
-        uint256 amount,
-        uint256 tokenToNativeRate,
-        uint256 tokenDecimals
+        uint256 amount
     )
         external
         view
@@ -156,10 +163,12 @@ contract CommissionManager is Ownable {
         } else {
             // NATIVE commission: user pays in ETH/BNB via msg.value
             tokenCommission = 0;
+            uint256 rate = resolvedMockTokenToNativeRate(token);
+            require(rate > 0, "CommissionManager: mock token to native rate not set");
             nativeCommission = convertTokenToNative(
                 stableFee,
-                tokenToNativeRate,
-                tokenDecimals
+                rate,
+                _tokenDecimals(token)
             );
             netAmount = amount; // Full amount bridges
         }
@@ -171,19 +180,16 @@ contract CommissionManager is Ownable {
      * @param destChain Destination chain identifier
      * @param token Token address
      * @param amount Amount to be released
-     * @param tokenToNativeRate Oracle rate: wei per token unit (for native commission)
-     * @param tokenDecimals Token decimals
      * @return tokenCommission Commission in token units
      * @return nativeCommission Commission in native units (wei)
      * @return netAmount Amount user receives after commission
+     * @dev See `calculateFundsInCommission` for decimals and native rate sourcing.
      */
     function calculateFundsOutCommission(
         string calldata sourceChain,
         string calldata destChain,
         address token,
-        uint256 amount,
-        uint256 tokenToNativeRate,
-        uint256 tokenDecimals
+        uint256 amount
     )
         external
         view
@@ -211,10 +217,12 @@ contract CommissionManager is Ownable {
         } else {
             // NATIVE commission for fundsOut: user pays in native (per blueprint)
             tokenCommission = 0;
+            uint256 rate = resolvedMockTokenToNativeRate(token);
+            require(rate > 0, "CommissionManager: mock token to native rate not set");
             nativeCommission = convertTokenToNative(
                 stableFee,
-                tokenToNativeRate,
-                tokenDecimals
+                rate,
+                _tokenDecimals(token)
             );
             netAmount = amount;
         }
@@ -236,18 +244,35 @@ contract CommissionManager is Ownable {
     }
 
     /**
-     * @notice Convert token-denominated fee to native (wei) using oracle rate (blueprint: convertTokenToNative)
+     * @notice Convert token-denominated fee to native (wei) (blueprint: convertTokenToNative)
      * @param tokenFee Fee amount in token smallest units
-     * @param tokenToNativeRate Wei per 1 token unit (smallest units), from oracle/signature
+     * @param rateWeiPerTokenUnit Wei per 1 whole token in smallest units, matching mock rate units
      * @param tokenDecimals Token decimals (e.g. 6 for USDT)
      * @return nativeFee Native amount in wei
      */
     function convertTokenToNative(
         uint256 tokenFee,
-        uint256 tokenToNativeRate,
+        uint256 rateWeiPerTokenUnit,
         uint256 tokenDecimals
     ) public pure returns (uint256 nativeFee) {
-        nativeFee = (tokenFee * tokenToNativeRate) / (10 ** tokenDecimals);
+        nativeFee = (tokenFee * rateWeiPerTokenUnit) / (10 ** tokenDecimals);
+    }
+
+    /**
+     * @notice Resolved mock rate for `token` (per-token mock if set, else global mock).
+     */
+    function resolvedMockTokenToNativeRate(address token) public view returns (uint256) {
+        uint256 r = mockTokenToNativeRateForToken[token];
+        if (r != 0) return r;
+        return mockTokenToNativeRate;
+    }
+
+    function _tokenDecimals(address token) internal view returns (uint256) {
+        try IERC20Metadata(token).decimals() returns (uint8 d) {
+            return uint256(d);
+        } catch {
+            revert("CommissionManager: decimals unavailable");
+        }
     }
 
     // ============ Configuration Functions ============
@@ -284,6 +309,23 @@ contract CommissionManager is Ownable {
         globalCurrency = currency;
 
         emit GlobalDefaultsUpdated(stablePercent, multiplier, side, currency);
+    }
+
+    /**
+     * @notice Set global mock wei-per-token rate for NATIVE commission (used when per-token mock is unset).
+     */
+    function setMockTokenToNativeRate(uint256 rate) external onlyOwner {
+        mockTokenToNativeRate = rate;
+        emit MockTokenToNativeRateUpdated(rate);
+    }
+
+    /**
+     * @notice Set per-token mock rate; pass 0 to clear and use global `mockTokenToNativeRate`.
+     */
+    function setMockTokenToNativeRateForToken(address token, uint256 rate) external onlyOwner {
+        require(token != address(0), "CommissionManager: Invalid token");
+        mockTokenToNativeRateForToken[token] = rate;
+        emit MockTokenToNativeRateForTokenUpdated(token, rate);
     }
 
     /**

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -40,8 +40,8 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
     /// @notice Address allowed to credit token and native commission.
     address public bridgeAddress;
 
-    /// @notice Default `stablePercent` when no per-route rule exists (×100; default 400 = 4%).
-    uint256 public globalStablePercent = 400;
+    /// @notice Default `stablePercent` when no per-route rule exists (×100; 0 = no % fee until configured).
+    uint256 public globalStablePercent = 0;
     /// @notice Default `multiplier` for `calculateStableFee` (typically 100).
     uint8 public globalMultiplier = 100;
     /// @notice Default `side` for routes without an override.
@@ -137,13 +137,17 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
         } else {
             // NATIVE commission: user pays in ETH/BNB via msg.value
             tokenCommission = 0;
-            uint256 rate = resolvedMockTokenToNativeRate(token);
-            if (rate == 0) revert MockTokenToNativeRateNotSet();
-            nativeCommission = convertTokenToNative(
-                stableFee,
-                rate,
-                _tokenDecimals(token)
-            );
+            if (stableFee == 0) {
+                nativeCommission = 0;
+            } else {
+                uint256 rate = resolvedMockTokenToNativeRate(token);
+                if (rate == 0) revert MockTokenToNativeRateNotSet();
+                nativeCommission = convertTokenToNative(
+                    stableFee,
+                    rate,
+                    _tokenDecimals(token)
+                );
+            }
             netAmount = amount; // Full amount bridges
         }
     }
@@ -191,13 +195,17 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
         } else {
             // NATIVE commission for fundsOut: user pays in native (per blueprint)
             tokenCommission = 0;
-            uint256 rate = resolvedMockTokenToNativeRate(token);
-            if (rate == 0) revert MockTokenToNativeRateNotSet();
-            nativeCommission = convertTokenToNative(
-                stableFee,
-                rate,
-                _tokenDecimals(token)
-            );
+            if (stableFee == 0) {
+                nativeCommission = 0;
+            } else {
+                uint256 rate = resolvedMockTokenToNativeRate(token);
+                if (rate == 0) revert MockTokenToNativeRateNotSet();
+                nativeCommission = convertTokenToNative(
+                    stableFee,
+                    rate,
+                    _tokenDecimals(token)
+                );
+            }
             netAmount = amount;
         }
     }
@@ -261,7 +269,7 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
 
     /**
      * @notice Sets defaults used when no per-route rule exists for a key.
-     * @param stablePercent Percent × 100; must be > 0 and ≤ 9000.
+     * @param stablePercent Percent × 100 (0 = no stable % fee); must be ≤ 9000.
      * @param multiplier Default multiplier (typically 100).
      * @param side Default `FUNDS_IN` vs `FUNDS_OUT`.
      * @param currency Default `TOKEN` vs `NATIVE`.
@@ -274,7 +282,6 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
     ) external onlyOwner {
         if (stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (multiplier == 0) revert MultiplierZero();
-        if (stablePercent == 0) revert StablePercentZero();
 
         globalStablePercent = stablePercent;
         globalMultiplier = multiplier;
@@ -320,7 +327,6 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
         if (token == address(0)) revert InvalidToken();
         // Validate config
         if (config.stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
-        if (config.stablePercent == 0) revert StablePercentZero();
         if (config.multiplier == 0) revert MultiplierZero();
 
         // Build route key

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -341,6 +341,7 @@ contract CommissionManager is Ownable {
         address token,
         CommissionConfig calldata config
     ) external onlyOwner {
+        require(token != address(0), "CommissionManager: Invalid token");
         // Validate config
         require(
             config.stablePercent <= _MAX_STABLE_PERCENT,
@@ -375,6 +376,7 @@ contract CommissionManager is Ownable {
         string calldata destChain,
         address token
     ) external onlyOwner {
+        require(token != address(0), "CommissionManager: Invalid token");
         bytes32 key = buildRouteKey(sourceChain, destChain, token);
         delete commissionRules[key];
         emit CommissionRuleCleared(sourceChain, destChain, token);
@@ -484,6 +486,7 @@ contract CommissionManager is Ownable {
      * @param token Token address
      */
     function receiveTokenCommission(address token) external onlyBridge {
+        require(token != address(0), "CommissionManager: Invalid token");
         uint256 newBalance = IERC20(token).balanceOf(address(this));
         uint256 priorPool = tokenCommissionPool[token];
         require(
@@ -519,6 +522,7 @@ contract CommissionManager is Ownable {
         address to,
         uint256 amount
     ) external onlyOwner {
+        require(token != address(0), "CommissionManager: Invalid token");
         require(to != address(0), "CommissionManager: Invalid recipient");
         require(
             tokenCommissionPool[token] >= amount,
@@ -557,6 +561,8 @@ contract CommissionManager is Ownable {
      * @notice Withdraw entire token commission balance for one token
      */
     function withdrawAllTokenCommission(address token, address to) external onlyOwner {
+        require(token != address(0), "CommissionManager: Invalid token");
+        require(to != address(0), "CommissionManager: Invalid recipient");
         uint256 balance = tokenCommissionPool[token];
         require(balance > 0, "CommissionManager: No balance");
 
@@ -570,6 +576,7 @@ contract CommissionManager is Ownable {
      * @notice Withdraw entire native commission balance
      */
     function withdrawAllNativeCommission(address payable to) external onlyOwner {
+        require(to != address(0), "CommissionManager: Invalid recipient");
         uint256 balance = nativeCommissionPool;
         require(balance > 0, "CommissionManager: No balance");
 

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -9,27 +9,53 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 
 /**
  * @title CommissionManager
- * @notice Non-upgradeable commission calculation, configuration, and fee collection for the EVM bridge
- * @dev Aligns with blueprint v3: global defaults + per-route overrides, full on-chain stable/native math
+ * @author UTEXO bridge stack
+ * @notice On-chain commission quotes, owner configuration, and custody of bridge fees (ERC-20 and native).
+ * @dev Blueprint v3-style design: **global defaults** plus optional **per-route overrides** keyed by
+ *      `keccak256(abi.encode(sourceChain, destChain, token))`. Routes are **directional** (swapping
+ *      source and destination yields a different key), so independent rules can apply to each leg of a
+ *      round trip (e.g. ETH→RGB vs RGB→ETH).
+ *
+ *      **Side (`CommissionSide`):** For a given route config, commission applies only to **either**
+ *      `FUNDS_IN` **or** `FUNDS_OUT`, matching `calculateFundsInCommission` vs `calculateFundsOutCommission`.
+ *      **Currency (`CommissionCurrency`):** `TOKEN` deducts fee from the bridged amount; `NATIVE` expresses
+ *      fee in native wei using owner-set **mock** rates and `IERC20Metadata.decimals()` on `token`.
+ *
+ *      **Roles:** `bridgeAddress` may call `receiveTokenCommission` and `receive()` to credit fees;
+ *      `owner` configures rules and withdraws accumulated pools. `renounceOwnership` is disabled.
+ *      Withdrawals use `nonReentrant` against reentrancy via ERC-20 hooks or native recipients.
  */
 contract CommissionManager is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     // ============ Structs ============
 
+    /**
+     * @notice Stored commission parameters for one route (see `buildRouteKey`).
+     * @dev `isSet` distinguishes an explicit `commissionRules` entry from unset storage (all zeros).
+     */
     struct CommissionConfig {
-        uint256 stablePercent; // Percent * 100 (e.g. 400 = 4%)
-        uint8 multiplier; // Usually 100
-        CommissionSide side; // FUNDS_IN or FUNDS_OUT
-        CommissionCurrency currency; // TOKEN or NATIVE
-        bool isSet; // true = explicit route rule; false = fall back to globals
+        /// @notice Fee percent × 100 (e.g. 400 = 4%). Must be ≤ 9000 and > 0 when validated.
+        uint256 stablePercent;
+        /// @notice Divisor in `calculateStableFee`; typically 100.
+        uint8 multiplier;
+        /// @notice Whether this route’s fee applies to funds-in or funds-out quotes.
+        CommissionSide side;
+        /// @notice Fee in token units, or native (via mock rate) when `NATIVE`.
+        CommissionCurrency currency;
+        /// @notice True when this struct is an active per-route override; false for a cleared raw slot.
+        bool isSet;
     }
 
     // ============ Enums ============
+
+    /// @notice Which bridge operation this route’s fee is tied to (must match the calculator used).
     enum CommissionSide {
         FUNDS_IN,
         FUNDS_OUT
     }
+
+    /// @notice Take fee from bridged token amount or express it in native wei.
     enum CommissionCurrency {
         TOKEN,
         NATIVE
@@ -37,53 +63,76 @@ contract CommissionManager is Ownable, ReentrancyGuard {
 
     // ============ Errors ============
 
+    /// @notice Caller is not `bridgeAddress`.
     error OnlyBridge();
+    /// @notice Bridge address argument is zero.
     error InvalidBridgeAddress();
+    /// @notice Token address is zero where forbidden.
     error InvalidToken();
+    /// @notice Recipient address is zero.
     error InvalidRecipient();
+    /// @notice `stablePercent` exceeds maximum (90%).
     error StablePercentTooHigh();
+    /// @notice `stablePercent` is zero where forbidden.
     error StablePercentZero();
+    /// @notice `multiplier` is zero.
     error MultiplierZero();
+    /// @notice NATIVE currency configured but resolved mock rate is zero.
     error MockTokenToNativeRateNotSet();
+    /// @notice `IERC20Metadata.decimals()` reverted or missing.
     error TokenDecimalsUnavailable();
+    /// @notice ERC-20 balance is below recorded pool.
     error BalanceBelowRecordedPool();
+    /// @notice No net tokens received since last pool snapshot.
     error NothingReceived();
+    /// @notice Native `receive()` with zero value.
     error ZeroNativeAmount();
+    /// @notice Withdrawal exceeds accrued pool.
     error InsufficientBalance();
+    /// @notice Native transfer to recipient failed.
     error NativeTransferFailed();
+    /// @notice Full withdrawal with zero accrued balance.
     error NoBalance();
+    /// @notice `renounceOwnership` is disabled.
+    error RenounceOwnershipBlocked();
 
     // ============ State Variables ============
 
-    // Bridge address (only bridge can send commissions)
+    /// @notice Address allowed to credit token and native commission.
     address public bridgeAddress;
 
-    // Global defaults (when route rule is not set)
-    uint256 public globalStablePercent = 400; // 4% default
+    /// @notice Default `stablePercent` when no per-route rule exists (×100; default 400 = 4%).
+    uint256 public globalStablePercent = 400;
+    /// @notice Default `multiplier` for `calculateStableFee` (typically 100).
     uint8 public globalMultiplier = 100;
+    /// @notice Default `side` for routes without an override.
     CommissionSide public globalSide = CommissionSide.FUNDS_IN;
+    /// @notice Default `currency` for routes without an override.
     CommissionCurrency public globalCurrency = CommissionCurrency.TOKEN;
 
-    // Constants
-    uint256 private constant _MAX_STABLE_PERCENT = 9000; // 90%
+    /// @notice Maximum allowed `stablePercent` (9000 = 90%).
+    uint256 private constant _MAX_STABLE_PERCENT = 9000;
 
-    // Per-route overrides
-    // key = keccak256(abi.encode(sourceChain, destChain, tokenAddress))
+    /// @notice Per-route overrides; key = `buildRouteKey(sourceChain, destChain, token)`.
     mapping(bytes32 => CommissionConfig) public commissionRules;
 
-    // Accumulated fees
+    /// @notice Accrued ERC-20 commission per token (tracks balance held for that token).
     mapping(address => uint256) public tokenCommissionPool;
+    /// @notice Accrued native commission in wei.
     uint256 public nativeCommissionPool;
 
-    /// @dev Mock wei-per-token-unit rate for NATIVE commission; used when `mockTokenToNativeRateForToken[token]` is zero.
+    /// @notice Global mock wei-per-token rate for NATIVE conversion if per-token mock is unset.
     uint256 public mockTokenToNativeRate;
-    /// @dev Optional per-token mock; zero means use `mockTokenToNativeRate`.
+    /// @notice Per-token mock rate; zero means use `mockTokenToNativeRate`.
     mapping(address => uint256) public mockTokenToNativeRateForToken;
 
     // ============ Events ============
 
+    /// @notice Emitted when `setBridgeAddress` runs.
+    /// @param newBridge New bridge address.
     event BridgeAddressUpdated(address indexed newBridge);
 
+    /// @notice Emitted when global defaults change.
     event GlobalDefaultsUpdated(
         uint256 stablePercent,
         uint8 multiplier,
@@ -91,6 +140,7 @@ contract CommissionManager is Ownable, ReentrancyGuard {
         CommissionCurrency currency
     );
 
+    /// @notice Emitted when a route rule is stored.
     event CommissionRuleUpdated(
         string sourceChain,
         string destChain,
@@ -98,27 +148,37 @@ contract CommissionManager is Ownable, ReentrancyGuard {
         CommissionConfig config
     );
 
+    /// @notice Emitted when a route rule is removed (globals apply again).
     event CommissionRuleCleared(
         string sourceChain,
         string destChain,
         address indexed token
     );
 
+    /// @notice Token commission credited from the bridge.
+    /// @param token ERC-20 token.
+    /// @param amount Net increase credited this call.
     event TokenCommissionReceived(address indexed token, uint256 amount);
+    /// @notice Native commission received from the bridge.
     event NativeCommissionReceived(uint256 amount);
 
+    /// @notice Global mock rate updated.
     event MockTokenToNativeRateUpdated(uint256 rate);
+    /// @notice Per-token mock rate updated.
     event MockTokenToNativeRateForTokenUpdated(address indexed token, uint256 rate);
 
+    /// @notice Owner withdrew token commission.
     event TokenCommissionWithdrawn(
         address indexed token,
         address indexed to,
         uint256 amount
     );
+    /// @notice Owner withdrew native commission.
     event NativeCommissionWithdrawn(address indexed to, uint256 amount);
 
     // ============ Modifiers ============
 
+    /// @dev Restricts call to `bridgeAddress`.
     modifier onlyBridge() {
         if (msg.sender != bridgeAddress) revert OnlyBridge();
         _;
@@ -126,23 +186,34 @@ contract CommissionManager is Ownable, ReentrancyGuard {
 
     // ============ Constructor ============
 
+    /**
+     * @notice Deploys the manager; `msg.sender` is owner; `_bridgeAddress` is the initial bridge.
+     * @param _bridgeAddress Bridge that will send commissions (non-zero).
+     */
     constructor(address _bridgeAddress) Ownable(msg.sender) {
         if (_bridgeAddress == address(0)) revert InvalidBridgeAddress();
         bridgeAddress = _bridgeAddress;
     }
 
+    /// @inheritdoc Ownable
+    /// @notice Always reverts. Use `transferOwnership` to change admin.
+    function renounceOwnership() public view override onlyOwner {
+        revert RenounceOwnershipBlocked();
+    }
+
     // ============ Core Calculation Functions ============
 
     /**
-     * @notice Calculate commission for fundsIn operation
-     * @param sourceChain Source chain identifier
-     * @param destChain Destination chain identifier
-     * @param token Token address
-     * @param amount Amount being bridged
-     * @return tokenCommission Commission in token units
-     * @return nativeCommission Commission in native units (wei)
-     * @return netAmount Amount after commission deduction
-     * @dev Token decimals are read from the token via ERC-20 metadata. Native commission uses owner-set mock rates.
+     * @notice Quote commission for an inbound (`fundsIn`) transfer on this chain.
+     * @param sourceChain Origin chain id (must match configured route keys).
+     * @param destChain Destination chain id.
+     * @param token ERC-20 token used for the transfer.
+     * @param amount Gross amount bridged (same units as token).
+     * @return tokenCommission Fee in token smallest units (0 if not `TOKEN` currency).
+     * @return nativeCommission Fee in wei (0 if not `NATIVE` currency).
+     * @return netAmount Amount after fee if `TOKEN`; full `amount` if `NATIVE` (fee paid separately in native).
+     * @dev Returns `(0, 0, amount)` if effective `side` is not `FUNDS_IN`. NATIVE path uses
+     *      `resolvedMockTokenToNativeRate` and `IERC20Metadata(token).decimals()`.
      */
     function calculateFundsInCommission(
         string calldata sourceChain,
@@ -189,15 +260,15 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Calculate commission for fundsOut operation
-     * @param sourceChain Source chain identifier
-     * @param destChain Destination chain identifier
-     * @param token Token address
-     * @param amount Amount to be released
-     * @return tokenCommission Commission in token units
-     * @return nativeCommission Commission in native units (wei)
-     * @return netAmount Amount user receives after commission
-     * @dev See `calculateFundsInCommission` for decimals and native rate sourcing.
+     * @notice Quote commission for an outbound (`fundsOut`) release on this chain.
+     * @param sourceChain Origin chain id (must match configured route keys).
+     * @param destChain Destination chain id.
+     * @param token ERC-20 token being released.
+     * @param amount Gross amount to release before fee.
+     * @return tokenCommission Fee in token units (0 if not `TOKEN` currency).
+     * @return nativeCommission Fee in wei (0 if not `NATIVE`).
+     * @return netAmount User receives `amount - tokenCommission` for `TOKEN`; `amount` for `NATIVE` (fee separate).
+     * @dev Returns `(0, 0, amount)` if effective `side` is not `FUNDS_OUT`. See `calculateFundsInCommission` for rates/decimals.
      */
     function calculateFundsOutCommission(
         string calldata sourceChain,
@@ -243,11 +314,11 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Calculate stable commission fee
-     * @param amount Token amount
-     * @param stablePercent Percent * 100 (e.g., 400 = 4%)
-     * @param multiplier Usually 100
-     * @return Fee in token units
+     * @notice Stable fee: `(amount * stablePercent) / multiplier / multiplier`.
+     * @param amount Token amount in smallest units.
+     * @param stablePercent Percent × 100 (e.g. 400 = 4%).
+     * @param multiplier Typically 100.
+     * @return Fee in token smallest units.
      */
     function calculateStableFee(
         uint256 amount,
@@ -258,11 +329,11 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Convert token-denominated fee to native (wei) (blueprint: convertTokenToNative)
-     * @param tokenFee Fee amount in token smallest units
-     * @param rateWeiPerTokenUnit Wei per 1 whole token in smallest units, matching mock rate units
-     * @param tokenDecimals Token decimals (e.g. 6 for USDT)
-     * @return nativeFee Native amount in wei
+     * @notice Convert a token-denominated fee to native wei (blueprint `convertTokenToNative`).
+     * @param tokenFee Fee in token smallest units.
+     * @param rateWeiPerTokenUnit Mock rate: wei per 10**`tokenDecimals` token units.
+     * @param tokenDecimals Token decimals (e.g. 18).
+     * @return nativeFee Equivalent native amount in wei.
      */
     function convertTokenToNative(
         uint256 tokenFee,
@@ -273,7 +344,9 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Resolved mock rate for `token` (per-token mock if set, else global mock).
+     * @notice Effective mock wei-per-token rate: per-token if non-zero, else global.
+     * @param token ERC-20 token (used with decimals in commission math).
+     * @return rate Wei-per-token-unit rate for `convertTokenToNative`.
      */
     function resolvedMockTokenToNativeRate(address token) public view returns (uint256) {
         uint256 r = mockTokenToNativeRateForToken[token];
@@ -281,6 +354,12 @@ contract CommissionManager is Ownable, ReentrancyGuard {
         return mockTokenToNativeRate;
     }
 
+    /**
+     * @notice ERC-20 `decimals()` as `uint256` for exponent math.
+     * @param token Token to query.
+     * @return Token decimals (typically 6–18).
+     * @dev Reverts `TokenDecimalsUnavailable` if the call fails (non-standard token).
+     */
     function _tokenDecimals(address token) internal view returns (uint256) {
         try IERC20Metadata(token).decimals() returns (uint8 d) {
             return uint256(d);
@@ -292,11 +371,11 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     // ============ Configuration Functions ============
 
     /**
-     * @notice Set global default commission parameters
-     * @param stablePercent Default stable percent (e.g., 400 = 4%)
-     * @param multiplier Default multiplier (usually 100)
-     * @param side Default commission side (FUNDS_IN or FUNDS_OUT)
-     * @param currency Default commission currency (TOKEN or NATIVE)
+     * @notice Sets defaults used when no per-route rule exists for a key.
+     * @param stablePercent Percent × 100; must be > 0 and ≤ 9000.
+     * @param multiplier Default multiplier (typically 100).
+     * @param side Default `FUNDS_IN` vs `FUNDS_OUT`.
+     * @param currency Default `TOKEN` vs `NATIVE`.
      */
     function setGlobalDefaults(
         uint256 stablePercent,
@@ -317,7 +396,8 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Set global mock wei-per-token rate for NATIVE commission (used when per-token mock is unset).
+     * @notice Sets `mockTokenToNativeRate` (fallback when per-token mock is zero).
+     * @param rate Wei-per-token-unit rate for `convertTokenToNative`.
      */
     function setMockTokenToNativeRate(uint256 rate) external onlyOwner {
         mockTokenToNativeRate = rate;
@@ -325,7 +405,9 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Set per-token mock rate; pass 0 to clear and use global `mockTokenToNativeRate`.
+     * @notice Sets or clears per-token mock rate for NATIVE commission quotes.
+     * @param token ERC-20 token (non-zero).
+     * @param rate Mock rate; 0 clears override so global `mockTokenToNativeRate` applies.
      */
     function setMockTokenToNativeRateForToken(address token, uint256 rate) external onlyOwner {
         if (token == address(0)) revert InvalidToken();
@@ -334,11 +416,11 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Set commission rule for a specific route
-     * @param sourceChain Source chain identifier
-     * @param destChain Destination chain identifier
-     * @param token Token address
-     * @param config Commission configuration
+     * @notice Writes or replaces the override for `buildRouteKey(sourceChain, destChain, token)`.
+     * @param sourceChain Route source id (directional; paired with `destChain`).
+     * @param destChain Route destination id.
+     * @param token ERC-20 token (non-zero).
+     * @param config Rule parameters; `isSet` is forced true on store.
      */
     function setCommissionRule(
         string calldata sourceChain,
@@ -362,10 +444,10 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Clear route-specific config (revert to global defaults)
-     * @param sourceChain Source chain identifier
-     * @param destChain Destination chain identifier
-     * @param token Token address
+     * @notice Deletes the override for this route key; `getEffectiveConfig` will use globals.
+     * @param sourceChain Route source id.
+     * @param destChain Route destination id.
+     * @param token ERC-20 token (non-zero).
      */
     function clearCommissionRule(
         string calldata sourceChain,
@@ -379,8 +461,8 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Update bridge address
-     * @param newBridge New bridge contract address
+     * @notice Updates `bridgeAddress` (only that address may credit commissions).
+     * @param newBridge Non-zero bridge contract.
      */
     function setBridgeAddress(address newBridge) external onlyOwner {
         if (newBridge == address(0)) revert InvalidBridgeAddress();
@@ -391,9 +473,9 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     // ============ View Functions ============
 
     /**
-     * @notice Get effective configuration for a route (with fallback to globals)
-     * @param ruleKey Route key (keccak256 of sourceChain, destChain, token)
-     * @return Effective commission configuration
+     * @notice Resolves stored rule or materializes global defaults with `isSet: true`.
+     * @param ruleKey `buildRouteKey` output.
+     * @return config Effective parameters for calculators.
      */
     function getEffectiveConfig(
         bytes32 ruleKey
@@ -416,11 +498,11 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Get global default configuration
-     * @return stablePercent Global stable percent
-     * @return multiplier Global multiplier
-     * @return side Global commission side
-     * @return currency Global commission currency
+     * @notice Returns current global defaults (used when no per-route override exists).
+     * @return stablePercent Global percent × 100.
+     * @return multiplier Global multiplier.
+     * @return side Global `CommissionSide`.
+     * @return currency Global `CommissionCurrency`.
      */
     function getGlobalDefaults()
         external
@@ -441,11 +523,11 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Get commission rule for a specific route
-     * @param sourceChain Source chain identifier
-     * @param destChain Destination chain identifier
-     * @param token Token address
-     * @return Commission configuration for the route
+     * @notice Raw storage read for a route (may be unset; check `config.isSet`).
+     * @param sourceChain Route source id.
+     * @param destChain Route destination id.
+     * @param token ERC-20 token.
+     * @return config Stored override or empty struct if never set.
      */
     function getCommissionRule(
         string calldata sourceChain,
@@ -457,8 +539,12 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice keccak256(abi.encode(sourceChain, destChain, token))
-     * @dev Uses abi.encode (not encodePacked) so dynamic string arguments cannot be concatenated ambiguously.
+     * @notice Deterministic route id for commission rules.
+     * @param sourceChain Route source id.
+     * @param destChain Route destination id.
+     * @param token ERC-20 token address.
+     * @return key `keccak256(abi.encode(sourceChain, destChain, token))`.
+     * @dev Uses `abi.encode` (not `encodePacked`) to avoid ambiguous hashing over dynamic strings.
      */
     function buildRouteKey(
         string calldata sourceChain,
@@ -471,11 +557,9 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     // ============ Commission Collection Functions ============
 
     /**
-     * @notice Receive token commission from bridge
-     * @dev Credits the actual ERC-20 balance increase since the last recorded pool for this token.
-     *      The bridge must transfer tokens to this contract before calling; the `amount` is not taken
-     *      from calldata so accounting matches real transfers (including fee-on-transfer tokens).
-     * @param token Token address
+     * @notice Credits token commission: increases `tokenCommissionPool[token]` by the actual balance delta.
+     * @param token ERC-20 token (non-zero). Bridge must transfer tokens before this call.
+     * @dev Pool tracks on-chain balance; no calldata amount (supports fee-on-transfer tokens).
      */
     function receiveTokenCommission(address token) external onlyBridge {
         if (token == address(0)) revert InvalidToken();
@@ -489,8 +573,8 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Receive native commission from bridge
-     * @dev Called via payable function or direct transfer
+     * @notice Accepts native commission from the bridge; increases `nativeCommissionPool`.
+     * @dev Callable only by `bridgeAddress`; `msg.value` must be non-zero.
      */
     receive() external payable onlyBridge {
         if (msg.value == 0) revert ZeroNativeAmount();
@@ -501,10 +585,11 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     // ============ Withdrawal Functions ============
 
     /**
-     * @notice Withdraw token commission
-     * @param token Token address
-     * @param to Recipient address
-     * @param amount Amount to withdraw
+     * @notice Owner withdraws `amount` of accrued `token` commission to `to`.
+     * @param token ERC-20 token (non-zero).
+     * @param to Recipient (non-zero).
+     * @param amount Amount to send (≤ pool).
+     * @dev `nonReentrant`; updates pool before `safeTransfer`.
      */
     function withdrawTokenCommission(
         address token,
@@ -522,9 +607,10 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Withdraw native commission
-     * @param to Recipient address
-     * @param amount Amount to withdraw
+     * @notice Owner withdraws `amount` wei of native commission.
+     * @param to Recipient (non-zero).
+     * @param amount Wei to send (≤ pool).
+     * @dev `nonReentrant`; updates pool before native transfer.
      */
     function withdrawNativeCommission(
         address payable to,
@@ -541,7 +627,10 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Withdraw entire token commission balance for one token
+     * @notice Owner withdraws the full accrued balance for `token` to `to`.
+     * @param token ERC-20 token (non-zero).
+     * @param to Recipient (non-zero).
+     * @dev `nonReentrant`. Reverts `NoBalance` if pool is zero.
      */
     function withdrawAllTokenCommission(address token, address to) external onlyOwner nonReentrant {
         if (token == address(0)) revert InvalidToken();
@@ -556,7 +645,9 @@ contract CommissionManager is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Withdraw entire native commission balance
+     * @notice Owner withdraws the full `nativeCommissionPool` to `to`.
+     * @param to Recipient (non-zero).
+     * @dev `nonReentrant`. Reverts `NoBalance` if pool is zero.
      */
     function withdrawAllNativeCommission(address payable to) external onlyOwner nonReentrant {
         if (to == address(0)) revert InvalidRecipient();

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -18,7 +18,6 @@ contract CommissionManager is Ownable {
 
     struct CommissionConfig {
         uint256 stablePercent; // Percent * 100 (e.g. 400 = 4%)
-        uint256 gasEstimate; // Reserved for future gas-based logic (blueprint field)
         uint8 multiplier; // Usually 100
         CommissionSide side; // FUNDS_IN or FUNDS_OUT
         CommissionCurrency currency; // TOKEN or NATIVE
@@ -35,6 +34,24 @@ contract CommissionManager is Ownable {
         NATIVE
     }
 
+    // ============ Errors ============
+
+    error OnlyBridge();
+    error InvalidBridgeAddress();
+    error InvalidToken();
+    error InvalidRecipient();
+    error StablePercentTooHigh();
+    error StablePercentZero();
+    error MultiplierZero();
+    error MockTokenToNativeRateNotSet();
+    error TokenDecimalsUnavailable();
+    error BalanceBelowRecordedPool();
+    error NothingReceived();
+    error ZeroNativeAmount();
+    error InsufficientBalance();
+    error NativeTransferFailed();
+    error NoBalance();
+
     // ============ State Variables ============
 
     // Bridge address (only bridge can send commissions)
@@ -42,7 +59,6 @@ contract CommissionManager is Ownable {
 
     // Global defaults (when route rule is not set)
     uint256 public globalStablePercent = 400; // 4% default
-    uint256 public globalGasEstimate = 0;
     uint8 public globalMultiplier = 100;
     CommissionSide public globalSide = CommissionSide.FUNDS_IN;
     CommissionCurrency public globalCurrency = CommissionCurrency.TOKEN;
@@ -103,17 +119,14 @@ contract CommissionManager is Ownable {
     // ============ Modifiers ============
 
     modifier onlyBridge() {
-        require(msg.sender == bridgeAddress, "CommissionManager: Only bridge");
+        if (msg.sender != bridgeAddress) revert OnlyBridge();
         _;
     }
 
     // ============ Constructor ============
 
     constructor(address _bridgeAddress) Ownable(msg.sender) {
-        require(
-            _bridgeAddress != address(0),
-            "CommissionManager: Invalid bridge address"
-        );
+        if (_bridgeAddress == address(0)) revert InvalidBridgeAddress();
         bridgeAddress = _bridgeAddress;
     }
 
@@ -164,7 +177,7 @@ contract CommissionManager is Ownable {
             // NATIVE commission: user pays in ETH/BNB via msg.value
             tokenCommission = 0;
             uint256 rate = resolvedMockTokenToNativeRate(token);
-            require(rate > 0, "CommissionManager: mock token to native rate not set");
+            if (rate == 0) revert MockTokenToNativeRateNotSet();
             nativeCommission = convertTokenToNative(
                 stableFee,
                 rate,
@@ -218,7 +231,7 @@ contract CommissionManager is Ownable {
             // NATIVE commission for fundsOut: user pays in native (per blueprint)
             tokenCommission = 0;
             uint256 rate = resolvedMockTokenToNativeRate(token);
-            require(rate > 0, "CommissionManager: mock token to native rate not set");
+            if (rate == 0) revert MockTokenToNativeRateNotSet();
             nativeCommission = convertTokenToNative(
                 stableFee,
                 rate,
@@ -271,7 +284,7 @@ contract CommissionManager is Ownable {
         try IERC20Metadata(token).decimals() returns (uint8 d) {
             return uint256(d);
         } catch {
-            revert("CommissionManager: decimals unavailable");
+            revert TokenDecimalsUnavailable();
         }
     }
 
@@ -290,18 +303,9 @@ contract CommissionManager is Ownable {
         CommissionSide side,
         CommissionCurrency currency
     ) external onlyOwner {
-        require(
-            stablePercent <= _MAX_STABLE_PERCENT,
-            "CommissionManager: Percent too high"
-        );
-        require(
-            multiplier > 0,
-            "CommissionManager: Multiplier must be nonzero"
-        );
-        require(
-            stablePercent > 0,
-            "CommissionManager: Percent must be nonzero"
-        );
+        if (stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
+        if (multiplier == 0) revert MultiplierZero();
+        if (stablePercent == 0) revert StablePercentZero();
 
         globalStablePercent = stablePercent;
         globalMultiplier = multiplier;
@@ -323,7 +327,7 @@ contract CommissionManager is Ownable {
      * @notice Set per-token mock rate; pass 0 to clear and use global `mockTokenToNativeRate`.
      */
     function setMockTokenToNativeRateForToken(address token, uint256 rate) external onlyOwner {
-        require(token != address(0), "CommissionManager: Invalid token");
+        if (token == address(0)) revert InvalidToken();
         mockTokenToNativeRateForToken[token] = rate;
         emit MockTokenToNativeRateForTokenUpdated(token, rate);
     }
@@ -341,20 +345,11 @@ contract CommissionManager is Ownable {
         address token,
         CommissionConfig calldata config
     ) external onlyOwner {
-        require(token != address(0), "CommissionManager: Invalid token");
+        if (token == address(0)) revert InvalidToken();
         // Validate config
-        require(
-            config.stablePercent <= _MAX_STABLE_PERCENT,
-            "CommissionManager: Percent too high"
-        );
-        require(
-            config.stablePercent > 0,
-            "CommissionManager: Percent must be nonzero"
-        );
-        require(
-            config.multiplier > 0,
-            "CommissionManager: Multiplier must be nonzero"
-        );
+        if (config.stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
+        if (config.stablePercent == 0) revert StablePercentZero();
+        if (config.multiplier == 0) revert MultiplierZero();
 
         // Build route key
         bytes32 key = buildRouteKey(sourceChain, destChain, token);
@@ -376,7 +371,7 @@ contract CommissionManager is Ownable {
         string calldata destChain,
         address token
     ) external onlyOwner {
-        require(token != address(0), "CommissionManager: Invalid token");
+        if (token == address(0)) revert InvalidToken();
         bytes32 key = buildRouteKey(sourceChain, destChain, token);
         delete commissionRules[key];
         emit CommissionRuleCleared(sourceChain, destChain, token);
@@ -387,10 +382,7 @@ contract CommissionManager is Ownable {
      * @param newBridge New bridge contract address
      */
     function setBridgeAddress(address newBridge) external onlyOwner {
-        require(
-            newBridge != address(0),
-            "CommissionManager: Invalid bridge address"
-        );
+        if (newBridge == address(0)) revert InvalidBridgeAddress();
         bridgeAddress = newBridge;
         emit BridgeAddressUpdated(newBridge);
     }
@@ -415,7 +407,6 @@ contract CommissionManager is Ownable {
         return
             CommissionConfig({
                 stablePercent: globalStablePercent,
-                gasEstimate: globalGasEstimate,
                 multiplier: globalMultiplier,
                 side: globalSide,
                 currency: globalCurrency,
@@ -486,15 +477,12 @@ contract CommissionManager is Ownable {
      * @param token Token address
      */
     function receiveTokenCommission(address token) external onlyBridge {
-        require(token != address(0), "CommissionManager: Invalid token");
+        if (token == address(0)) revert InvalidToken();
         uint256 newBalance = IERC20(token).balanceOf(address(this));
         uint256 priorPool = tokenCommissionPool[token];
-        require(
-            newBalance >= priorPool,
-            "CommissionManager: balance below recorded pool"
-        );
+        if (newBalance < priorPool) revert BalanceBelowRecordedPool();
         uint256 recorded = newBalance - priorPool;
-        require(recorded > 0, "CommissionManager: nothing received");
+        if (recorded == 0) revert NothingReceived();
         tokenCommissionPool[token] = newBalance;
         emit TokenCommissionReceived(token, recorded);
     }
@@ -504,7 +492,7 @@ contract CommissionManager is Ownable {
      * @dev Called via payable function or direct transfer
      */
     receive() external payable onlyBridge {
-        require(msg.value > 0, "CommissionManager: Amount must be positive");
+        if (msg.value == 0) revert ZeroNativeAmount();
         nativeCommissionPool += msg.value;
         emit NativeCommissionReceived(msg.value);
     }
@@ -522,12 +510,9 @@ contract CommissionManager is Ownable {
         address to,
         uint256 amount
     ) external onlyOwner {
-        require(token != address(0), "CommissionManager: Invalid token");
-        require(to != address(0), "CommissionManager: Invalid recipient");
-        require(
-            tokenCommissionPool[token] >= amount,
-            "CommissionManager: Insufficient balance"
-        );
+        if (token == address(0)) revert InvalidToken();
+        if (to == address(0)) revert InvalidRecipient();
+        if (tokenCommissionPool[token] < amount) revert InsufficientBalance();
 
         tokenCommissionPool[token] -= amount;
         IERC20(token).safeTransfer(to, amount);
@@ -544,15 +529,12 @@ contract CommissionManager is Ownable {
         address payable to,
         uint256 amount
     ) external onlyOwner {
-        require(to != address(0), "CommissionManager: Invalid recipient");
-        require(
-            nativeCommissionPool >= amount,
-            "CommissionManager: Insufficient balance"
-        );
+        if (to == address(0)) revert InvalidRecipient();
+        if (nativeCommissionPool < amount) revert InsufficientBalance();
 
         nativeCommissionPool -= amount;
         (bool success, ) = to.call{value: amount}("");
-        require(success, "CommissionManager: Native transfer failed");
+        if (!success) revert NativeTransferFailed();
 
         emit NativeCommissionWithdrawn(to, amount);
     }
@@ -561,10 +543,10 @@ contract CommissionManager is Ownable {
      * @notice Withdraw entire token commission balance for one token
      */
     function withdrawAllTokenCommission(address token, address to) external onlyOwner {
-        require(token != address(0), "CommissionManager: Invalid token");
-        require(to != address(0), "CommissionManager: Invalid recipient");
+        if (token == address(0)) revert InvalidToken();
+        if (to == address(0)) revert InvalidRecipient();
         uint256 balance = tokenCommissionPool[token];
-        require(balance > 0, "CommissionManager: No balance");
+        if (balance == 0) revert NoBalance();
 
         tokenCommissionPool[token] = 0;
         IERC20(token).safeTransfer(to, balance);
@@ -576,13 +558,13 @@ contract CommissionManager is Ownable {
      * @notice Withdraw entire native commission balance
      */
     function withdrawAllNativeCommission(address payable to) external onlyOwner {
-        require(to != address(0), "CommissionManager: Invalid recipient");
+        if (to == address(0)) revert InvalidRecipient();
         uint256 balance = nativeCommissionPool;
-        require(balance > 0, "CommissionManager: No balance");
+        if (balance == 0) revert NoBalance();
 
         nativeCommissionPool = 0;
         (bool success, ) = to.call{value: balance}("");
-        require(success, "CommissionManager: Native transfer failed");
+        if (!success) revert NativeTransferFailed();
 
         emit NativeCommissionWithdrawn(to, balance);
     }

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+/**
+ * @title ICommissionManager types & interface
+ * @notice Shared enums and struct for {CommissionManager}; see `ICommissionManager` for the external API.
+ */
+
+/// @notice Which bridge operation a route fee is tied to.
+enum CommissionSide {
+    FUNDS_IN,
+    FUNDS_OUT
+}
+
+/// @notice Fee taken in token units or expressed in native wei.
+enum CommissionCurrency {
+    TOKEN,
+    NATIVE
+}
+
+/// @notice Commission parameters for one directional route (keyed by `buildRouteKey`).
+struct CommissionConfig {
+    uint256 stablePercent;
+    uint8 multiplier;
+    CommissionSide side;
+    CommissionCurrency currency;
+    bool isSet;
+}
+
+/**
+ * @title ICommissionManager
+ * @notice Commission quotes, owner configuration, and custody of bridge fees. `CommissionManager` is the reference implementation.
+ */
+interface ICommissionManager {
+    // ============ Errors ============
+
+    error OnlyBridge();
+    error InvalidBridgeAddress();
+    error InvalidToken();
+    error InvalidRecipient();
+    error StablePercentTooHigh();
+    error StablePercentZero();
+    error MultiplierZero();
+    error MockTokenToNativeRateNotSet();
+    error TokenDecimalsUnavailable();
+    error BalanceBelowRecordedPool();
+    error NothingReceived();
+    error ZeroNativeAmount();
+    error InsufficientBalance();
+    error NativeTransferFailed();
+    error NoBalance();
+    error RenounceOwnershipBlocked();
+
+    // ============ Events ============
+
+    event BridgeAddressUpdated(address indexed newBridge);
+
+    event GlobalDefaultsUpdated(
+        uint256 stablePercent,
+        uint8 multiplier,
+        CommissionSide side,
+        CommissionCurrency currency
+    );
+
+    event CommissionRuleUpdated(
+        string sourceChain,
+        string destChain,
+        address indexed token,
+        CommissionConfig config
+    );
+
+    event CommissionRuleCleared(
+        string sourceChain,
+        string destChain,
+        address indexed token
+    );
+
+    event TokenCommissionReceived(address indexed token, uint256 amount);
+    event NativeCommissionReceived(uint256 amount);
+
+    event MockTokenToNativeRateUpdated(uint256 rate);
+    event MockTokenToNativeRateForTokenUpdated(address indexed token, uint256 rate);
+
+    event TokenCommissionWithdrawn(
+        address indexed token,
+        address indexed to,
+        uint256 amount
+    );
+    event NativeCommissionWithdrawn(address indexed to, uint256 amount);
+
+    // ============ State getters ============
+
+    function bridgeAddress() external view returns (address);
+
+    function globalStablePercent() external view returns (uint256);
+
+    function globalMultiplier() external view returns (uint8);
+
+    function globalSide() external view returns (CommissionSide);
+
+    function globalCurrency() external view returns (CommissionCurrency);
+
+    function tokenCommissionPool(address token) external view returns (uint256);
+
+    function nativeCommissionPool() external view returns (uint256);
+
+    function mockTokenToNativeRate() external view returns (uint256);
+
+    function mockTokenToNativeRateForToken(address token) external view returns (uint256);
+
+    // ============ Core calculations ============
+
+    function calculateFundsInCommission(
+        string calldata sourceChain,
+        string calldata destChain,
+        address token,
+        uint256 amount
+    )
+        external
+        view
+        returns (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount);
+
+    function calculateFundsOutCommission(
+        string calldata sourceChain,
+        string calldata destChain,
+        address token,
+        uint256 amount
+    )
+        external
+        view
+        returns (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount);
+
+    function calculateStableFee(
+        uint256 amount,
+        uint256 stablePercent,
+        uint256 multiplier
+    ) external pure returns (uint256);
+
+    function convertTokenToNative(
+        uint256 tokenFee,
+        uint256 rateWeiPerTokenUnit,
+        uint256 tokenDecimals
+    ) external pure returns (uint256 nativeFee);
+
+    function resolvedMockTokenToNativeRate(address token) external view returns (uint256);
+
+    // ============ Admin / config ============
+
+    function setGlobalDefaults(
+        uint256 stablePercent,
+        uint8 multiplier,
+        CommissionSide side,
+        CommissionCurrency currency
+    ) external;
+
+    function setMockTokenToNativeRate(uint256 rate) external;
+
+    function setMockTokenToNativeRateForToken(address token, uint256 rate) external;
+
+    function setCommissionRule(
+        string calldata sourceChain,
+        string calldata destChain,
+        address token,
+        CommissionConfig calldata config
+    ) external;
+
+    function clearCommissionRule(
+        string calldata sourceChain,
+        string calldata destChain,
+        address token
+    ) external;
+
+    function setBridgeAddress(address newBridge) external;
+
+    function getGlobalDefaults()
+        external
+        view
+        returns (
+            uint256 stablePercent,
+            uint8 multiplier,
+            CommissionSide side,
+            CommissionCurrency currency
+        );
+
+    function getCommissionRule(
+        string calldata sourceChain,
+        string calldata destChain,
+        address token
+    ) external view returns (CommissionConfig memory);
+
+    function buildRouteKey(
+        string calldata sourceChain,
+        string calldata destChain,
+        address token
+    ) external pure returns (bytes32);
+
+    // ============ Commission ingress (bridge) ============
+
+    function receiveTokenCommission(address token) external;
+
+    /// @notice Native commission ingress; only `bridgeAddress` may call with non-zero value (see implementation).
+    receive() external payable;
+
+    // ============ Withdrawals (owner) ============
+
+    function withdrawTokenCommission(
+        address token,
+        address to,
+        uint256 amount
+    ) external;
+
+    function withdrawNativeCommission(address payable to, uint256 amount) external;
+
+    function withdrawAllTokenCommission(address token, address to) external;
+
+    function withdrawAllNativeCommission(address payable to) external;
+}

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -39,7 +39,6 @@ interface ICommissionManager {
     error InvalidToken();
     error InvalidRecipient();
     error StablePercentTooHigh();
-    error StablePercentZero();
     error MultiplierZero();
     error MockTokenToNativeRateNotSet();
     error TokenDecimalsUnavailable();

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -1,0 +1,487 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import { Test } from 'forge-std/Test.sol';
+import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
+import { CommissionManager } from '../src/CommissionManager.sol';
+import {
+    CommissionConfig,
+    CommissionCurrency,
+    CommissionSide,
+    ICommissionManager
+} from '../src/interfaces/ICommissionManager.sol';
+import { MockERC20 } from './helpers/MockERC20.sol';
+
+contract CommissionManagerTest is Test {
+    CommissionManager internal cm;
+    MockERC20 internal token;
+
+    address internal constant BRIDGE = address(0xB01);
+    address internal owner = makeAddr('owner');
+    address internal user = makeAddr('user');
+    address internal recipient = makeAddr('recipient');
+
+    string internal constant SRC = 'eth';
+    string internal constant DST = 'rgb';
+
+    event BridgeAddressUpdated(address indexed newBridge);
+    event GlobalDefaultsUpdated(
+        uint256 stablePercent,
+        uint8 multiplier,
+        CommissionSide side,
+        CommissionCurrency currency
+    );
+
+    function setUp() public {
+        vm.prank(owner);
+        cm = new CommissionManager(BRIDGE);
+        token = new MockERC20('Test', 'TST');
+        vm.prank(owner);
+        cm.setGlobalDefaults(0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    // --- Constructor ---
+
+    function test_constructor_setsBridgeAndOwner() public view {
+        assertEq(cm.bridgeAddress(), BRIDGE);
+        assertEq(cm.owner(), owner);
+    }
+
+    function test_constructor_revertsOnZeroBridge() public {
+        vm.expectRevert(ICommissionManager.InvalidBridgeAddress.selector);
+        new CommissionManager(address(0));
+    }
+
+    function test_renounceOwnership_blocked() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.RenounceOwnershipBlocked.selector);
+        cm.renounceOwnership();
+    }
+
+    // --- Pure math helpers ---
+
+    function test_calculateStableFee_defaultMultiplier() public view {
+        // 10000 amount, 400 (=4%), mult 100 → 10000*400/10000 = 400
+        assertEq(cm.calculateStableFee(10000, 400, 100), 400);
+    }
+
+    function test_convertTokenToNative() public view {
+        uint256 native = cm.convertTokenToNative(1e18, 2e9, 18);
+        assertEq(native, 2e9);
+    }
+
+    function test_buildRouteKey_matchesEncodeHash() public view {
+        address t = address(token);
+        bytes32 expected = keccak256(abi.encode(SRC, DST, t));
+        assertEq(cm.buildRouteKey(SRC, DST, t), expected);
+    }
+
+    // --- Global defaults ---
+
+    function test_getGlobalDefaults_initial() public view {
+        (uint256 sp, uint8 m, CommissionSide side, CommissionCurrency cur) =
+            cm.getGlobalDefaults();
+        assertEq(sp, 0);
+        assertEq(m, 100);
+        assertEq(uint8(side), uint8(CommissionSide.FUNDS_IN));
+        assertEq(uint8(cur), uint8(CommissionCurrency.TOKEN));
+    }
+
+    function test_setGlobalDefaults_updatesAndEmits() public {
+        vm.expectEmit(true, true, true, true);
+        emit GlobalDefaultsUpdated(
+            200,
+            100,
+            CommissionSide.FUNDS_OUT,
+            CommissionCurrency.NATIVE
+        );
+        vm.prank(owner);
+        cm.setGlobalDefaults(
+            200,
+            100,
+            CommissionSide.FUNDS_OUT,
+            CommissionCurrency.NATIVE
+        );
+        (uint256 sp, uint8 m, CommissionSide side, CommissionCurrency cur) =
+            cm.getGlobalDefaults();
+        assertEq(sp, 200);
+        assertEq(m, 100);
+        assertEq(uint8(side), uint8(CommissionSide.FUNDS_OUT));
+        assertEq(uint8(cur), uint8(CommissionCurrency.NATIVE));
+    }
+
+    function test_setGlobalDefaults_onlyOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        cm.setGlobalDefaults(
+            400,
+            100,
+            CommissionSide.FUNDS_IN,
+            CommissionCurrency.TOKEN
+        );
+    }
+
+    function test_setGlobalDefaults_revertsPercentTooHigh() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.StablePercentTooHigh.selector);
+        cm.setGlobalDefaults(
+            9001,
+            100,
+            CommissionSide.FUNDS_IN,
+            CommissionCurrency.TOKEN
+        );
+    }
+
+    function test_setGlobalDefaults_acceptsZeroPercent() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(
+            100,
+            100,
+            CommissionSide.FUNDS_IN,
+            CommissionCurrency.TOKEN
+        );
+        assertEq(cm.globalStablePercent(), 100);
+        vm.prank(owner);
+        cm.setGlobalDefaults(
+            0,
+            100,
+            CommissionSide.FUNDS_IN,
+            CommissionCurrency.TOKEN
+        );
+        (uint256 sp,,,) = cm.getGlobalDefaults();
+        assertEq(sp, 0);
+    }
+
+    function test_setGlobalDefaults_revertsZeroMultiplier() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.MultiplierZero.selector);
+        cm.setGlobalDefaults(
+            400,
+            0,
+            CommissionSide.FUNDS_IN,
+            CommissionCurrency.TOKEN
+        );
+    }
+
+    // --- Commission calculations (globals) ---
+
+    function test_calculateFundsInCommission_token_deductsFromAmount() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        address t = address(token);
+        uint256 amount = 100_000;
+        (uint256 tok, uint256 nat, uint256 net) =
+            cm.calculateFundsInCommission(SRC, DST, t, amount);
+        assertEq(tok, 4000); // 4% of 100_000
+        assertEq(nat, 0);
+        assertEq(net, amount - 4000);
+    }
+
+    function test_calculateFundsInCommission_zeroStablePercent_noTokenFee() public view {
+        address t = address(token);
+        uint256 amount = 100_000;
+        (uint256 tok, uint256 nat, uint256 net) =
+            cm.calculateFundsInCommission(SRC, DST, t, amount);
+        assertEq(tok, 0);
+        assertEq(nat, 0);
+        assertEq(net, amount);
+    }
+
+    function test_calculateFundsInCommission_zeroStablePercent_native_skipsRateCheck() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(
+            0,
+            100,
+            CommissionSide.FUNDS_IN,
+            CommissionCurrency.NATIVE
+        );
+        address t = address(token);
+        // Deliberately no setMockTokenToNativeRate: nonzero fee would revert.
+        uint256 amount = 1000 ether;
+        (uint256 tok, uint256 nat, uint256 net) =
+            cm.calculateFundsInCommission(SRC, DST, t, amount);
+        assertEq(tok, 0);
+        assertEq(nat, 0);
+        assertEq(net, amount);
+    }
+
+    function test_calculateFundsInCommission_native_fullAmount_bridged() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(
+            400,
+            100,
+            CommissionSide.FUNDS_IN,
+            CommissionCurrency.NATIVE
+        );
+        address t = address(token);
+        uint256 amount = 100_000 ether;
+        uint256 rate = 2000 gwei; // wei per 1 wei of token with 18 decimals — illustrative
+        vm.prank(owner);
+        cm.setMockTokenToNativeRateForToken(t, rate);
+        (uint256 tok, uint256 nat, uint256 net) =
+            cm.calculateFundsInCommission(SRC, DST, t, amount);
+        uint256 stableFee = 4000 ether; // 4% of 100_000 ether
+        uint256 expectedNat = cm.convertTokenToNative(stableFee, rate, 18);
+        assertEq(tok, 0);
+        assertEq(nat, expectedNat);
+        assertEq(net, amount);
+    }
+
+    function test_calculateFundsInCommission_skipsWhenSideIsFundsOut() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(
+            400,
+            100,
+            CommissionSide.FUNDS_OUT,
+            CommissionCurrency.TOKEN
+        );
+        address t = address(token);
+        (uint256 tok, uint256 nat, uint256 net) =
+            cm.calculateFundsInCommission(SRC, DST, t, 50_000);
+        assertEq(tok, 0);
+        assertEq(nat, 0);
+        assertEq(net, 50_000);
+    }
+
+    function test_calculateFundsInCommission_native_revertsWhenRateUnset() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(
+            400,
+            100,
+            CommissionSide.FUNDS_IN,
+            CommissionCurrency.NATIVE
+        );
+        address t = address(token);
+        vm.expectRevert(ICommissionManager.MockTokenToNativeRateNotSet.selector);
+        cm.calculateFundsInCommission(SRC, DST, t, 1000);
+    }
+
+    function test_resolvedMockTokenToNativeRate_fallsBackToGlobalMock() public {
+        vm.prank(owner);
+        cm.setMockTokenToNativeRate(123e9);
+        assertEq(cm.resolvedMockTokenToNativeRate(address(token)), 123e9);
+        vm.prank(owner);
+        cm.setMockTokenToNativeRateForToken(address(token), 999e9);
+        assertEq(cm.resolvedMockTokenToNativeRate(address(token)), 999e9);
+    }
+
+    function test_calculateFundsOutCommission_token() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(
+            400,
+            100,
+            CommissionSide.FUNDS_OUT,
+            CommissionCurrency.TOKEN
+        );
+        address t = address(token);
+        uint256 amount = 80_000;
+        (uint256 tok, uint256 nat, uint256 net) =
+            cm.calculateFundsOutCommission(SRC, DST, t, amount);
+        assertEq(tok, 3200);
+        assertEq(nat, 0);
+        assertEq(net, amount - 3200);
+    }
+
+    function test_calculateFundsOutCommission_skipsWhenSideIsFundsIn() public view {
+        address t = address(token);
+        (uint256 tok, uint256 nat, uint256 net) =
+            cm.calculateFundsOutCommission(SRC, DST, t, 40_000);
+        assertEq(tok, 0);
+        assertEq(nat, 0);
+        assertEq(net, 40_000);
+    }
+
+    // --- Per-route rules ---
+
+    function test_setCommissionRule_overridesGlobal() public {
+        address t = address(token);
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 1000,
+            multiplier: 100,
+            side: CommissionSide.FUNDS_IN,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+        vm.prank(owner);
+        cm.setCommissionRule(SRC, DST, t, cfg);
+
+        (uint256 tok,, uint256 net) =
+            cm.calculateFundsInCommission(SRC, DST, t, 50_000);
+        assertEq(tok, 5000); // 10%
+        assertEq(net, 45_000);
+
+        CommissionConfig memory stored = cm.getCommissionRule(SRC, DST, t);
+        assertTrue(stored.isSet);
+        assertEq(stored.stablePercent, 1000);
+    }
+
+    function test_clearCommissionRule_fallsBackToGlobal() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        address t = address(token);
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 1000,
+            multiplier: 100,
+            side: CommissionSide.FUNDS_IN,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+        vm.prank(owner);
+        cm.setCommissionRule(SRC, DST, t, cfg);
+        vm.prank(owner);
+        cm.clearCommissionRule(SRC, DST, t);
+
+        CommissionConfig memory stored = cm.getCommissionRule(SRC, DST, t);
+        assertFalse(stored.isSet);
+
+        (uint256 tok,,) = cm.calculateFundsInCommission(SRC, DST, t, 50_000);
+        assertEq(tok, 2000); // back to global 4%
+    }
+
+    function test_setCommissionRule_revertsInvalidPercent() public {
+        address t = address(token);
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 9001,
+            multiplier: 100,
+            side: CommissionSide.FUNDS_IN,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.StablePercentTooHigh.selector);
+        cm.setCommissionRule(SRC, DST, t, cfg);
+    }
+
+    // --- Bridge address ---
+
+    function test_setBridgeAddress_updates() public {
+        address newBridge = makeAddr('newBridge');
+        vm.expectEmit(true, true, true, true);
+        emit BridgeAddressUpdated(newBridge);
+        vm.prank(owner);
+        cm.setBridgeAddress(newBridge);
+        assertEq(cm.bridgeAddress(), newBridge);
+    }
+
+    function test_setBridgeAddress_revertsZero() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.InvalidBridgeAddress.selector);
+        cm.setBridgeAddress(address(0));
+    }
+
+    // --- Token commission accounting ---
+
+    function test_receiveTokenCommission_onlyBridge() public {
+        uint256 amt = 100 ether;
+        token.mint(address(cm), amt);
+
+        vm.prank(user);
+        vm.expectRevert(ICommissionManager.OnlyBridge.selector);
+        cm.receiveTokenCommission(address(token));
+
+        vm.prank(BRIDGE);
+        cm.receiveTokenCommission(address(token));
+        assertEq(cm.tokenCommissionPool(address(token)), amt);
+    }
+
+    function test_receiveTokenCommission_revertsNothingReceived() public {
+        vm.prank(BRIDGE);
+        vm.expectRevert(ICommissionManager.NothingReceived.selector);
+        cm.receiveTokenCommission(address(token));
+    }
+
+    function test_receiveTokenCommission_revertsNothingReceived_whenNoNewTokens() public {
+        uint256 amt = 10 ether;
+        token.mint(address(cm), amt);
+        vm.startPrank(BRIDGE);
+        cm.receiveTokenCommission(address(token));
+        vm.expectRevert(ICommissionManager.NothingReceived.selector);
+        cm.receiveTokenCommission(address(token));
+        vm.stopPrank();
+    }
+
+    function test_withdrawTokenCommission_transfersAndUpdatesPool() public {
+        uint256 amt = 50 ether;
+        token.mint(address(cm), amt);
+        vm.prank(BRIDGE);
+        cm.receiveTokenCommission(address(token));
+
+        vm.prank(owner);
+        cm.withdrawTokenCommission(address(token), recipient, amt);
+
+        assertEq(cm.tokenCommissionPool(address(token)), 0);
+        assertEq(token.balanceOf(recipient), amt);
+    }
+
+    function test_withdrawAllTokenCommission() public {
+        uint256 amt = 30 ether;
+        token.mint(address(cm), amt);
+        vm.prank(BRIDGE);
+        cm.receiveTokenCommission(address(token));
+
+        vm.prank(owner);
+        cm.withdrawAllTokenCommission(address(token), recipient);
+
+        assertEq(cm.tokenCommissionPool(address(token)), 0);
+        assertEq(token.balanceOf(recipient), amt);
+    }
+
+    function test_withdrawTokenCommission_revertsInsufficient() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.InsufficientBalance.selector);
+        cm.withdrawTokenCommission(address(token), recipient, 1);
+    }
+
+    // --- Native commission ---
+
+    function test_receive_onlyBridge() public {
+        vm.deal(user, 1 ether);
+        vm.prank(user);
+        (bool okUser,) = address(cm).call{value: 1 ether}('');
+        assertFalse(okUser);
+
+        vm.deal(BRIDGE, 1 ether);
+        vm.prank(BRIDGE);
+        (bool okBridge,) = address(cm).call{value: 1 ether}('');
+        assertTrue(okBridge);
+        assertEq(cm.nativeCommissionPool(), 1 ether);
+    }
+
+    function test_receive_revertsZeroValue() public {
+        vm.prank(BRIDGE);
+        (bool ok,) = address(cm).call{value: 0}('');
+        assertFalse(ok); // receive() reverts with ZeroNativeAmount; call returns false
+    }
+
+    function test_withdrawNativeCommission() public {
+        vm.deal(BRIDGE, 5 ether);
+        vm.prank(BRIDGE);
+        (bool ok,) = address(cm).call{value: 2 ether}('');
+        assertTrue(ok);
+
+        uint256 before = recipient.balance;
+        vm.prank(owner);
+        cm.withdrawNativeCommission(payable(recipient), 2 ether);
+        assertEq(cm.nativeCommissionPool(), 0);
+        assertEq(recipient.balance, before + 2 ether);
+    }
+
+    function test_withdrawAllNativeCommission() public {
+        vm.deal(BRIDGE, 3 ether);
+        vm.prank(BRIDGE);
+        (bool ok,) = address(cm).call{value: 3 ether}('');
+        assertTrue(ok);
+
+        uint256 before = recipient.balance;
+        vm.prank(owner);
+        cm.withdrawAllNativeCommission(payable(recipient));
+        assertEq(cm.nativeCommissionPool(), 0);
+        assertEq(recipient.balance, before + 3 ether);
+    }
+
+    function test_withdrawNativeCommission_revertsInsufficient() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.InsufficientBalance.selector);
+        cm.withdrawNativeCommission(payable(recipient), 1 wei);
+    }
+}


### PR DESCRIPTION
Chsnges:
- [Added ownable, fixing mutability, removed unused constant](https://github.com/UTEXO-Protocol/utexo-smart-contracts/commit/9523c1f977b23059d07e1e8da251c07f0dd7805b)
- [expanded receiveTokenCommission](https://github.com/UTEXO-Protocol/utexo-smart-contracts/commit/14bd39a2fd198d56422fa8d9b7e36ad6a38ab89d)
- [replaced abi.encodePacked -> abi.encode](https://github.com/UTEXO-Protocol/utexo-smart-contracts/commit/300e09007f04c97cadb7f07ca493adf3a13fb4d5)
- [IERC20Metadata to get decimals, mocked tokenToNativeRate](https://github.com/UTEXO-Protocol/utexo-smart-contracts/commit/77bc4131431c4cee92f1ffe322f6c04dba5efebe)
- [Added !=0 addresschecks](https://github.com/UTEXO-Protocol/utexo-smart-contracts/commit/5091c4ae81745dea0f6a76ffeb64ceed6bf9ba0e)
- [Removed gasEstimate, added custom errors](https://github.com/UTEXO-Protocol/utexo-smart-contracts/commit/a86ae4740eccad28bee58efcc3f3869dfcf1f15e)
- [Added nonReentrant to withdraw functions](https://github.com/UTEXO-Protocol/utexo-smart-contracts/commit/515a5dfe73912c0b6b1252d5dc0b1ea994086c6c)
- [Updated contract documentation, added renounceOwnership method](https://github.com/UTEXO-Protocol/utexo-smart-contracts/commit/06076fab63f2d2f1a04f1f5e0c169c1bca12da2e)
- [CommissionManager interface](https://github.com/UTEXO-Protocol/utexo-smart-contracts/commit/c3a3d0d52feadb8ef592165d7ae9ba6d38212ed5)
- [globalStablePercent now also treated as 0](https://github.com/UTEXO-Protocol/utexo-smart-contracts/commit/c7bfc753258daac49e4a64b535269b3ddc70d862)