### PR TITLE
feat(commissionManager)<BREAKING CHANGE>: switch chain identifiers from string to uint256

### DIFF
--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -27,12 +27,14 @@ No TEE verification, no destination chain field, **no commission integration**. 
 
 Production bridge for UTEXO. Inherits `BridgeBase`, implements `IBridge`.
 
-Constructor takes four immutable addresses/values: the accepted ERC-20 token, the BtcRelay contract, the CommissionManager, and `sourceChainName` (this bridge's chain identifier as used in CommissionManager route keys, e.g. `"arbitrum"`).
+Constructor takes four immutable addresses/values: the accepted ERC-20 token, the BtcRelay contract, the CommissionManager, and the initial LayerZero adapter (`address(0)` is allowed — wire it in later via federation governance). The bridge's own chain identifier is `block.chainid` — chain IDs are uint256 throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
 
-- `fundsIn(amount, destinationChain, destinationAddress, operationId)` — open, **`payable`**. Quotes commission from `CommissionManager` using route key `(sourceChainName, destinationChain, TOKEN)`; if the route uses NATIVE currency, `msg.value` must equal the quoted native commission. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and stores `operationId => netAmount` in `fundsInRecords`. Emits two events:
+- `fundsIn(amount, destinationChainId, destinationAddress, operationId)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must equal the quoted native commission. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and stores `operationId => netAmount` in `fundsInRecords`. Emits two events:
   - `FundsIn` (from `BridgeBase`) — minimal, uses `netAmount`.
   - `BridgeFundsIn` (from `IBridge`) — full, consumed by the UTEXO backend.
-- `fundsOut(recipient, amount, operationId, burnId, sourceChain, destChain, sourceAddress, blockHeight, commitmentHash, fundsInIds)` — `onlyOwner`, called via `MultisigProxy.execute()` or `MultisigProxy.executeBatch()`. Checks `burnId` has not been consumed yet (single-use replay guard, marks it consumed before any external interaction), verifies referenced fundsIn operations exist on-chain (prevents double-spend and fake event attacks on TEE), verifies the Bitcoin block header via BtcRelay, quotes commission from `CommissionManager` using `(sourceChain, destChain, TOKEN)`, forwards any token commission to the pool, and releases `netAmount` to the recipient. Emits `BridgeFundsOut`. NATIVE commission on `fundsOut` is disallowed (the caller is the multisig, not a user) — the contract reverts `NativeCommissionNotAllowedOnFundsOut`.
+- `fundsInFromAdapter(amount, destinationChainId, destinationAddress, operationId, sourceChainId)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating `msg.sender` on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` to the bridge. Otherwise identical semantics to `fundsIn`.
+- `setLZAdapter(adapter)` — `onlyOwner`. Rotates the address authorized to call `fundsInFromAdapter`. Set to `address(0)` to close the adapter path entirely.
+- `fundsOut(recipient, amount, operationId, burnId, sourceChainId, destChainId, sourceAddress, blockHeight, commitmentHash, fundsInIds)` — `onlyOwner`, called via `MultisigProxy.execute()` or `MultisigProxy.executeBatch()`. All ten parameters are `uint256` except `recipient` (address), `sourceAddress` (string), `commitmentHash` (bytes32), and the `fundsInIds` array. Checks `burnId` has not been consumed yet (single-use replay guard, marks it consumed before any external interaction), verifies referenced fundsIn operations exist on-chain (prevents double-spend and fake event attacks on TEE), verifies the Bitcoin block header via BtcRelay, quotes commission from `CommissionManager` using `(sourceChainId, destChainId, TOKEN)`, forwards any token commission to the pool, and releases `netAmount` to the recipient. Emits `BridgeFundsOut`. NATIVE commission on `fundsOut` is disallowed (the caller is the multisig, not a user) — the contract reverts `NativeCommissionNotAllowedOnFundsOut`.
 
 Owner **must** be `MultisigProxy`. `fundsOut` is only reachable through `MultisigProxy.execute()` (single-call) or `MultisigProxy.executeBatch()` (atomic multi-call, e.g. `Bridge.fundsOut` + `LZAdapter.sendOut` for outbound to non-Arbitrum), both of which require M-of-N TEE signatures.
 
@@ -57,7 +59,7 @@ Every `fundsOut` call carries a `burnId` — an identifier the backend extracts 
 
 Standalone fee contract. Holds protocol commissions separately from bridge liquidity so that deployment, auditing, and withdrawal of fees are independent of bridge funds.
 
-- **Route keys** are `keccak256(abi.encode(sourceChain, destChain, token))` — directional, so each leg of a round trip can have its own config.
+- **Route keys** are `keccak256(abi.encode(sourceChainId, destChainId, token))` where both chain IDs are `uint256` — directional, so each leg of a round trip can have its own config. EVM legs use `block.chainid`; non-EVM endpoints get backend-assigned IDs in a reserved namespace (e.g. `RGB = 1_000_001`).
 - **Config** selects per route: `side` (`FUNDS_IN` vs `FUNDS_OUT`), `currency` (`TOKEN` vs `NATIVE`), `stablePercent` (×100, capped at 9000 = 90%), and `multiplier`. Global defaults apply to any route without an override.
 - **NATIVE quotes** use an owner-set mock wei-per-token rate (global or per-token) and the token's `decimals()`.
 - **Ingress:** `receiveTokenCommission(token)` and `receive()` are gated by `onlyBridge` — only `Bridge` may credit commissions. Pools are updated from balance deltas, so fee-on-transfer tokens are supported.
@@ -85,23 +87,27 @@ Federation-controlled operations (`OperationType`):
 | `WithdrawTokenCommissionCM` | CommissionManager | Withdraw ERC-20 commission to `commissionRecipient` |
 | `WithdrawNativeCommissionCM` | CommissionManager | Withdraw native commission to `commissionRecipient` |
 | `UpdateCommissionManager` | self | Migrate to a redeployed CommissionManager |
+| `AdminExecuteAdapter` | LZAdapter | Generic call into the registered LayerZero adapter (`setTrustedEntrypoint`, `refundStuckFunds`, …). Reverts `ZeroTarget` if `MultisigProxy.lzAdapter` is unset. |
+| `UpdateLZAdapter` | self | Rotate `MultisigProxy.lzAdapter` — the routing target for `AdminExecuteAdapter`. Setting to `address(0)` closes the adapter-admin path. |
+
+Note: `MultisigProxy.lzAdapter` and `Bridge.lzAdapter` are **separate** fields with different roles. `Bridge.lzAdapter` gates `fundsInFromAdapter` (data path); `MultisigProxy.lzAdapter` is the target of `AdminExecuteAdapter` proposals (governance path). Both default to `address(0)` and are wired in by federation after the adapter is deployed.
 
 ## How it works
 
 ### FundsIn (user deposits)
 
-1. The user (or frontend) quotes commission from `CommissionManager.calculateFundsInCommission(sourceChainName, destinationChain, token, amount)`.
-2. The user approves `amount` to `Bridge` and calls `Bridge.fundsIn{ value: nativeCommission }(...)`. No signature required — any user can lock tokens. Validation of the destination address and chain happens off-chain on the UTEXO backend before minting on the other side.
+1. The user (or frontend) quotes commission from `CommissionManager.calculateFundsInCommission(sourceChainId, destinationChainId, token, amount)`. EVM users pass `block.chainid` as `sourceChainId`.
+2. The user approves `amount` to `Bridge` and calls `Bridge.fundsIn{ value: nativeCommission }(amount, destinationChainId, destinationAddress, operationId)`. No signature required — any user can lock tokens. Cross-chain (LayerZero compose) deposits land through `Bridge.fundsInFromAdapter(...)` instead, called by the trusted `LZAdapter` with an authenticated `sourceChainId`. Validation of the destination address and chain happens off-chain on the UTEXO backend before minting on the other side.
 3. Bridge pulls `amount` in tokens, forwards `tokenCommission` and `nativeCommission` (if any) to `CommissionManager`, stores `netAmount = amount - tokenCommission` in `fundsInRecords`, and emits `FundsIn` + `BridgeFundsIn`.
 
 ### FundsOut (bridge withdrawals)
 
-`Bridge.fundsOut()` is `onlyOwner`, where the owner is `MultisigProxy`. The backend collects M-of-N ECDSA signatures from TEE signers over an EIP-712 `BridgeOperation` message (selector, callData, nonce, deadline). The call data includes `burnId` (replay guard for the source-side burn), `blockHeight` and `commitmentHash` for BtcRelay verification, plus `destChain` so CommissionManager can pick the right outbound route. `MultisigProxy.execute()` verifies the signatures on-chain and forwards the call to `Bridge`, which then:
+`Bridge.fundsOut()` is `onlyOwner`, where the owner is `MultisigProxy`. The backend collects M-of-N ECDSA signatures from TEE signers over an EIP-712 `BridgeOperation` message (selector, callData, nonce, deadline). The call data includes `burnId` (replay guard for the source-side burn), `blockHeight` and `commitmentHash` for BtcRelay verification, plus `destChainId` so CommissionManager can pick the right outbound route. `MultisigProxy.execute()` verifies the signatures on-chain and forwards the call to `Bridge`, which then:
 
 1. Checks `burnId` has not been consumed yet and marks it consumed (replay guard).
 2. Verifies the referenced `fundsInIds` exist and consumes them.
 3. Verifies the Bitcoin block header against BtcRelay.
-4. Quotes outbound commission via `CommissionManager.calculateFundsOutCommission(sourceChain, destChain, token, amount)`.
+4. Quotes outbound commission via `CommissionManager.calculateFundsOutCommission(sourceChainId, destChainId, token, amount)`.
 5. Forwards any token commission to `CommissionManager` and releases `netAmount` to the recipient.
 
 ### Federation governance (two-phase timelock)
@@ -159,17 +165,19 @@ set -a && source .env.interact && set +a   # before interact scripts
 **Key deploy variables** (`.env.deploy`):
 - `USDT0_ADDRESS` — accepted ERC-20 token
 - `BTC_RELAY_ADDRESS` — Atomiq BtcRelay contract address
-- `SOURCE_CHAIN_NAME` — this bridge's chain id used by `CommissionManager` route keys (e.g. `"arbitrum"`)
+- `LZ_ADAPTER` — initial LayerZero adapter address (optional; pass `0x0` if the adapter has not been deployed yet, then wire it in via federation governance after the adapter ships)
 - `COMMISSION_MANAGER` — `CommissionManager` address (step-by-step deploys only)
 - `COMMISSION_RECIPIENT` — destination for CM withdrawals
 - `ENCLAVE_SIGNERS` / `FEDERATION_SIGNERS` — comma-separated addresses, ordered by bitmap bit index
 - `TIMELOCK_DURATION` — federation timelock window in seconds
 
+> Chain identifiers are `uint256` everywhere — `block.chainid` for EVM legs, backend-assigned values for non-EVM endpoints. There is no `SOURCE_CHAIN_NAME` env var anymore; the bridge reads `block.chainid` at runtime.
+
 **Key interact variables** (`.env.interact`):
 - `BRIDGE_ADDRESS`, `PROXY_ADDRESS`, `BASE_BRIDGE_ADDRESS` — deployed contracts
 - `OPERATION_ID` — backend-assigned operation id (replay guard)
 - `BURN_ID`, `BLOCK_HEIGHT`, `COMMITMENT_HASH`, `FUNDS_IN_IDS` — fundsOut-only inputs
-- `DEST_CHAIN` — destination chain string used by `MultisigExecuteFundsOut.s.sol` when building calldata
+- `DEST_CHAIN_ID` — destination chain id (`uint256`) used by `MultisigExecuteFundsOut.s.sol` when building calldata
 - `ENCLAVE_PKS` / `FED_PKS` — comma-separated private keys for local TEE/federation simulation
 
 ## Deployment
@@ -217,7 +225,7 @@ Scripts in `script/interact/` let you exercise contracts manually before the bac
 | `BridgeFundsIn.s.sol` | Quotes commission from `CommissionManager`, approves tokens and calls `Bridge.fundsIn{ value: nativeCommission }(...)` |
 | `BaseBridgeFundsIn.s.sol` | Approves tokens and calls `BaseBridge.fundsIn(amount, operationId)` |
 | `BaseBridgeFundsOut.s.sol` | Calls `BaseBridge.fundsOut()` as owner |
-| `MultisigExecuteFundsOut.s.sol` | Signs a `Bridge.fundsOut()` locally with `ENCLAVE_PKS` (10-arg signature including `destChain` and `burnId`) and submits via `MultisigProxy.execute()` |
+| `MultisigExecuteFundsOut.s.sol` | Signs a `Bridge.fundsOut()` locally with `ENCLAVE_PKS` (10-arg `uint256`-chain-id signature including `destChainId`, `sourceChainId` and `burnId`) and submits via `MultisigProxy.execute()` |
 | `EmergencyPause.s.sol` | Signs and submits `MultisigProxy.emergencyPause()` with `FED_PKS` |
 | `EmergencyUnpause.s.sol` | Signs and submits `MultisigProxy.emergencyUnpause()` with `FED_PKS` |
 
@@ -235,10 +243,12 @@ forge script script/interact/BridgeFundsIn.s.sol --rpc-url $RPC_URL --broadcast
 2. Verify CommissionManager ownership: `CommissionManager.owner()` returns the `MultisigProxy` address.
 3. Verify CommissionManager linkage: `CommissionManager.bridgeAddress()` returns the live `Bridge` address; `Bridge.commissionManager()` returns the live `CommissionManager` address.
 4. Verify BtcRelay: `Bridge.btcRelay()` returns the expected BtcRelay contract address.
-5. Verify source chain name: `Bridge.sourceChainName()` matches the expected `SOURCE_CHAIN_NAME`.
+5. Verify LZ adapter wiring: `Bridge.lzAdapter()` and `MultisigProxy.lzAdapter()` both return `address(0)` immediately after deploy. Once the adapter is live, federation must run two timelocked proposals:
+   - `proposeAdminExecute` on the proxy with calldata `Bridge.setLZAdapter(adapter)` — opens the `fundsInFromAdapter` data path.
+   - `proposeUpdateLZAdapter(adapter)` — opens the `AdminExecuteAdapter` governance path on the proxy.
 6. Verify enclave signers: `MultisigProxy.getEnclaveSigners()` returns the TEE addresses.
 7. Verify federation signers: `MultisigProxy.getFederationSigners()` returns the governance addresses.
-8. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` (selector for the 10-arg `fundsOut` signature with `destChain` and `burnId`).
+8. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` (selector for the 10-arg `uint256`-chain-id `fundsOut` signature with `destChainId`, `sourceChainId` and `burnId`).
 9. Test `fundsIn` with a small amount (zero commission by default) to confirm token transfer and event emission.
 
 ## Project structure

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -15,10 +15,15 @@ import { MultisigProxy } from '../../src/MultisigProxy.sol';
 ///           5. Transfer Bridge and CommissionManager ownership to MultisigProxy.
 ///
 /// Env:
-///   PRIVATE_KEY, USDT0_ADDRESS, BTC_RELAY_ADDRESS, SOURCE_CHAIN_NAME,
+///   PRIVATE_KEY, USDT0_ADDRESS, BTC_RELAY_ADDRESS,
 ///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD,
 ///   FEDERATION_SIGNERS, FEDERATION_THRESHOLD,
 ///   COMMISSION_RECIPIENT, TIMELOCK_DURATION
+///
+/// Note: the Bridge's `lzAdapter` is left as `address(0)` here. After this
+/// flow finishes the adapter is deployed in `utexo-usdt0-contracts` and
+/// federation governance points the Bridge at it via `setLZAdapter` on the
+/// MultisigProxy admin-execute path.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployAll.s.sol \
@@ -31,7 +36,6 @@ contract DeployAll is Script {
         uint256 pk             = vm.envUint('PRIVATE_KEY');
         address usdt0          = vm.envAddress('USDT0_ADDRESS');
         address btcRelay       = vm.envAddress('BTC_RELAY_ADDRESS');
-        string memory srcChain = vm.envString('SOURCE_CHAIN_NAME');
         address[] memory enc   = vm.envAddress('ENCLAVE_SIGNERS', ',');
         uint256 encThr         = vm.envUint('ENCLAVE_THRESHOLD');
         address[] memory fed   = vm.envAddress('FEDERATION_SIGNERS', ',');
@@ -53,7 +57,7 @@ contract DeployAll is Script {
         vm.startBroadcast(pk);
 
         cm     = new CommissionManager(predictedBridge);
-        bridge = new Bridge(usdt0, btcRelay, payable(address(cm)), srcChain);
+        bridge = new Bridge(usdt0, btcRelay, payable(address(cm)), address(0));
         proxy  = new MultisigProxy(
             address(bridge),
             address(cm),

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -20,10 +20,6 @@ import { MultisigProxy } from '../../src/MultisigProxy.sol';
 ///   FEDERATION_SIGNERS, FEDERATION_THRESHOLD,
 ///   COMMISSION_RECIPIENT, TIMELOCK_DURATION
 ///
-/// Note: the Bridge's `lzAdapter` is left as `address(0)` here. After this
-/// flow finishes the adapter is deployed in `utexo-usdt0-contracts` and
-/// federation governance points the Bridge at it via `setLZAdapter` on the
-/// MultisigProxy admin-execute path.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployAll.s.sol \

--- a/ethereum/script/deploy/DeployBridge.s.sol
+++ b/ethereum/script/deploy/DeployBridge.s.sol
@@ -15,9 +15,14 @@ import { Bridge } from '../../src/Bridge.sol';
 ///   BTC_RELAY_ADDRESS         — BtcRelay contract for Bitcoin header verification
 ///   COMMISSION_MANAGER        — CommissionManager contract (must already be deployed)
 ///   LZ_ADAPTER                — Optional initial LayerZero adapter address;
-///                               pass `0x0` if the adapter has not been deployed
-///                               yet, and wire it in later via federation
-///                               governance (`setLZAdapter`).
+///                               omit or pass `0x0` if the adapter has not been
+///                               deployed yet. Once the adapter exists in
+///                               `utexo-usdt0-contracts`, wire it in via
+///                               federation governance: `proposeAdminExecute`
+///                               on MultisigProxy with calldata
+///                               `Bridge.setLZAdapter(adapter)`. The Bridge
+///                               accepts adapter-only `fundsInFromAdapter`
+///                               calls *only* from the configured adapter.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployBridge.s.sol \

--- a/ethereum/script/deploy/DeployBridge.s.sol
+++ b/ethereum/script/deploy/DeployBridge.s.sol
@@ -14,7 +14,10 @@ import { Bridge } from '../../src/Bridge.sol';
 ///   USDT0_ADDRESS             — accepted ERC-20 token
 ///   BTC_RELAY_ADDRESS         — BtcRelay contract for Bitcoin header verification
 ///   COMMISSION_MANAGER        — CommissionManager contract (must already be deployed)
-///   SOURCE_CHAIN_NAME         — this bridge's chain id for CM route keys (e.g. "arbitrum")
+///   LZ_ADAPTER                — Optional initial LayerZero adapter address;
+///                               pass `0x0` if the adapter has not been deployed
+///                               yet, and wire it in later via federation
+///                               governance (`setLZAdapter`).
 ///
 /// Usage:
 ///   forge script script/deploy/DeployBridge.s.sol \
@@ -25,10 +28,10 @@ contract DeployBridge is Script {
         address usdt0             = vm.envAddress('USDT0_ADDRESS');
         address btcRelay          = vm.envAddress('BTC_RELAY_ADDRESS');
         address commissionManager = vm.envAddress('COMMISSION_MANAGER');
-        string memory srcChain    = vm.envString('SOURCE_CHAIN_NAME');
+        address lzAdapter         = vm.envOr('LZ_ADAPTER', address(0));
 
         vm.startBroadcast(pk);
-        bridge = new Bridge(usdt0, btcRelay, payable(commissionManager), srcChain);
+        bridge = new Bridge(usdt0, btcRelay, payable(commissionManager), lzAdapter);
         vm.stopBroadcast();
 
         console2.log('Bridge deployed at:  ', address(bridge));
@@ -36,6 +39,6 @@ contract DeployBridge is Script {
         console2.log('Token:               ', bridge.TOKEN());
         console2.log('BtcRelay:            ', bridge.btcRelay());
         console2.log('CommissionManager:   ', address(bridge.commissionManager()));
-        console2.log('Source chain name:   ', bridge.sourceChainName());
+        console2.log('LZ adapter:          ', bridge.lzAdapter());
     }
 }

--- a/ethereum/script/deploy/DeployMultisigProxy.s.sol
+++ b/ethereum/script/deploy/DeployMultisigProxy.s.sol
@@ -54,8 +54,13 @@ contract DeployMultisigProxy is Script {
         console2.log('Commission recipient:     ', proxy.commissionRecipient());
         console2.log('Timelock duration (sec):  ', proxy.timelockDuration());
         console2.log('');
+        console2.log('lzAdapter (proxy):        ', proxy.lzAdapter());
+        console2.log('');
         console2.log('Next steps:');
         console2.log('  1) Transfer Bridge ownership to MultisigProxy.');
         console2.log('  2) Transfer CommissionManager ownership to MultisigProxy.');
+        console2.log('  3) Once the LayerZero adapter is deployed:');
+        console2.log('     a) propose Bridge.setLZAdapter(adapter) via proposeAdminExecute');
+        console2.log('     b) propose MultisigProxy.lzAdapter via proposeUpdateLZAdapter');
     }
 }

--- a/ethereum/script/interact/BridgeFundsIn.s.sol
+++ b/ethereum/script/interact/BridgeFundsIn.s.sol
@@ -26,8 +26,14 @@ contract BridgeFundsIn is Script {
         address token = bridge.TOKEN();
 
         ICommissionManager cm = bridge.commissionManager();
+        // FIXME(PR2): the chain identifiers become uint256 throughout in the
+        // matching Bridge refactor. Until then, the script keccak-casts the
+        // strings to satisfy the new CM signature.
         (, uint256 nativeCommission, ) = cm.calculateFundsInCommission(
-            bridge.sourceChainName(), dChain, token, amount
+            uint256(keccak256(bytes(bridge.sourceChainName()))),
+            uint256(keccak256(bytes(dChain))),
+            token,
+            amount
         );
 
         console2.log('Native commission (wei):', nativeCommission);

--- a/ethereum/script/interact/BridgeFundsIn.s.sol
+++ b/ethereum/script/interact/BridgeFundsIn.s.sol
@@ -7,31 +7,31 @@ import { Bridge } from '../../src/Bridge.sol';
 import { ICommissionManager } from '../../src/interfaces/ICommissionManager.sol';
 
 /// @title BridgeFundsIn
-/// @notice Approves and calls Bridge.fundsIn() as the current signer. Quotes the
-///         native commission from CommissionManager and attaches it as msg.value.
+/// @notice Approves and calls the public `Bridge.fundsIn()` overload as the
+///         current signer. Quotes the native commission from CommissionManager
+///         and attaches it as `msg.value`. `sourceChainId` is filled with
+///         `block.chainid` by the Bridge — the script just reads it back to
+///         drive the quote.
 ///
 /// Env:
 ///   PRIVATE_KEY, BRIDGE_ADDRESS, AMOUNT (wei),
-///   DESTINATION_CHAIN, DESTINATION_ADDRESS, OPERATION_ID
+///   DESTINATION_CHAIN_ID, DESTINATION_ADDRESS, OPERATION_ID
 contract BridgeFundsIn is Script {
     function run() external {
-        uint256 pk           = vm.envUint('PRIVATE_KEY');
-        address bridgeAddr   = vm.envAddress('BRIDGE_ADDRESS');
-        uint256 amount       = vm.envUint('AMOUNT');
-        string memory dChain = vm.envString('DESTINATION_CHAIN');
-        string memory dAddr  = vm.envString('DESTINATION_ADDRESS');
-        uint256 operationId  = vm.envUint('OPERATION_ID');
+        uint256 pk            = vm.envUint('PRIVATE_KEY');
+        address bridgeAddr    = vm.envAddress('BRIDGE_ADDRESS');
+        uint256 amount        = vm.envUint('AMOUNT');
+        uint256 destChainId   = vm.envUint('DESTINATION_CHAIN_ID');
+        string memory dAddr   = vm.envString('DESTINATION_ADDRESS');
+        uint256 operationId   = vm.envUint('OPERATION_ID');
 
         Bridge bridge = Bridge(bridgeAddr);
         address token = bridge.TOKEN();
 
         ICommissionManager cm = bridge.commissionManager();
-        // FIXME(PR2): the chain identifiers become uint256 throughout in the
-        // matching Bridge refactor. Until then, the script keccak-casts the
-        // strings to satisfy the new CM signature.
         (, uint256 nativeCommission, ) = cm.calculateFundsInCommission(
-            uint256(keccak256(bytes(bridge.sourceChainName()))),
-            uint256(keccak256(bytes(dChain))),
+            block.chainid,
+            destChainId,
             token,
             amount
         );
@@ -40,7 +40,7 @@ contract BridgeFundsIn is Script {
 
         vm.startBroadcast(pk);
         IERC20(token).approve(bridgeAddr, amount);
-        bridge.fundsIn{ value: nativeCommission }(amount, dChain, dAddr, operationId);
+        bridge.fundsIn{ value: nativeCommission }(amount, destChainId, dAddr, operationId);
         vm.stopBroadcast();
 
         console2.log('fundsIn succeeded. Bridge balance:', IERC20(token).balanceOf(bridgeAddr));

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -16,15 +16,24 @@ import { ICommissionManager } from './interfaces/ICommissionManager.sol';
 ///         commission to a standalone CommissionManager so protocol fees are held
 ///         separately from bridge liquidity.
 ///
-/// @dev - Owner must be MultisigProxy. fundsOut is called via MultisigProxy.execute()
-///        (TEE M-of-N).
-///      - fundsIn is open — any user can lock tokens. Validation of destination
-///        address and chain happens on the backend before minting on the other side.
-///      - fundsOut verifies the Bitcoin block header via BtcRelay before releasing funds.
-///      - Commission routing: fundsIn uses route key
-///        `(sourceChainName, destinationChain, TOKEN)`; fundsOut uses
-///        `(sourceChain, destChain, TOKEN)`. NATIVE currency is only supported on
-///        fundsIn — revert on fundsOut.
+/// @dev - Owner is `MultisigProxy`. `fundsOut` is called via
+///        `MultisigProxy.execute()` (TEE M-of-N).
+///      - `fundsIn` has two overloads:
+///        • Public 4-arg: any EVM user on this chain can lock tokens; the
+///          source chain id is filled with `block.chainid`.
+///        • Adapter-only 5-arg: callable only by the trusted `lzAdapter`,
+///          which forwards a non-spoofable `sourceChainId` carried in
+///          `composeMsg` from the source chain. Both overloads share the same
+///          private body via `_fundsIn`.
+///      - `fundsOut` verifies the Bitcoin block header via BtcRelay and the
+///        referenced `fundsIn` records before releasing funds.
+///      - Commission routing keys on `(sourceChainId, destinationChainId,
+///        TOKEN)` for both directions. NATIVE currency is only supported on
+///        `fundsIn`; `fundsOut` reverts if a NATIVE rule is configured.
+///      - `lzAdapter` is mutable so federation governance can rotate adapter
+///        deployments without redeploying the Bridge (the adapter itself
+///        immutably points back at the Bridge, so a swap is a one-way
+///        Bridge → Adapter pointer update).
 contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
@@ -38,10 +47,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     /// @notice CommissionManager that receives and custodies protocol fees.
     ICommissionManager public immutable commissionManager;
 
-    /// @notice Hash of this bridge's chain identifier (the `sourceChain` half of
-    ///         the fundsIn route key). The string itself is kept immutable-ish via
-    ///         storage + an immutable hash for quick equality checks if ever needed.
-    string private _sourceChainName;
+    /// @inheritdoc IBridge
+    address public override lzAdapter;
 
     /// @notice On-chain record of fundsIn operations: operationId => netAmount.
     ///         Stores the amount actually bridged after token commission is deducted;
@@ -55,37 +62,53 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     mapping(uint256 => bool) public consumedBurnIds;
 
     // =========================================================================
+    // Modifiers
+    // =========================================================================
+
+    /// @dev Restricts a function to the configured `lzAdapter`. Until federation
+    ///      sets a non-zero adapter, the modifier closes the function for every
+    ///      caller (no EOA or contract has `address(0)` as its `msg.sender`).
+    modifier onlyLZAdapter() {
+        if (msg.sender != lzAdapter) revert NotLZAdapter();
+        _;
+    }
+
+    // =========================================================================
     // Constructor
     // =========================================================================
 
     /// @param usdt0_             USDT0 token address on this chain.
     /// @param btcRelay_          BtcRelay contract for Bitcoin header verification.
     /// @param commissionManager_ CommissionManager that receives protocol fees.
-    /// @param sourceChainName_   This bridge's chain id as used in CommissionManager
-    ///                           route keys (e.g. "arbitrum"). Non-empty, immutable.
+    /// @param lzAdapter_         Initial trusted LayerZero adapter; pass
+    ///                           `address(0)` if it has not been deployed yet
+    ///                           (federation can wire it up later via
+    ///                           `setLZAdapter`).
     constructor(
         address usdt0_,
         address btcRelay_,
         address payable commissionManager_,
-        string memory sourceChainName_
+        address lzAdapter_
     ) BridgeBase(usdt0_) {
         if (btcRelay_ == address(0))          revert InvalidBtcRelayAddress();
         if (commissionManager_ == address(0)) revert InvalidCommissionManagerAddress();
-        if (bytes(sourceChainName_).length == 0) revert InvalidSourceChainName();
 
         btcRelay          = btcRelay_;
         commissionManager = ICommissionManager(commissionManager_);
-        _sourceChainName  = sourceChainName_;
+        lzAdapter         = lzAdapter_;
     }
 
     // =========================================================================
-    // View
+    // External — admin
     // =========================================================================
 
-    /// @notice Returns the source chain identifier used as the origin side of the
-    ///         CommissionManager route key for fundsIn.
-    function sourceChainName() external view returns (string memory) {
-        return _sourceChainName;
+    /// @inheritdoc IBridge
+    /// @dev Owner is `MultisigProxy`; federation governance gates this call on
+    ///      its M-of-N timelock flow.
+    function setLZAdapter(address newAdapter) external override onlyOwner {
+        address old = lzAdapter;
+        lzAdapter = newAdapter;
+        emit LZAdapterUpdated(old, newAdapter);
     }
 
     // =========================================================================
@@ -95,56 +118,35 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     /// @inheritdoc IBridge
     function fundsIn(
         uint256 amount,
-        string  calldata destinationChain,
+        uint256 destinationChainId,
         string  calldata destinationAddress,
         uint256 operationId
-    ) external payable whenNotPaused nonReentrant {
-        if (bytes(destinationAddress).length == 0) revert InvalidDestinationAddress();
-        if (bytes(destinationChain).length == 0)   revert InvalidDestinationChain();
-        if (fundsInRecords[operationId] != 0)      revert DuplicateOperationId();
-
-        (
-            uint256 tokenCommission,
-            uint256 nativeCommission,
-            uint256 netAmount
-        ) = commissionManager.calculateFundsInCommission(
-            block.chainid,
-            uint256(keccak256(bytes(destinationChain))),
-            TOKEN,
-            amount
-        );
-
-        // Native payment must match the quote exactly (includes the zero-native case).
-        if (msg.value != nativeCommission) revert NativeValueMismatch();
-
-        // Pull the full gross amount from the user into this contract.
-        IERC20(TOKEN).safeTransferFrom(_msgSender(), address(this), amount);
-
-        // Record the net amount as the bridged liquidity for this operation.
-        fundsInRecords[operationId] = netAmount;
-
-        // Forward token commission, if any, to the CommissionManager pool.
-        if (tokenCommission != 0) {
-            IERC20(TOKEN).safeTransfer(address(commissionManager), tokenCommission);
-            commissionManager.receiveTokenCommission(TOKEN);
-        }
-
-        // Forward native commission, if any, to the CommissionManager pool.
-        if (nativeCommission != 0) {
-            (bool ok, ) = address(commissionManager).call{ value: nativeCommission }('');
-            if (!ok) revert NativeValueMismatch();
-        }
-
-        emit FundsIn(_msgSender(), operationId, netAmount);
-        emit BridgeFundsIn(
+    ) external payable override whenNotPaused nonReentrant {
+        _fundsIn(
             _msgSender(),
-            operationId,
             amount,
-            netAmount,
-            tokenCommission,
-            nativeCommission,
-            destinationChain,
-            destinationAddress
+            block.chainid,
+            destinationChainId,
+            destinationAddress,
+            operationId
+        );
+    }
+
+    /// @inheritdoc IBridge
+    function fundsIn(
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string  calldata destinationAddress,
+        uint256 operationId
+    ) external payable override whenNotPaused nonReentrant onlyLZAdapter {
+        _fundsIn(
+            _msgSender(),
+            amount,
+            sourceChainId,
+            destinationChainId,
+            destinationAddress,
+            operationId
         );
     }
 
@@ -158,14 +160,16 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         uint256 amount,
         uint256 operationId,
         uint256 burnId,
-        string  calldata sourceChain,
-        string  calldata destChain,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
         string  calldata sourceAddress,
         uint256 blockHeight,
         bytes32 commitmentHash,
         uint256[] calldata fundsInIds
-    ) external onlyOwner nonReentrant {
-        if (recipient == address(0)) revert InvalidRecipientAddress();
+    ) external override onlyOwner nonReentrant {
+        if (recipient == address(0))               revert InvalidRecipientAddress();
+        if (sourceChainId == 0)                    revert InvalidSourceChainId();
+        if (destinationChainId == 0)               revert InvalidDestinationChainId();
         if (amount > IERC20(TOKEN).balanceOf(address(this))) revert AmountExceedBridgePool();
 
         // Set the flag before any external interaction so a revert
@@ -206,8 +210,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             uint256 nativeCommission,
             uint256 netAmount
         ) = commissionManager.calculateFundsOutCommission(
-            uint256(keccak256(bytes(sourceChain))),
-            uint256(keccak256(bytes(destChain))),
+            sourceChainId,
+            destinationChainId,
             TOKEN,
             amount
         );
@@ -232,8 +236,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             tokenCommission,
             operationId,
             burnId,
-            sourceChain,
-            destChain,
+            sourceChainId,
+            destinationChainId,
             sourceAddress,
             blockHeight,
             commitmentHash
@@ -248,5 +252,69 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         onlyOwner
     {
         revert RenounceOwnershipBlocked();
+    }
+
+    // =========================================================================
+    // Internal
+    // =========================================================================
+
+    /// @dev Shared body for both `fundsIn` overloads.
+    function _fundsIn(
+        address from,
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory destinationAddress,
+        uint256 operationId
+    ) private {
+        if (bytes(destinationAddress).length == 0) revert InvalidDestinationAddress();
+        if (sourceChainId == 0)                    revert InvalidSourceChainId();
+        if (destinationChainId == 0)               revert InvalidDestinationChainId();
+        if (fundsInRecords[operationId] != 0)      revert DuplicateOperationId();
+
+        (
+            uint256 tokenCommission,
+            uint256 nativeCommission,
+            uint256 netAmount
+        ) = commissionManager.calculateFundsInCommission(
+            sourceChainId,
+            destinationChainId,
+            TOKEN,
+            amount
+        );
+
+        // Native payment must match the quote exactly (includes the zero-native case).
+        if (msg.value != nativeCommission) revert NativeValueMismatch();
+
+        // Pull the full gross amount from `from` into this contract.
+        IERC20(TOKEN).safeTransferFrom(from, address(this), amount);
+
+        // Record the net amount as the bridged liquidity for this operation.
+        fundsInRecords[operationId] = netAmount;
+
+        // Forward token commission, if any, to the CommissionManager pool.
+        if (tokenCommission != 0) {
+            IERC20(TOKEN).safeTransfer(address(commissionManager), tokenCommission);
+            commissionManager.receiveTokenCommission(TOKEN);
+        }
+
+        // Forward native commission, if any, to the CommissionManager pool.
+        if (nativeCommission != 0) {
+            (bool ok, ) = address(commissionManager).call{ value: nativeCommission }('');
+            if (!ok) revert NativeValueMismatch();
+        }
+
+        emit FundsIn(from, operationId, netAmount);
+        emit BridgeFundsIn(
+            from,
+            operationId,
+            amount,
+            netAmount,
+            tokenCommission,
+            nativeCommission,
+            sourceChainId,
+            destinationChainId,
+            destinationAddress
+        );
     }
 }

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -103,14 +103,13 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (bytes(destinationChain).length == 0)   revert InvalidDestinationChain();
         if (fundsInRecords[operationId] != 0)      revert DuplicateOperationId();
 
-        // Quote commission for this route.
         (
             uint256 tokenCommission,
             uint256 nativeCommission,
             uint256 netAmount
         ) = commissionManager.calculateFundsInCommission(
-            _sourceChainName,
-            destinationChain,
+            block.chainid,
+            uint256(keccak256(bytes(destinationChain))),
             TOKEN,
             amount
         );
@@ -202,14 +201,13 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // Verify Bitcoin block header is known to BtcRelay (reverts if unknown).
         IBtcRelayView(btcRelay).verifyBlockheaderHash(blockHeight, commitmentHash);
 
-        // Quote commission for the outbound route.
         (
             uint256 tokenCommission,
             uint256 nativeCommission,
             uint256 netAmount
         ) = commissionManager.calculateFundsOutCommission(
-            sourceChain,
-            destChain,
+            uint256(keccak256(bytes(sourceChain))),
+            uint256(keccak256(bytes(destChain))),
             TOKEN,
             amount
         );

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -19,9 +19,11 @@ import {
  * @author UTEXO bridge stack
  * @notice On-chain commission quotes, owner configuration, and custody of bridge fees (ERC-20 and native).
  * @dev Blueprint v3-style design: **global defaults** plus optional **per-route overrides** keyed by
- *      `keccak256(abi.encode(sourceChain, destChain, token))`. Routes are **directional** (swapping
- *      source and destination yields a different key), so independent rules can apply to each leg of a
- *      round trip (e.g. ETH→RGB vs RGB→ETH).
+ *      `keccak256(abi.encode(sourceChainId, destChainId, token))`. Chain ids are `uint256` values: EVM
+ *      chains use their native `block.chainid`; non-EVM endpoints (RGB, Bitcoin, …) are assigned
+ *      numeric ids by the Utexo backend in a namespace reserved above the EVM range (see README).
+ *      Routes are **directional** (swapping source and destination yields a different key), so
+ *      independent rules can apply to each leg of a round trip (e.g. ETH→RGB vs RGB→ETH).
  *
  *      **Side (`CommissionSide`):** For a given route config, commission applies only to **either**
  *      `FUNDS_IN` **or** `FUNDS_OUT`, matching `calculateFundsInCommission` vs `calculateFundsOutCommission`.
@@ -52,7 +54,7 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
     /// @notice Maximum allowed `stablePercent` (9000 = 90%).
     uint256 private constant _MAX_STABLE_PERCENT = 9000;
 
-    /// @notice Per-route overrides; key = `buildRouteKey(sourceChain, destChain, token)`.
+    /// @notice Per-route overrides; key = `buildRouteKey(sourceChainId, destChainId, token)`.
     mapping(bytes32 => CommissionConfig) public commissionRules;
 
     /// @notice Accrued ERC-20 commission per token (tracks balance held for that token).
@@ -94,8 +96,11 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
 
     /**
      * @notice Quote commission for an inbound (`fundsIn`) transfer on this chain.
-     * @param sourceChain Origin chain id (must match configured route keys).
-     * @param destChain Destination chain id.
+     * @param sourceChainId Origin chain id (must match configured route keys).
+     *                      EVM source uses `block.chainid`; non-EVM source uses
+     *                      the backend's assigned numeric id.
+     * @param destChainId Destination chain id (EVM `block.chainid` or assigned
+     *                    backend id for non-EVM targets).
      * @param token ERC-20 token used for the transfer.
      * @param amount Gross amount bridged (same units as token).
      * @return tokenCommission Fee in token smallest units (0 if not `TOKEN` currency).
@@ -105,8 +110,8 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
      *      `resolvedMockTokenToNativeRate` and `IERC20Metadata(token).decimals()`.
      */
     function calculateFundsInCommission(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token,
         uint256 amount
     )
@@ -118,7 +123,7 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
             uint256 netAmount
         )
     {
-        bytes32 ruleKey = buildRouteKey(sourceChain, destChain, token);
+        bytes32 ruleKey = buildRouteKey(sourceChainId, destChainId, token);
         CommissionConfig memory config = getEffectiveConfig(ruleKey);
 
         // Only calculate if this config is for FUNDS_IN
@@ -154,8 +159,10 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
 
     /**
      * @notice Quote commission for an outbound (`fundsOut`) release on this chain.
-     * @param sourceChain Origin chain id (must match configured route keys).
-     * @param destChain Destination chain id.
+     * @param sourceChainId Origin chain id (must match configured route keys).
+     *                      For RGB→EVM the source is the backend's assigned id
+     *                      for the Bitcoin-side network.
+     * @param destChainId Destination chain id (the EVM chain receiving the release).
      * @param token ERC-20 token being released.
      * @param amount Gross amount to release before fee.
      * @return tokenCommission Fee in token units (0 if not `TOKEN` currency).
@@ -164,8 +171,8 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
      * @dev Returns `(0, 0, amount)` if effective `side` is not `FUNDS_OUT`. See `calculateFundsInCommission` for rates/decimals.
      */
     function calculateFundsOutCommission(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token,
         uint256 amount
     )
@@ -177,7 +184,7 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
             uint256 netAmount
         )
     {
-        bytes32 ruleKey = buildRouteKey(sourceChain, destChain, token);
+        bytes32 ruleKey = buildRouteKey(sourceChainId, destChainId, token);
         CommissionConfig memory config = getEffectiveConfig(ruleKey);
 
         // Only calculate if this config is for FUNDS_OUT
@@ -312,15 +319,15 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
     }
 
     /**
-     * @notice Writes or replaces the override for `buildRouteKey(sourceChain, destChain, token)`.
-     * @param sourceChain Route source id (directional; paired with `destChain`).
-     * @param destChain Route destination id.
+     * @notice Writes or replaces the override for `buildRouteKey(sourceChainId, destChainId, token)`.
+     * @param sourceChainId Route source id (directional; paired with `destChainId`).
+     * @param destChainId Route destination id.
      * @param token ERC-20 token (non-zero).
      * @param config Rule parameters; `isSet` is forced true on store.
      */
     function setCommissionRule(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token,
         CommissionConfig calldata config
     ) external onlyOwner {
@@ -330,29 +337,29 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
         if (config.multiplier == 0) revert MultiplierZero();
 
         // Build route key
-        bytes32 key = buildRouteKey(sourceChain, destChain, token);
+        bytes32 key = buildRouteKey(sourceChainId, destChainId, token);
 
         commissionRules[key] = config;
         commissionRules[key].isSet = true;
 
-        emit CommissionRuleUpdated(sourceChain, destChain, token, config);
+        emit CommissionRuleUpdated(sourceChainId, destChainId, token, config);
     }
 
     /**
      * @notice Deletes the override for this route key; `getEffectiveConfig` will use globals.
-     * @param sourceChain Route source id.
-     * @param destChain Route destination id.
+     * @param sourceChainId Route source id.
+     * @param destChainId Route destination id.
      * @param token ERC-20 token (non-zero).
      */
     function clearCommissionRule(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token
     ) external onlyOwner {
         if (token == address(0)) revert InvalidToken();
-        bytes32 key = buildRouteKey(sourceChain, destChain, token);
+        bytes32 key = buildRouteKey(sourceChainId, destChainId, token);
         delete commissionRules[key];
-        emit CommissionRuleCleared(sourceChain, destChain, token);
+        emit CommissionRuleCleared(sourceChainId, destChainId, token);
     }
 
     /**
@@ -419,34 +426,33 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
 
     /**
      * @notice Raw storage read for a route (may be unset; check `config.isSet`).
-     * @param sourceChain Route source id.
-     * @param destChain Route destination id.
+     * @param sourceChainId Route source id.
+     * @param destChainId Route destination id.
      * @param token ERC-20 token.
      * @return config Stored override or empty struct if never set.
      */
     function getCommissionRule(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token
     ) external view returns (CommissionConfig memory) {
-        bytes32 ruleKey = buildRouteKey(sourceChain, destChain, token);
+        bytes32 ruleKey = buildRouteKey(sourceChainId, destChainId, token);
         return commissionRules[ruleKey];
     }
 
     /**
      * @notice Deterministic route id for commission rules.
-     * @param sourceChain Route source id.
-     * @param destChain Route destination id.
+     * @param sourceChainId Route source id.
+     * @param destChainId Route destination id.
      * @param token ERC-20 token address.
-     * @return key `keccak256(abi.encode(sourceChain, destChain, token))`.
-     * @dev Uses `abi.encode` (not `encodePacked`) to avoid ambiguous hashing over dynamic strings.
+     * @return key `keccak256(abi.encode(sourceChainId, destChainId, token))`.
      */
     function buildRouteKey(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token
     ) public pure returns (bytes32) {
-        return keccak256(abi.encode(sourceChain, destChain, token));
+        return keccak256(abi.encode(sourceChainId, destChainId, token));
     }
 
     // ============ Commission Collection Functions ============

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -14,6 +14,11 @@ contract MultisigProxy is IMultisigProxy {
     address public bridge;
     address public commissionManager;
 
+    /// @notice Routing target for `AdminExecuteAdapter` proposals. Settable via
+    ///         `UpdateLZAdapter` after the adapter is deployed; `address(0)`
+    ///         until then (closes adapter-execute by default).
+    address public lzAdapter;
+
     address[] private _enclaveSigners;
     uint256 public enclaveThreshold;
 
@@ -102,6 +107,14 @@ contract MultisigProxy is IMultisigProxy {
         'ProposeUpdateCommissionManager(address newCommissionManager,uint256 nonce,uint256 deadline)'
     );
 
+    // Federation propose — LZAdapter side
+    bytes32 private constant _PROPOSE_ADMIN_EXECUTE_ADAPTER_TYPEHASH = keccak256(
+        'ProposeAdminExecuteAdapter(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
+    );
+    bytes32 private constant _PROPOSE_UPDATE_LZ_ADAPTER_TYPEHASH = keccak256(
+        'ProposeUpdateLZAdapter(address newLZAdapter,uint256 nonce,uint256 deadline)'
+    );
+
     // Cancel
     bytes32 private constant _CANCEL_PROPOSAL_TYPEHASH = keccak256(
         'CancelProposal(bytes32 proposalId,uint256 nonce,uint256 deadline)'
@@ -155,7 +168,7 @@ contract MultisigProxy is IMultisigProxy {
         // federation governance through `proposeSetTeeAllowedCall`.
         teeAllowedCalls[bridge_][
             bytes4(keccak256(
-                'fundsOut(address,uint256,uint256,uint256,string,string,string,uint256,bytes32,uint256[])'
+                'fundsOut(address,uint256,uint256,uint256,uint256,uint256,string,uint256,bytes32,uint256[])'
             ))
         ] = true;
 
@@ -532,6 +545,53 @@ contract MultisigProxy is IMultisigProxy {
     }
 
     // =========================================================================
+    // Federation propose (Phase 1) — LZAdapter side
+    // =========================================================================
+
+    /// @inheritdoc IMultisigProxy
+    function proposeAdminExecuteAdapter(
+        bytes calldata callData,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        if (callData.length < 4) revert CallDataTooShort();
+
+        bytes4 selector;
+        assembly { selector := calldataload(callData.offset) }
+
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_ADMIN_EXECUTE_ADAPTER_TYPEHASH, selector, keccak256(callData), nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.AdminExecuteAdapter,
+            callData,
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
+    /// @inheritdoc IMultisigProxy
+    function proposeUpdateLZAdapter(
+        address newLZAdapter,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_UPDATE_LZ_ADAPTER_TYPEHASH, newLZAdapter, nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.UpdateLZAdapter,
+            abi.encode(newLZAdapter),
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
+    // =========================================================================
     // Cancel
     // =========================================================================
 
@@ -743,6 +803,19 @@ contract MultisigProxy is IMultisigProxy {
             address old = commissionManager;
             commissionManager = newCm;
             emit CommissionManagerUpdated(old, newCm);
+
+        } else if (opType == OperationType.AdminExecuteAdapter) {
+            // opData = raw LZAdapter callData. The adapter must be wired in
+            // first via UpdateLZAdapter; a zero target closes the path.
+            if (lzAdapter == address(0)) revert ZeroTarget();
+            (bool ok, bytes memory ret) = lzAdapter.call(opData);
+            _propagateRevert(ok, ret);
+
+        } else if (opType == OperationType.UpdateLZAdapter) {
+            address newAdapter = abi.decode(opData, (address));
+            address oldAdapter = lzAdapter;
+            lzAdapter = newAdapter;
+            emit LZAdapterUpdated(oldAdapter, newAdapter);
 
         } else {
             revert UnknownOperationType();

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -56,6 +56,11 @@ contract MultisigProxy is IMultisigProxy {
     /// @notice Hard upper bound on `executeBatch` size to keep gas use bounded.
     uint256 public constant MAX_BATCH_SIZE = 3;
 
+    /// @notice Length of a Solidity function selector (`bytes4`) in bytes. Used
+    ///         to guard `callData` against payloads too short to even carry a
+    ///         selector before it is sliced via `calldataload`.
+    uint256 public constant SELECTOR_LENGTH = 4;
+
     bytes32 public immutable DOMAIN_SEPARATOR;
 
     bytes32 private constant _DOMAIN_TYPEHASH = keccak256(
@@ -194,7 +199,7 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata enclaveSigs
     ) external {
         if (block.timestamp > deadline) revert Expired();
-        if (callData.length < 4) revert CallDataTooShort();
+        if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
@@ -234,7 +239,7 @@ contract MultisigProxy is IMultisigProxy {
         bytes4[] memory selectors = new bytes4[](n);
         uint256 totalValue;
         for (uint256 i = 0; i < n; i++) {
-            if (callDatas[i].length < 4) revert CallDataTooShort();
+            if (callDatas[i].length < SELECTOR_LENGTH) revert CallDataTooShort();
 
             bytes calldata cd = callDatas[i];
             bytes4 sel;
@@ -324,7 +329,7 @@ contract MultisigProxy is IMultisigProxy {
         uint256 fedBitmap,
         bytes[] calldata fedSigs
     ) external returns (bytes32) {
-        if (callData.length < 4) revert CallDataTooShort();
+        if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
@@ -470,7 +475,7 @@ contract MultisigProxy is IMultisigProxy {
         uint256 fedBitmap,
         bytes[] calldata fedSigs
     ) external returns (bytes32) {
-        if (callData.length < 4) revert CallDataTooShort();
+        if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
@@ -556,7 +561,7 @@ contract MultisigProxy is IMultisigProxy {
         uint256 fedBitmap,
         bytes[] calldata fedSigs
     ) external returns (bytes32) {
-        if (callData.length < 4) revert CallDataTooShort();
+        if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -7,10 +7,11 @@ interface IBridge {
     // =========================================================================
 
     error InvalidDestinationAddress();
-    error InvalidDestinationChain();
+    error InvalidDestinationChainId();
+    error InvalidSourceChainId();
     error InvalidBtcRelayAddress();
     error InvalidCommissionManagerAddress();
-    error InvalidSourceChainName();
+    error NotLZAdapter();
     error DuplicateOperationId();
     error BurnIdAlreadyConsumed(uint256 burnId);
     error FundsInNotFound(uint256 operationId);
@@ -22,13 +23,23 @@ interface IBridge {
     // Events
     // =========================================================================
 
-    /// @param sender             Address that deposited the tokens.
+    /// @notice Emitted on every successful `setLZAdapter`.
+    /// @param oldAdapter Previous trusted adapter (zero before first set).
+    /// @param newAdapter New trusted adapter (zero disables the adapter overload).
+    event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
+
+    /// @param sender             Address that deposited the tokens (the EOA on the
+    ///                           public overload, or the LZ adapter on the
+    ///                           adapter-only overload).
     /// @param operationId        Backend-assigned operation identifier.
     /// @param amount             Gross amount the user supplied (pre-commission).
     /// @param netAmount          Amount actually bridged after token commission is taken.
     /// @param tokenCommission    Fee charged in the bridged token (deducted from `amount`).
     /// @param nativeCommission   Fee charged in native wei (paid via `msg.value`).
-    /// @param destinationChain   Target chain identifier (e.g. "rgb").
+    /// @param sourceChainId      EVM `block.chainid` for direct deposits, or the
+    ///                           non-spoofable chain id forwarded by the adapter.
+    /// @param destinationChainId Target chain id (backend-assigned for non-EVM
+    ///                           destinations like RGB / Bitcoin).
     /// @param destinationAddress Target address on the destination chain.
     event BridgeFundsIn(
         address indexed sender,
@@ -37,22 +48,23 @@ interface IBridge {
         uint256 netAmount,
         uint256 tokenCommission,
         uint256 nativeCommission,
-        string  destinationChain,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
         string  destinationAddress
     );
 
-    /// @param recipient        Recipient on this chain.
-    /// @param amount           Gross amount released from the bridge pool (pre-commission).
-    /// @param netAmount        Amount actually delivered to `recipient`.
-    /// @param tokenCommission  Fee taken in the bridged token (sent to the CommissionManager).
-    /// @param operationId      Backend-assigned operation identifier.
-    /// @param burnId           Identifier extracted from the burn consignment on the
-    ///                         source side. Stored on-chain to block fundsOut replays.
-    /// @param sourceChain      Source chain identifier.
-    /// @param destChain        Destination chain identifier (used for commission routing).
-    /// @param sourceAddress    Sender address on the source chain.
-    /// @param blockHeight      Bitcoin block height verified via BtcRelay.
-    /// @param commitmentHash   Bitcoin block commitment hash verified via BtcRelay.
+    /// @param recipient          Recipient on this chain.
+    /// @param amount             Gross amount released from the bridge pool (pre-commission).
+    /// @param netAmount          Amount actually delivered to `recipient`.
+    /// @param tokenCommission    Fee taken in the bridged token (sent to the CommissionManager).
+    /// @param operationId        Backend-assigned operation identifier.
+    /// @param burnId             Identifier extracted from the burn consignment on the
+    ///                           source side. Stored on-chain to block fundsOut replays.
+    /// @param sourceChainId      Source chain id (non-EVM side for RGB→EVM releases).
+    /// @param destinationChainId Destination chain id (EVM target receiving the release).
+    /// @param sourceAddress      Sender address on the source chain.
+    /// @param blockHeight        Bitcoin block height verified via BtcRelay.
+    /// @param commitmentHash     Bitcoin block commitment hash verified via BtcRelay.
     event BridgeFundsOut(
         address indexed recipient,
         uint256 amount,
@@ -60,8 +72,8 @@ interface IBridge {
         uint256 tokenCommission,
         uint256 operationId,
         uint256 burnId,
-        string  sourceChain,
-        string  destChain,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
         string  sourceAddress,
         uint256 blockHeight,
         bytes32 commitmentHash
@@ -71,14 +83,31 @@ interface IBridge {
     // External — user-facing
     // =========================================================================
 
-    /// @notice Lock USDT0 in the bridge to initiate a transfer to another chain.
+    /// @notice Direct deposit overload for EVM users on this chain. The
+    ///         `sourceChainId` half of the commission route key is filled with
+    ///         `block.chainid` — non-spoofable by the caller.
     /// @dev Payable: if the active route uses NATIVE commission currency, `msg.value`
     ///      must equal the quoted native commission; otherwise `msg.value` must be 0.
-    /// @dev Permissionless on the EVM side. Replay protection is enforced via
-    ///      `operationId` (rejected if it already exists in `fundsInRecords`).
+    /// @dev Permissionless. Replay protection is enforced via `operationId`
+    ///      (rejected if it already exists in `fundsInRecords`).
     function fundsIn(
         uint256 amount,
-        string  calldata destinationChain,
+        uint256 destinationChainId,
+        string  calldata destinationAddress,
+        uint256 operationId
+    ) external payable;
+
+    /// @notice Adapter-only overload. Used by `UtexoLZAdapter.lzCompose` to
+    ///         forward a cross-chain deposit while preserving the original
+    ///         source-chain id (carried in `composeMsg` and validated against
+    ///         the adapter's trusted-entrypoint registry on the source side).
+    /// @dev Reverts `NotLZAdapter` if `msg.sender` is not the configured
+    ///      `lzAdapter`. Until federation sets a non-zero adapter, the
+    ///      overload is effectively closed.
+    function fundsIn(
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
         string  calldata destinationAddress,
         uint256 operationId
     ) external payable;
@@ -91,28 +120,39 @@ interface IBridge {
     ///         is known to BtcRelay and that the referenced fundsIn operations
     ///         exist on-chain before releasing.
     ///         Only callable by owner (MultisigProxy via execute()).
-    /// @dev `destChain` is part of the CommissionManager route key and lets the
-    ///      same Bridge serve multi-hop routes (e.g. BTC→Arbitrum→ETH via LayerZero).
+    /// @dev `destinationChainId` is part of the CommissionManager route key and
+    ///      lets the same Bridge serve multi-hop routes.
     /// @dev `burnId` is the identifier the backend extracts from the burn
     ///      consignment on the source side. The contract records it on success
-    ///      and rejects any future call referencing the same `burnId` — this is
-    ///      the on-chain replay guard for fundsOut.
+    ///      and rejects any future call referencing the same `burnId`.
     /// @dev `fundsInIds` are processed sequentially: each referenced record is
     ///      either fully consumed (deleted) or partially consumed (decremented)
-    ///      until `amount` is fully covered. Surplus on the last referenced id
-    ///      remains available for future fundsOut calls.
+    ///      until `amount` is fully covered.
     function fundsOut(
         address recipient,
         uint256 amount,
         uint256 operationId,
         uint256 burnId,
-        string  calldata sourceChain,
-        string  calldata destChain,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
         string  calldata sourceAddress,
         uint256 blockHeight,
         bytes32 commitmentHash,
         uint256[] calldata fundsInIds
     ) external;
+
+    // =========================================================================
+    // External — admin (called via MultisigProxy)
+    // =========================================================================
+
+    /// @notice Updates the trusted LayerZero adapter address. Owner-only
+    ///         (MultisigProxy in production). Passing `address(0)` disables the
+    ///         adapter overload until a non-zero address is set again.
+    function setLZAdapter(address newAdapter) external;
+
+    /// @notice Current trusted adapter; `address(0)` means the adapter overload
+    ///         is closed.
+    function lzAdapter() external view returns (address);
 
     /// @notice Permanently blocked — ownership cannot be renounced.
     function renounceOwnership() external view;

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -4,6 +4,12 @@ pragma solidity 0.8.20;
 /**
  * @title ICommissionManager types & interface
  * @notice Shared enums and struct for {CommissionManager}; see `ICommissionManager` for the external API.
+ *
+ *         Chain identifiers — both `sourceChainId` and `destChainId` — are uint256
+ *         values. EVM chains use their native `block.chainid`. Non-EVM
+ *         destinations (RGB, Bitcoin, …) are assigned numeric ids by the Utexo
+ *         backend in a namespace reserved above the EVM range (see project
+ *         README for the conventions).
  */
 
 /// @notice Which bridge operation a route fee is tied to.
@@ -62,15 +68,15 @@ interface ICommissionManager {
     );
 
     event CommissionRuleUpdated(
-        string sourceChain,
-        string destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address indexed token,
         CommissionConfig config
     );
 
     event CommissionRuleCleared(
-        string sourceChain,
-        string destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address indexed token
     );
 
@@ -110,8 +116,8 @@ interface ICommissionManager {
     // ============ Core calculations ============
 
     function calculateFundsInCommission(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token,
         uint256 amount
     )
@@ -120,8 +126,8 @@ interface ICommissionManager {
         returns (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount);
 
     function calculateFundsOutCommission(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token,
         uint256 amount
     )
@@ -157,15 +163,15 @@ interface ICommissionManager {
     function setMockTokenToNativeRateForToken(address token, uint256 rate) external;
 
     function setCommissionRule(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token,
         CommissionConfig calldata config
     ) external;
 
     function clearCommissionRule(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token
     ) external;
 
@@ -182,14 +188,14 @@ interface ICommissionManager {
         );
 
     function getCommissionRule(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token
     ) external view returns (CommissionConfig memory);
 
     function buildRouteKey(
-        string calldata sourceChain,
-        string calldata destChain,
+        uint256 sourceChainId,
+        uint256 destChainId,
         address token
     ) external pure returns (bytes32);
 

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -74,17 +74,19 @@ interface IMultisigProxy {
     // =========================================================================
 
     enum OperationType {
-        AdminExecute,                    // 0 — generic call into Bridge
+        AdminExecute,                    // 0  — generic call into Bridge
         UpdateEnclaveSigners,            // 1
         UpdateFederationSigners,         // 2
         UpdateBridge,                    // 3
         SetCommissionRecipient,          // 4
-        SetTeeAllowedCall,               // 5 — (target, selector, allowed) entry in TEE allowlist
+        SetTeeAllowedCall,               // 5  — (target, selector, allowed) entry in TEE allowlist
         SetTimelockDuration,             // 6
-        AdminExecuteCommissionManager,   // 7 — generic call into CommissionManager
-        WithdrawTokenCommissionCM,       // 8 — CM.withdrawTokenCommission -> commissionRecipient
-        WithdrawNativeCommissionCM,      // 9 — CM.withdrawNativeCommission -> commissionRecipient
-        UpdateCommissionManager          // 10 — migrate to a new CommissionManager address
+        AdminExecuteCommissionManager,   // 7  — generic call into CommissionManager
+        WithdrawTokenCommissionCM,       // 8  — CM.withdrawTokenCommission -> commissionRecipient
+        WithdrawNativeCommissionCM,      // 9  — CM.withdrawNativeCommission -> commissionRecipient
+        UpdateCommissionManager,         // 10 — migrate to a new CommissionManager address
+        AdminExecuteAdapter,             // 11 — generic call into LZAdapter (setTrustedEntrypoint, refundStuckFunds, …)
+        UpdateLZAdapter                  // 12 — rotate the routing target for AdminExecuteAdapter
     }
 
     enum ProposalStatus { None, Pending, Executed, Cancelled }
@@ -126,6 +128,7 @@ interface IMultisigProxy {
     event FederationSignersUpdated(address[] newSigners, uint256 newThreshold);
     event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
+    event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event CommissionRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
     event TeeAllowedCallUpdated(address indexed target, bytes4 indexed selector, bool allowed);
     event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
@@ -307,6 +310,32 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
+    // --- LZAdapter-targeted operations ---
+
+    /// @notice Propose an arbitrary call into the LZAdapter (routes through the
+    ///         stored `lzAdapter` address). Federation typically uses this for
+    ///         `setTrustedEntrypoint`, `refundStuckFunds`, and any other
+    ///         `onlyMultisigProxy`-gated adapter admin.
+    /// @dev opData = raw ABI-encoded LZAdapter callData (selector + args).
+    function proposeAdminExecuteAdapter(
+        bytes calldata callData,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
+    /// @notice Propose rotating the LZAdapter routing target stored on this proxy.
+    /// @dev opData = abi.encode(address newLZAdapter). `address(0)` is allowed
+    ///      and closes adapter-execute until set again.
+    function proposeUpdateLZAdapter(
+        address newLZAdapter,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
     // =========================================================================
     // Cancel & Execute
     // =========================================================================
@@ -339,6 +368,7 @@ interface IMultisigProxy {
     function getNonce(bytes4 selector) external view returns (uint256);
     function bridge() external view returns (address);
     function commissionManager() external view returns (address);
+    function lzAdapter() external view returns (address);
     function getEnclaveSigners() external view returns (address[] memory);
     function enclaveThreshold() external view returns (uint256);
     function getFederationSigners() external view returns (address[] memory);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -110,7 +110,7 @@ contract BridgeTest is Test {
     function _setFundsInTokenRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            SOURCE_CHAIN, DST_CHAIN, address(usdt0),
+            uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -124,7 +124,7 @@ contract BridgeTest is Test {
     function _setFundsInNativeRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            SOURCE_CHAIN, DST_CHAIN, address(usdt0),
+            uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -138,7 +138,7 @@ contract BridgeTest is Test {
     function _setFundsOutTokenRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            SRC_CHAIN, DST_CHAIN_OUT, address(usdt0),
+            uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -152,7 +152,7 @@ contract BridgeTest is Test {
     function _setFundsOutNativeRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            SRC_CHAIN, DST_CHAIN_OUT, address(usdt0),
+            uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -547,7 +547,7 @@ contract BridgeTest is Test {
         cm.setMockTokenToNativeRate(rate);
 
         (uint256 tokenC, uint256 nativeC, uint256 net) =
-            cm.calculateFundsInCommission(SOURCE_CHAIN, DST_CHAIN, address(usdt0), AMOUNT);
+            cm.calculateFundsInCommission(uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(usdt0), AMOUNT);
         assertEq(tokenC, 0);
         assertGt(nativeC, 0);
         assertEq(net, AMOUNT);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -27,7 +27,8 @@ contract BridgeTest is Test {
         uint256 netAmount,
         uint256 tokenCommission,
         uint256 nativeCommission,
-        string  destinationChain,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
         string  destinationAddress
     );
     event BridgeFundsOut(
@@ -37,12 +38,13 @@ contract BridgeTest is Test {
         uint256 tokenCommission,
         uint256 operationId,
         uint256 burnId,
-        string  sourceChain,
-        string  destChain,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
         string  sourceAddress,
         uint256 blockHeight,
         bytes32 commitmentHash
     );
+    event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
 
     Bridge            bridge;
     MockERC20         usdt0;
@@ -54,16 +56,16 @@ contract BridgeTest is Test {
     address recipient = makeAddr('recipient');
     address multisig  = makeAddr('multisig');
 
-    string  constant SOURCE_CHAIN = 'arbitrum';
-    string  constant DST_CHAIN    = 'rgb';
-    string  constant DST_ADDR     = 'rgb:asset1qp0y3mq6h5k8d9f2e4j7n6c3w/utxo1abc123';
-    // For outbound, source is "rgb" coming to "arbitrum" (this chain).
-    string  constant SRC_CHAIN    = 'rgb';
-    string  constant DST_CHAIN_OUT = 'arbitrum';
-    string  constant SRC_ADDR     = 'rgb:sender/utxo1src';
-    uint256 constant AMOUNT       = 100e18;
-    uint256 constant TX_ID        = 42;
-    uint256 constant BURN_ID      = 9_001;
+    // Chain identifiers are uint256: real EVM uses block.chainid; non-EVM is
+    // assigned by backend convention (see README).
+    uint256 constant SOURCE_CHAIN_ID = 31337;     // foundry default block.chainid
+    uint256 constant RGB_CHAIN_ID    = 1_000_001; // backend-assigned for RGB
+    string  constant DST_ADDR        = 'rgb:asset1qp0y3mq6h5k8d9f2e4j7n6c3w/utxo1abc123';
+    // For outbound, source is the RGB side, destination is this chain.
+    string  constant SRC_ADDR        = 'rgb:sender/utxo1src';
+    uint256 constant AMOUNT          = 100e18;
+    uint256 constant TX_ID           = 42;
+    uint256 constant BURN_ID         = 9_001;
 
     // BtcRelay test data
     uint256 constant BLOCK_HEIGHT     = 850_000;
@@ -110,7 +112,7 @@ contract BridgeTest is Test {
     function _setFundsInTokenRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(usdt0),
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -124,7 +126,7 @@ contract BridgeTest is Test {
     function _setFundsInNativeRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(usdt0),
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -138,7 +140,7 @@ contract BridgeTest is Test {
     function _setFundsOutTokenRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), address(usdt0),
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -152,7 +154,7 @@ contract BridgeTest is Test {
     function _setFundsOutNativeRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), address(usdt0),
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -187,7 +189,74 @@ contract BridgeTest is Test {
     function test_constructor_revertsOnZeroCommissionManager() public {
         vm.expectRevert(IBridge.InvalidCommissionManagerAddress.selector);
         new Bridge(address(usdt0), address(btcRelay), payable(address(0)), address(0));
-    }    
+    }
+
+    function test_constructor_storesInitialLZAdapter() public {
+        address initialAdapter = makeAddr('initial-adapter');
+        vm.prank(deployer);
+        Bridge b = new Bridge(address(usdt0), address(btcRelay), payable(address(cm)), initialAdapter);
+        assertEq(b.lzAdapter(), initialAdapter, 'lzAdapter set in constructor');
+    }
+
+    // ========================================================================
+    // setLZAdapter
+    // ========================================================================
+
+    function test_setLZAdapter_ownerCanSetAndUnset() public {
+        address adapter = makeAddr('adapter');
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit LZAdapterUpdated(address(0), adapter);
+
+        vm.prank(multisig);
+        bridge.setLZAdapter(adapter);
+        assertEq(bridge.lzAdapter(), adapter, 'set');
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit LZAdapterUpdated(adapter, address(0));
+
+        vm.prank(multisig);
+        bridge.setLZAdapter(address(0));
+        assertEq(bridge.lzAdapter(), address(0), 'unset');
+    }
+
+    function test_setLZAdapter_revertsIfNotOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.setLZAdapter(makeAddr('adapter'));
+    }
+
+    // ========================================================================
+    // fundsIn — adapter overload (`onlyLZAdapter`)
+    // ========================================================================
+
+    function test_fundsInFromAdapter_revertsIfCallerIsNotLZAdapter() public {
+        // No adapter set in setUp — caller is `user`.
+        vm.prank(user);
+        vm.expectRevert(IBridge.NotLZAdapter.selector);
+        bridge.fundsIn(AMOUNT, 1, RGB_CHAIN_ID, DST_ADDR, TX_ID);
+    }
+
+    function test_fundsInFromAdapter_acceptsCustomSourceChainId() public {
+        // Register a mock adapter and prime it with tokens + approval.
+        address mockAdapter = makeAddr('mock-adapter');
+        vm.prank(multisig);
+        bridge.setLZAdapter(mockAdapter);
+
+        usdt0.mint(mockAdapter, AMOUNT);
+        vm.prank(mockAdapter);
+        usdt0.approve(address(bridge), AMOUNT);
+
+        uint256 customSrc = 137; // pretend Polygon
+
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit BridgeFundsIn(mockAdapter, TX_ID, AMOUNT, AMOUNT, 0, 0, customSrc, RGB_CHAIN_ID, DST_ADDR);
+
+        vm.prank(mockAdapter);
+        bridge.fundsIn(AMOUNT, customSrc, RGB_CHAIN_ID, DST_ADDR, TX_ID);
+
+        assertEq(bridge.fundsInRecords(TX_ID), AMOUNT, 'record stored');
+    }
 
     // ========================================================================
     // fundsIn — happy path (zero commission default)
@@ -197,7 +266,7 @@ contract BridgeTest is Test {
         uint256 userBefore = usdt0.balanceOf(user);
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
         assertEq(usdt0.balanceOf(user),            userBefore - AMOUNT);
@@ -205,7 +274,7 @@ contract BridgeTest is Test {
 
     function test_fundsIn_storesRecord() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(bridge.fundsInRecords(TX_ID), AMOUNT);
     }
@@ -214,10 +283,10 @@ contract BridgeTest is Test {
         vm.expectEmit(true, false, false, true);
         emit FundsIn(user, TX_ID, AMOUNT);
         vm.expectEmit(true, false, false, true);
-        emit BridgeFundsIn(user, TX_ID, AMOUNT, AMOUNT, 0, 0, DST_CHAIN, DST_ADDR);
+        emit BridgeFundsIn(user, TX_ID, AMOUNT, AMOUNT, 0, 0, SOURCE_CHAIN_ID, RGB_CHAIN_ID, DST_ADDR);
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     function test_fundsIn_anyUserCanCall() public {
@@ -227,7 +296,7 @@ contract BridgeTest is Test {
         usdt0.approve(address(bridge), AMOUNT);
 
         vm.prank(stranger);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
     }
@@ -239,7 +308,7 @@ contract BridgeTest is Test {
     function test_fundsIn_revertsOnEmptyDestinationAddress() public {
         vm.expectRevert(IBridge.InvalidDestinationAddress.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), '', TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, '', TX_ID);
     }
 
     function test_fundsIn_revertsOnEmptyDestinationChain() public {
@@ -254,16 +323,16 @@ contract BridgeTest is Test {
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     function test_fundsIn_revertsOnDuplicateOperationId() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.expectRevert(IBridge.DuplicateOperationId.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     // ========================================================================
@@ -272,16 +341,16 @@ contract BridgeTest is Test {
 
     function test_fundsOut_transfersAndEmits() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.expectEmit(true, false, false, true);
         emit BridgeFundsOut(
             recipient, AMOUNT, AMOUNT, 0, TX_ID, BURN_ID,
-            SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH
         );
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(usdt0.balanceOf(recipient),       AMOUNT);
         assertEq(usdt0.balanceOf(address(bridge)), 0);
@@ -289,10 +358,10 @@ contract BridgeTest is Test {
 
     function test_fundsOut_consumesFundsInRecord() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(bridge.fundsInRecords(TX_ID), 0);
     }
@@ -304,16 +373,16 @@ contract BridgeTest is Test {
         uint256 amount2 = 40e18;
 
         vm.prank(user);
-        bridge.fundsIn(amount1, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
+        bridge.fundsIn(amount1, RGB_CHAIN_ID, DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(amount2, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
+        bridge.fundsIn(amount2, RGB_CHAIN_ID, DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](2);
         ids[0] = txId1;
         ids[1] = txId2;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, amount1 + amount2, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, amount1 + amount2, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
 
         assertEq(usdt0.balanceOf(recipient), amount1 + amount2);
         assertEq(bridge.fundsInRecords(txId1), 0);
@@ -324,12 +393,12 @@ contract BridgeTest is Test {
         // Single fundsIn of 100. fundsOut for 60 should decrement the record to 40
         // (not delete it), preserving the residual liquidity for future fundsOut.
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         uint256 partialAmount = 60e18;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, partialAmount, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, partialAmount, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(usdt0.balanceOf(recipient), partialAmount);
         assertEq(bridge.fundsInRecords(TX_ID), AMOUNT - partialAmount, 'residual preserved');
@@ -342,16 +411,16 @@ contract BridgeTest is Test {
         uint256 txId2 = 101;
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](2);
         ids[0] = txId1;
         ids[1] = txId2;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, 150e18, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, 150e18, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
 
         assertEq(usdt0.balanceOf(recipient), 150e18);
         assertEq(bridge.fundsInRecords(txId1), 0,    'first id fully consumed');
@@ -365,9 +434,9 @@ contract BridgeTest is Test {
         uint256 txId2 = 101;
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](2);
         ids[0] = txId1;
@@ -375,7 +444,7 @@ contract BridgeTest is Test {
 
         // Amount of 50 < first record; second id should remain untouched.
         vm.prank(multisig);
-        bridge.fundsOut(recipient, 50e18, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, 50e18, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
 
         assertEq(bridge.fundsInRecords(txId1), 50e18,  'first decremented');
         assertEq(bridge.fundsInRecords(txId2), AMOUNT, 'second untouched');
@@ -387,14 +456,14 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnUnverifiedBlock() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         uint256 unknownHeight = 999_999;
         bytes32 unknownHash = keccak256('unknown-block');
 
         vm.expectRevert('verify: block commitment');
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, unknownHeight, unknownHash, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, unknownHeight, unknownHash, _singleFundsInId());
     }
 
     // ========================================================================
@@ -403,30 +472,30 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnUnknownFundsInId() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         uint256[] memory ids = new uint256[](1);
         ids[0] = 999;
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.FundsInNotFound.selector, 999));
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
     }
 
     function test_fundsOut_revertsOnAmountExceedsFundsIn() public {
         uint256 txId1 = 100;
         uint256 txId2 = 101;
         vm.prank(user);
-        bridge.fundsIn(50e18, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
+        bridge.fundsIn(50e18, RGB_CHAIN_ID, DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(50e18, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
+        bridge.fundsIn(50e18, RGB_CHAIN_ID, DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](1);
         ids[0] = txId1;
 
         vm.expectRevert(IBridge.FundsOutAmountExceedsFundsIn.selector);
         vm.prank(multisig);
-        bridge.fundsOut(recipient, 60e18, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, 60e18, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
     }
 
     function test_fundsOut_revertsOnReplayedBurnId() public {
@@ -435,9 +504,9 @@ contract BridgeTest is Test {
         uint256 txId1 = 200;
         uint256 txId2 = 201;
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId2);
 
         uint256[] memory ids1 = new uint256[](1);
         ids1[0] = txId1;
@@ -446,13 +515,13 @@ contract BridgeTest is Test {
 
         // First fundsOut consumes BURN_ID.
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids1);
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids1);
         assertTrue(bridge.consumedBurnIds(BURN_ID), 'burnId recorded');
 
         // Second fundsOut uses fresh fundsIn record but the same burnId — must revert.
         vm.expectRevert(abi.encodeWithSelector(IBridge.BurnIdAlreadyConsumed.selector, BURN_ID));
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID + 100, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids2);
+        bridge.fundsOut(recipient, AMOUNT, TX_ID + 100, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids2);
 
         // Ensure the second call did not consume the underlying fundsIn record.
         assertEq(bridge.fundsInRecords(txId2), AMOUNT, 'fundsIn record preserved');
@@ -460,16 +529,16 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnDoubleSpendsConsumedFundsIn() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         usdt0.mint(address(bridge), AMOUNT);
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.FundsInNotFound.selector, TX_ID));
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID + 1, BURN_ID + 1, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID + 1, BURN_ID + 1, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     // ========================================================================
@@ -478,29 +547,29 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsIfNotOwner() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     function test_fundsOut_revertsOnZeroRecipient() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.expectRevert(BridgeBase.InvalidRecipientAddress.selector);
         vm.prank(multisig);
-        bridge.fundsOut(address(0), AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(address(0), AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     function test_fundsOut_revertsIfAmountExceedsPool() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.expectRevert(BridgeBase.AmountExceedBridgePool.selector);
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT + 1, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT + 1, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     // ========================================================================
@@ -516,7 +585,7 @@ contract BridgeTest is Test {
         uint256 expectedNet        = AMOUNT - expectedCommission;
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), expectedNet, 'bridge net');
         assertEq(usdt0.balanceOf(address(cm)),     expectedCommission, 'cm pool');
@@ -541,14 +610,14 @@ contract BridgeTest is Test {
         cm.setMockTokenToNativeRate(rate);
 
         (uint256 tokenC, uint256 nativeC, uint256 net) =
-            cm.calculateFundsInCommission(uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(usdt0), AMOUNT);
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
         assertEq(tokenC, 0);
         assertGt(nativeC, 0);
         assertEq(net, AMOUNT);
 
         vm.deal(user, nativeC);
         vm.prank(user);
-        bridge.fundsIn{ value: nativeC }(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn{ value: nativeC }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         // Bridge received full amount in token (no token commission).
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
@@ -566,7 +635,7 @@ contract BridgeTest is Test {
     function test_fundsOut_tokenCommission_routesToCM() public {
         // Deposit at zero commission first.
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         uint256 percent = 500; // 5%
         _setFundsOutTokenRule(percent);
@@ -575,7 +644,7 @@ contract BridgeTest is Test {
         uint256 expectedNet        = AMOUNT - expectedCommission;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(usdt0.balanceOf(recipient), expectedNet, 'recipient net');
         assertEq(usdt0.balanceOf(address(cm)), expectedCommission, 'cm pool');
@@ -588,7 +657,7 @@ contract BridgeTest is Test {
 
     function test_fundsOut_nativeCommission_reverts() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         _setFundsOutNativeRule(100);
         vm.prank(deployer);
@@ -596,7 +665,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(IBridge.NativeCommissionNotAllowedOnFundsOut.selector);
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     // ========================================================================
@@ -608,7 +677,7 @@ contract BridgeTest is Test {
         vm.deal(user, 1 ether);
         vm.expectRevert(IBridge.NativeValueMismatch.selector);
         vm.prank(user);
-        bridge.fundsIn{ value: 1 ether }(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn{ value: 1 ether }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     function test_fundsIn_revertsOnNativeValueMismatch_nativeRuleButNoValue() public {
@@ -618,7 +687,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(IBridge.NativeValueMismatch.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     // ========================================================================
@@ -652,7 +721,7 @@ contract BridgeTest is Test {
 
     function test_getContractBalance() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(bridge.getContractBalance(), AMOUNT);
     }
@@ -670,7 +739,7 @@ contract BridgeTest is Test {
         usdt0.mint(user, amount);
 
         vm.prank(user);
-        bridge.fundsIn(amount, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), amount);
         assertEq(bridge.fundsInRecords(TX_ID), amount);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -82,7 +82,7 @@ contract BridgeTest is Test {
         cm = new CommissionManager(deployer);
 
         vm.prank(deployer);
-        bridge = new Bridge(address(usdt0), address(btcRelay), payable(address(cm)), SOURCE_CHAIN);
+        bridge = new Bridge(address(usdt0), address(btcRelay), payable(address(cm)), address(0));
 
         // Point the CM to the real bridge.
         vm.prank(deployer);
@@ -171,29 +171,23 @@ contract BridgeTest is Test {
         assertEq(bridge.TOKEN(), address(usdt0));
         assertEq(bridge.owner(), multisig);
         assertEq(bridge.btcRelay(), address(btcRelay));
-        assertEq(address(bridge.commissionManager()), address(cm));
-        assertEq(bridge.sourceChainName(), SOURCE_CHAIN);
+        assertEq(address(bridge.commissionManager()), address(cm));        
     }
 
     function test_constructor_revertsOnZeroToken() public {
         vm.expectRevert(BridgeBase.InvalidTokenAddress.selector);
-        new Bridge(address(0), address(btcRelay), payable(address(cm)), SOURCE_CHAIN);
+        new Bridge(address(0), address(btcRelay), payable(address(cm)), address(0));
     }
 
     function test_constructor_revertsOnZeroBtcRelay() public {
         vm.expectRevert(IBridge.InvalidBtcRelayAddress.selector);
-        new Bridge(address(usdt0), address(0), payable(address(cm)), SOURCE_CHAIN);
+        new Bridge(address(usdt0), address(0), payable(address(cm)), address(0));
     }
 
     function test_constructor_revertsOnZeroCommissionManager() public {
         vm.expectRevert(IBridge.InvalidCommissionManagerAddress.selector);
-        new Bridge(address(usdt0), address(btcRelay), payable(address(0)), SOURCE_CHAIN);
-    }
-
-    function test_constructor_revertsOnEmptySourceChainName() public {
-        vm.expectRevert(IBridge.InvalidSourceChainName.selector);
-        new Bridge(address(usdt0), address(btcRelay), payable(address(cm)), '');
-    }
+        new Bridge(address(usdt0), address(btcRelay), payable(address(0)), address(0));
+    }    
 
     // ========================================================================
     // fundsIn — happy path (zero commission default)
@@ -203,7 +197,7 @@ contract BridgeTest is Test {
         uint256 userBefore = usdt0.balanceOf(user);
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
         assertEq(usdt0.balanceOf(user),            userBefore - AMOUNT);
@@ -211,7 +205,7 @@ contract BridgeTest is Test {
 
     function test_fundsIn_storesRecord() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         assertEq(bridge.fundsInRecords(TX_ID), AMOUNT);
     }
@@ -223,7 +217,7 @@ contract BridgeTest is Test {
         emit BridgeFundsIn(user, TX_ID, AMOUNT, AMOUNT, 0, 0, DST_CHAIN, DST_ADDR);
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
     }
 
     function test_fundsIn_anyUserCanCall() public {
@@ -233,7 +227,7 @@ contract BridgeTest is Test {
         usdt0.approve(address(bridge), AMOUNT);
 
         vm.prank(stranger);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
     }
@@ -245,13 +239,13 @@ contract BridgeTest is Test {
     function test_fundsIn_revertsOnEmptyDestinationAddress() public {
         vm.expectRevert(IBridge.InvalidDestinationAddress.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, '', TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), '', TX_ID);
     }
 
     function test_fundsIn_revertsOnEmptyDestinationChain() public {
-        vm.expectRevert(IBridge.InvalidDestinationChain.selector);
+        vm.expectRevert(IBridge.InvalidDestinationChainId.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, '', DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, 0, DST_ADDR, TX_ID);
     }
 
     function test_fundsIn_revertsWhenPaused() public {
@@ -260,16 +254,16 @@ contract BridgeTest is Test {
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
     }
 
     function test_fundsIn_revertsOnDuplicateOperationId() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         vm.expectRevert(IBridge.DuplicateOperationId.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
     }
 
     // ========================================================================
@@ -278,7 +272,7 @@ contract BridgeTest is Test {
 
     function test_fundsOut_transfersAndEmits() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         vm.expectEmit(true, false, false, true);
         emit BridgeFundsOut(
@@ -287,7 +281,7 @@ contract BridgeTest is Test {
         );
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(usdt0.balanceOf(recipient),       AMOUNT);
         assertEq(usdt0.balanceOf(address(bridge)), 0);
@@ -295,10 +289,10 @@ contract BridgeTest is Test {
 
     function test_fundsOut_consumesFundsInRecord() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(bridge.fundsInRecords(TX_ID), 0);
     }
@@ -310,16 +304,16 @@ contract BridgeTest is Test {
         uint256 amount2 = 40e18;
 
         vm.prank(user);
-        bridge.fundsIn(amount1, DST_CHAIN, DST_ADDR, txId1);
+        bridge.fundsIn(amount1, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(amount2, DST_CHAIN, DST_ADDR, txId2);
+        bridge.fundsIn(amount2, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](2);
         ids[0] = txId1;
         ids[1] = txId2;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, amount1 + amount2, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, amount1 + amount2, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
 
         assertEq(usdt0.balanceOf(recipient), amount1 + amount2);
         assertEq(bridge.fundsInRecords(txId1), 0);
@@ -330,12 +324,12 @@ contract BridgeTest is Test {
         // Single fundsIn of 100. fundsOut for 60 should decrement the record to 40
         // (not delete it), preserving the residual liquidity for future fundsOut.
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         uint256 partialAmount = 60e18;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, partialAmount, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, partialAmount, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(usdt0.balanceOf(recipient), partialAmount);
         assertEq(bridge.fundsInRecords(TX_ID), AMOUNT - partialAmount, 'residual preserved');
@@ -348,16 +342,16 @@ contract BridgeTest is Test {
         uint256 txId2 = 101;
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, txId1);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, txId2);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](2);
         ids[0] = txId1;
         ids[1] = txId2;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, 150e18, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, 150e18, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
 
         assertEq(usdt0.balanceOf(recipient), 150e18);
         assertEq(bridge.fundsInRecords(txId1), 0,    'first id fully consumed');
@@ -371,9 +365,9 @@ contract BridgeTest is Test {
         uint256 txId2 = 101;
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, txId1);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, txId2);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](2);
         ids[0] = txId1;
@@ -381,7 +375,7 @@ contract BridgeTest is Test {
 
         // Amount of 50 < first record; second id should remain untouched.
         vm.prank(multisig);
-        bridge.fundsOut(recipient, 50e18, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, 50e18, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
 
         assertEq(bridge.fundsInRecords(txId1), 50e18,  'first decremented');
         assertEq(bridge.fundsInRecords(txId2), AMOUNT, 'second untouched');
@@ -393,14 +387,14 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnUnverifiedBlock() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         uint256 unknownHeight = 999_999;
         bytes32 unknownHash = keccak256('unknown-block');
 
         vm.expectRevert('verify: block commitment');
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, unknownHeight, unknownHash, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, unknownHeight, unknownHash, _singleFundsInId());
     }
 
     // ========================================================================
@@ -409,30 +403,30 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnUnknownFundsInId() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         uint256[] memory ids = new uint256[](1);
         ids[0] = 999;
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.FundsInNotFound.selector, 999));
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
     }
 
     function test_fundsOut_revertsOnAmountExceedsFundsIn() public {
         uint256 txId1 = 100;
         uint256 txId2 = 101;
         vm.prank(user);
-        bridge.fundsIn(50e18, DST_CHAIN, DST_ADDR, txId1);
+        bridge.fundsIn(50e18, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(50e18, DST_CHAIN, DST_ADDR, txId2);
+        bridge.fundsIn(50e18, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](1);
         ids[0] = txId1;
 
         vm.expectRevert(IBridge.FundsOutAmountExceedsFundsIn.selector);
         vm.prank(multisig);
-        bridge.fundsOut(recipient, 60e18, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, 60e18, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
     }
 
     function test_fundsOut_revertsOnReplayedBurnId() public {
@@ -441,9 +435,9 @@ contract BridgeTest is Test {
         uint256 txId1 = 200;
         uint256 txId2 = 201;
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, txId1);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, txId2);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
 
         uint256[] memory ids1 = new uint256[](1);
         ids1[0] = txId1;
@@ -452,13 +446,13 @@ contract BridgeTest is Test {
 
         // First fundsOut consumes BURN_ID.
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids1);
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids1);
         assertTrue(bridge.consumedBurnIds(BURN_ID), 'burnId recorded');
 
         // Second fundsOut uses fresh fundsIn record but the same burnId — must revert.
         vm.expectRevert(abi.encodeWithSelector(IBridge.BurnIdAlreadyConsumed.selector, BURN_ID));
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID + 100, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids2);
+        bridge.fundsOut(recipient, AMOUNT, TX_ID + 100, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids2);
 
         // Ensure the second call did not consume the underlying fundsIn record.
         assertEq(bridge.fundsInRecords(txId2), AMOUNT, 'fundsIn record preserved');
@@ -466,16 +460,16 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnDoubleSpendsConsumedFundsIn() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         usdt0.mint(address(bridge), AMOUNT);
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.FundsInNotFound.selector, TX_ID));
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID + 1, BURN_ID + 1, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID + 1, BURN_ID + 1, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     // ========================================================================
@@ -484,29 +478,29 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsIfNotOwner() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     function test_fundsOut_revertsOnZeroRecipient() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         vm.expectRevert(BridgeBase.InvalidRecipientAddress.selector);
         vm.prank(multisig);
-        bridge.fundsOut(address(0), AMOUNT, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(address(0), AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     function test_fundsOut_revertsIfAmountExceedsPool() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         vm.expectRevert(BridgeBase.AmountExceedBridgePool.selector);
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT + 1, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT + 1, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     // ========================================================================
@@ -522,7 +516,7 @@ contract BridgeTest is Test {
         uint256 expectedNet        = AMOUNT - expectedCommission;
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), expectedNet, 'bridge net');
         assertEq(usdt0.balanceOf(address(cm)),     expectedCommission, 'cm pool');
@@ -554,7 +548,7 @@ contract BridgeTest is Test {
 
         vm.deal(user, nativeC);
         vm.prank(user);
-        bridge.fundsIn{ value: nativeC }(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn{ value: nativeC }(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         // Bridge received full amount in token (no token commission).
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
@@ -572,7 +566,7 @@ contract BridgeTest is Test {
     function test_fundsOut_tokenCommission_routesToCM() public {
         // Deposit at zero commission first.
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         uint256 percent = 500; // 5%
         _setFundsOutTokenRule(percent);
@@ -581,7 +575,7 @@ contract BridgeTest is Test {
         uint256 expectedNet        = AMOUNT - expectedCommission;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(usdt0.balanceOf(recipient), expectedNet, 'recipient net');
         assertEq(usdt0.balanceOf(address(cm)), expectedCommission, 'cm pool');
@@ -594,7 +588,7 @@ contract BridgeTest is Test {
 
     function test_fundsOut_nativeCommission_reverts() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         _setFundsOutNativeRule(100);
         vm.prank(deployer);
@@ -602,7 +596,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(IBridge.NativeCommissionNotAllowedOnFundsOut.selector);
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     // ========================================================================
@@ -614,7 +608,7 @@ contract BridgeTest is Test {
         vm.deal(user, 1 ether);
         vm.expectRevert(IBridge.NativeValueMismatch.selector);
         vm.prank(user);
-        bridge.fundsIn{ value: 1 ether }(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn{ value: 1 ether }(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
     }
 
     function test_fundsIn_revertsOnNativeValueMismatch_nativeRuleButNoValue() public {
@@ -624,7 +618,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(IBridge.NativeValueMismatch.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
     }
 
     // ========================================================================
@@ -658,7 +652,7 @@ contract BridgeTest is Test {
 
     function test_getContractBalance() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         assertEq(bridge.getContractBalance(), AMOUNT);
     }
@@ -676,7 +670,7 @@ contract BridgeTest is Test {
         usdt0.mint(user, amount);
 
         vm.prank(user);
-        bridge.fundsIn(amount, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(amount, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), amount);
         assertEq(bridge.fundsInRecords(TX_ID), amount);

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -21,8 +21,11 @@ contract CommissionManagerTest is Test {
     address internal user = makeAddr('user');
     address internal recipient = makeAddr('recipient');
 
-    string internal constant SRC = 'eth';
-    string internal constant DST = 'rgb';
+    /// @dev Chain identifiers are uint256: EVM uses native block.chainid;
+    ///      non-EVM endpoints use ids reserved above the EVM range by
+    ///      backend convention (see README).
+    uint256 internal constant SRC_CHAIN_ID = 1;          // Ethereum mainnet
+    uint256 internal constant DST_CHAIN_ID = 1_000_001;  // RGB (backend-assigned)
 
     event BridgeAddressUpdated(address indexed newBridge);
     event GlobalDefaultsUpdated(
@@ -72,8 +75,8 @@ contract CommissionManagerTest is Test {
 
     function test_buildRouteKey_matchesEncodeHash() public view {
         address t = address(token);
-        bytes32 expected = keccak256(abi.encode(SRC, DST, t));
-        assertEq(cm.buildRouteKey(SRC, DST, t), expected);
+        bytes32 expected = keccak256(abi.encode(SRC_CHAIN_ID, DST_CHAIN_ID, t));
+        assertEq(cm.buildRouteKey(SRC_CHAIN_ID, DST_CHAIN_ID, t), expected);
     }
 
     // --- Global defaults ---
@@ -171,7 +174,7 @@ contract CommissionManagerTest is Test {
         address t = address(token);
         uint256 amount = 100_000;
         (uint256 tok, uint256 nat, uint256 net) =
-            cm.calculateFundsInCommission(SRC, DST, t, amount);
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, amount);
         assertEq(tok, 4000); // 4% of 100_000
         assertEq(nat, 0);
         assertEq(net, amount - 4000);
@@ -181,7 +184,7 @@ contract CommissionManagerTest is Test {
         address t = address(token);
         uint256 amount = 100_000;
         (uint256 tok, uint256 nat, uint256 net) =
-            cm.calculateFundsInCommission(SRC, DST, t, amount);
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, amount);
         assertEq(tok, 0);
         assertEq(nat, 0);
         assertEq(net, amount);
@@ -199,7 +202,7 @@ contract CommissionManagerTest is Test {
         // Deliberately no setMockTokenToNativeRate: nonzero fee would revert.
         uint256 amount = 1000 ether;
         (uint256 tok, uint256 nat, uint256 net) =
-            cm.calculateFundsInCommission(SRC, DST, t, amount);
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, amount);
         assertEq(tok, 0);
         assertEq(nat, 0);
         assertEq(net, amount);
@@ -219,7 +222,7 @@ contract CommissionManagerTest is Test {
         vm.prank(owner);
         cm.setMockTokenToNativeRateForToken(t, rate);
         (uint256 tok, uint256 nat, uint256 net) =
-            cm.calculateFundsInCommission(SRC, DST, t, amount);
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, amount);
         uint256 stableFee = 4000 ether; // 4% of 100_000 ether
         uint256 expectedNat = cm.convertTokenToNative(stableFee, rate, 18);
         assertEq(tok, 0);
@@ -237,7 +240,7 @@ contract CommissionManagerTest is Test {
         );
         address t = address(token);
         (uint256 tok, uint256 nat, uint256 net) =
-            cm.calculateFundsInCommission(SRC, DST, t, 50_000);
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, 50_000);
         assertEq(tok, 0);
         assertEq(nat, 0);
         assertEq(net, 50_000);
@@ -253,7 +256,7 @@ contract CommissionManagerTest is Test {
         );
         address t = address(token);
         vm.expectRevert(ICommissionManager.MockTokenToNativeRateNotSet.selector);
-        cm.calculateFundsInCommission(SRC, DST, t, 1000);
+        cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, 1000);
     }
 
     function test_resolvedMockTokenToNativeRate_fallsBackToGlobalMock() public {
@@ -276,7 +279,7 @@ contract CommissionManagerTest is Test {
         address t = address(token);
         uint256 amount = 80_000;
         (uint256 tok, uint256 nat, uint256 net) =
-            cm.calculateFundsOutCommission(SRC, DST, t, amount);
+            cm.calculateFundsOutCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, amount);
         assertEq(tok, 3200);
         assertEq(nat, 0);
         assertEq(net, amount - 3200);
@@ -285,7 +288,7 @@ contract CommissionManagerTest is Test {
     function test_calculateFundsOutCommission_skipsWhenSideIsFundsIn() public view {
         address t = address(token);
         (uint256 tok, uint256 nat, uint256 net) =
-            cm.calculateFundsOutCommission(SRC, DST, t, 40_000);
+            cm.calculateFundsOutCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, 40_000);
         assertEq(tok, 0);
         assertEq(nat, 0);
         assertEq(net, 40_000);
@@ -303,14 +306,14 @@ contract CommissionManagerTest is Test {
             isSet: true
         });
         vm.prank(owner);
-        cm.setCommissionRule(SRC, DST, t, cfg);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t, cfg);
 
         (uint256 tok,, uint256 net) =
-            cm.calculateFundsInCommission(SRC, DST, t, 50_000);
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, 50_000);
         assertEq(tok, 5000); // 10%
         assertEq(net, 45_000);
 
-        CommissionConfig memory stored = cm.getCommissionRule(SRC, DST, t);
+        CommissionConfig memory stored = cm.getCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t);
         assertTrue(stored.isSet);
         assertEq(stored.stablePercent, 1000);
     }
@@ -327,14 +330,14 @@ contract CommissionManagerTest is Test {
             isSet: true
         });
         vm.prank(owner);
-        cm.setCommissionRule(SRC, DST, t, cfg);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t, cfg);
         vm.prank(owner);
-        cm.clearCommissionRule(SRC, DST, t);
+        cm.clearCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t);
 
-        CommissionConfig memory stored = cm.getCommissionRule(SRC, DST, t);
+        CommissionConfig memory stored = cm.getCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t);
         assertFalse(stored.isSet);
 
-        (uint256 tok,,) = cm.calculateFundsInCommission(SRC, DST, t, 50_000);
+        (uint256 tok,,) = cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, 50_000);
         assertEq(tok, 2000); // back to global 4%
     }
 
@@ -349,7 +352,7 @@ contract CommissionManagerTest is Test {
         });
         vm.prank(owner);
         vm.expectRevert(ICommissionManager.StablePercentTooHigh.selector);
-        cm.setCommissionRule(SRC, DST, t, cfg);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t, cfg);
     }
 
     // --- Bridge address ---

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -200,7 +200,7 @@ contract IntegrationTest is Test {
 
         // Sanity: CM now quotes commission for both routes.
         (uint256 tInQuote,, uint256 netIn) =
-            cm.calculateFundsInCommission(SOURCE_CHAIN, RGB_CHAIN, address(token), USER_DEPOSIT);
+            cm.calculateFundsInCommission(uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(RGB_CHAIN))), address(token), USER_DEPOSIT);
         assertEq(tInQuote, USER_DEPOSIT * FUNDS_IN_PERCENT / FUNDS_IN_MULT / FUNDS_IN_MULT, 'quote in');
         assertEq(netIn,    USER_DEPOSIT - tInQuote, 'net in');
 
@@ -353,7 +353,7 @@ contract IntegrationTest is Test {
         );
 
         (, uint256 nativeQuote, uint256 netQuote) =
-            cm.calculateFundsInCommission(SOURCE_CHAIN, RGB_CHAIN, address(token), USER_DEPOSIT);
+            cm.calculateFundsInCommission(uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(RGB_CHAIN))), address(token), USER_DEPOSIT);
         assertEq(netQuote,    USER_DEPOSIT,                                        'NATIVE: full amount bridges');
         assertEq(nativeQuote, USER_DEPOSIT * FUNDS_IN_PERCENT / FUNDS_IN_MULT / FUNDS_IN_MULT, 'native quote matches 1:1 rate');
 

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -61,8 +61,8 @@ contract IntegrationTest is Test {
     // Constants
     // =========================================================================
 
-    string  constant SOURCE_CHAIN = 'arbitrum'; // this chain
-    string  constant RGB_CHAIN    = 'rgb';
+    uint256 constant SOURCE_CHAIN_ID = 31337;     // foundry default block.chainid
+    uint256 constant RGB_CHAIN_ID    = 1_000_001; // backend-assigned for RGB
 
     uint256 constant USER_DEPOSIT = 100 ether; // 100 tokens gross
     // FUNDS_IN route: 2% token commission (stablePercent = 200, multiplier = 100 → 200/100/100 = 2%).
@@ -83,7 +83,7 @@ contract IntegrationTest is Test {
     uint256 constant TIMELOCK = 1 hours;
 
     bytes4 constant FUNDS_OUT_SELECTOR = bytes4(keccak256(
-        'fundsOut(address,uint256,uint256,uint256,string,string,string,uint256,bytes32,uint256[])'
+        'fundsOut(address,uint256,uint256,uint256,uint256,uint256,string,uint256,bytes32,uint256[])'
     ));
 
     // =========================================================================
@@ -97,8 +97,8 @@ contract IntegrationTest is Test {
         uint256 tokenCommission,
         uint256 operationId,
         uint256 burnId,
-        string  sourceChain,
-        string  destChain,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
         string  sourceAddress,
         uint256 blockHeight,
         bytes32 commitmentHash
@@ -173,7 +173,7 @@ contract IntegrationTest is Test {
         _proposeAndExecuteCmAdminCall(
             abi.encodeWithSelector(
                 ICommissionManager.setCommissionRule.selector,
-                SOURCE_CHAIN, RGB_CHAIN, address(token),
+                SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token),
                 CommissionConfig({
                     stablePercent: FUNDS_IN_PERCENT,
                     multiplier:    FUNDS_IN_MULT,
@@ -187,7 +187,7 @@ contract IntegrationTest is Test {
         _proposeAndExecuteCmAdminCall(
             abi.encodeWithSelector(
                 ICommissionManager.setCommissionRule.selector,
-                RGB_CHAIN, SOURCE_CHAIN, address(token),
+                RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token),
                 CommissionConfig({
                     stablePercent: FUNDS_OUT_PERCENT,
                     multiplier:    FUNDS_OUT_MULT,
@@ -200,7 +200,7 @@ contract IntegrationTest is Test {
 
         // Sanity: CM now quotes commission for both routes.
         (uint256 tInQuote,, uint256 netIn) =
-            cm.calculateFundsInCommission(uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(RGB_CHAIN))), address(token), USER_DEPOSIT);
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token), USER_DEPOSIT);
         assertEq(tInQuote, USER_DEPOSIT * FUNDS_IN_PERCENT / FUNDS_IN_MULT / FUNDS_IN_MULT, 'quote in');
         assertEq(netIn,    USER_DEPOSIT - tInQuote, 'net in');
 
@@ -212,7 +212,7 @@ contract IntegrationTest is Test {
         vm.prank(user);
         bridge.fundsIn(
             USER_DEPOSIT,
-            uint256(keccak256(bytes(RGB_CHAIN))),
+            RGB_CHAIN_ID,
             'rgb:asset1qp0y3mq/utxo1abc',
             TX_ID_IN
         );
@@ -239,8 +239,8 @@ contract IntegrationTest is Test {
             netBridgedIn,          // amount = full bridged pool from this deposit
             TX_ID_OUT,
             BURN_ID,
-            RGB_CHAIN,
-            SOURCE_CHAIN,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
             'rgb:sender/utxo1src',
             BLOCK_HEIGHT,
             COMMITMENT_HASH,
@@ -265,8 +265,8 @@ contract IntegrationTest is Test {
             tokenCommissionOut,
             TX_ID_OUT,
             BURN_ID,
-            RGB_CHAIN,
-            SOURCE_CHAIN,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
             'rgb:sender/utxo1src',
             BLOCK_HEIGHT,
             COMMITMENT_HASH
@@ -341,7 +341,7 @@ contract IntegrationTest is Test {
         _proposeAndExecuteCmAdminCall(
             abi.encodeWithSelector(
                 ICommissionManager.setCommissionRule.selector,
-                SOURCE_CHAIN, RGB_CHAIN, address(token),
+                SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token),
                 CommissionConfig({
                     stablePercent: FUNDS_IN_PERCENT,
                     multiplier:    FUNDS_IN_MULT,
@@ -353,7 +353,7 @@ contract IntegrationTest is Test {
         );
 
         (, uint256 nativeQuote, uint256 netQuote) =
-            cm.calculateFundsInCommission(uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(RGB_CHAIN))), address(token), USER_DEPOSIT);
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token), USER_DEPOSIT);
         assertEq(netQuote,    USER_DEPOSIT,                                        'NATIVE: full amount bridges');
         assertEq(nativeQuote, USER_DEPOSIT * FUNDS_IN_PERCENT / FUNDS_IN_MULT / FUNDS_IN_MULT, 'native quote matches 1:1 rate');
 
@@ -362,7 +362,7 @@ contract IntegrationTest is Test {
         vm.prank(user);
         bridge.fundsIn{ value: nativeQuote }(
             USER_DEPOSIT,
-            uint256(keccak256(bytes(RGB_CHAIN))),
+            RGB_CHAIN_ID,
             'rgb:asset1qp0y3mq/utxo1abc',
             TX_ID_IN
         );

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -124,7 +124,7 @@ contract IntegrationTest is Test {
         address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 1);
 
         cm     = new CommissionManager(predictedBridge);
-        bridge = new Bridge(address(token), address(btcRelay), payable(address(cm)), SOURCE_CHAIN);
+        bridge = new Bridge(address(token), address(btcRelay), payable(address(cm)), address(0));
 
         address[] memory enc = new address[](3);
         enc[0] = encA1; enc[1] = encA2; enc[2] = encA3;
@@ -212,7 +212,7 @@ contract IntegrationTest is Test {
         vm.prank(user);
         bridge.fundsIn(
             USER_DEPOSIT,
-            RGB_CHAIN,
+            uint256(keccak256(bytes(RGB_CHAIN))),
             'rgb:asset1qp0y3mq/utxo1abc',
             TX_ID_IN
         );
@@ -362,7 +362,7 @@ contract IntegrationTest is Test {
         vm.prank(user);
         bridge.fundsIn{ value: nativeQuote }(
             USER_DEPOSIT,
-            RGB_CHAIN,
+            uint256(keccak256(bytes(RGB_CHAIN))),
             'rgb:asset1qp0y3mq/utxo1abc',
             TX_ID_IN
         );

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -761,7 +761,7 @@ contract MultisigProxyTest is Test {
         // Seed commission by setting a fundsIn TOKEN rule and doing a deposit.
         vm.prank(address(proxy));
         cm.setCommissionRule(
-            SOURCE_CHAIN, DST_CHAIN, address(token),
+            uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(token),
             CommissionConfig({
                 stablePercent: 400, // 4%
                 multiplier: 100,

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -40,6 +40,7 @@ contract MultisigProxyTest is Test {
     event TeeAllowedCallUpdated(address indexed target, bytes4 indexed selector, bool allowed);
     event TimelockDurationUpdated(uint256 newDuration);
     event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
+    event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
 
     MultisigProxy     proxy;
     Bridge            bridge;
@@ -73,12 +74,11 @@ contract MultisigProxyTest is Test {
     bytes32 domainSep;
 
     // Canonical constants for Bridge calls
-    string  constant SOURCE_CHAIN = 'arbitrum';
-    string  constant DST_CHAIN    = 'rgb';
-    string  constant DST_ADDR     = 'rgb:asset/utxo1abc';
-    string  constant SRC_CHAIN    = 'rgb';
-    string  constant DST_CHAIN_OUT = 'arbitrum';
-    string  constant SRC_ADDR     = 'rgb:sender/utxo1src';
+    // Chain identifiers are uint256: foundry tests run with block.chainid = 31337.
+    uint256 constant SOURCE_CHAIN_ID = 31337;
+    uint256 constant RGB_CHAIN_ID    = 1_000_001;
+    string  constant DST_ADDR        = 'rgb:asset/utxo1abc';
+    string  constant SRC_ADDR        = 'rgb:sender/utxo1src';
     uint256 constant AMOUNT    = 100e18;
     uint256 constant TX_ID     = 42;
     uint256 constant BURN_ID   = 9_001;
@@ -142,7 +142,7 @@ contract MultisigProxyTest is Test {
         vm.prank(user);
         token.approve(address(bridge), type(uint256).max);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT * 5, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT * 5, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     // ========================================================================
@@ -171,7 +171,7 @@ contract MultisigProxyTest is Test {
     function _fundsOutCalldata() internal view returns (bytes memory) {
         return abi.encodeWithSelector(
             FUNDS_OUT_SELECTOR,
-            recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _fundsInIds()
+            recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _fundsInIds()
         );
     }
 
@@ -761,7 +761,7 @@ contract MultisigProxyTest is Test {
         // Seed commission by setting a fundsIn TOKEN rule and doing a deposit.
         vm.prank(address(proxy));
         cm.setCommissionRule(
-            uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(token),
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token),
             CommissionConfig({
                 stablePercent: 400, // 4%
                 multiplier: 100,
@@ -773,7 +773,7 @@ contract MultisigProxyTest is Test {
 
         uint256 depositAmount = 100e18;
         vm.prank(user);
-        bridge.fundsIn(depositAmount, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID + 1);
+        bridge.fundsIn(depositAmount, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1);
 
         uint256 expectedCommission = (depositAmount * 400) / 100 / 100;
         assertEq(cm.tokenCommissionPool(address(token)), expectedCommission);
@@ -905,6 +905,173 @@ contract MultisigProxyTest is Test {
 
         vm.expectRevert(IMultisigProxy.IndexOutOfRange.selector);
         proxy.verifyEnclaveSignature(digest, sig, 99);
+    }
+
+    // ========================================================================
+    // Propose + Execute — UpdateLZAdapter
+    // ========================================================================
+
+    function _proposeUpdateLZAdapter(address newAdapter) internal returns (bytes32 id) {
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateLZAdapter(domainSep, newAdapter, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        id = proxy.proposeUpdateLZAdapter(newAdapter, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_lzAdapter_defaultsToZero() public view {
+        assertEq(proxy.lzAdapter(), address(0));
+    }
+
+    function test_proposeUpdateLZAdapter_executeSetsAdapter() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        vm.expectEmit(true, true, false, false);
+        emit LZAdapterUpdated(address(0), newAdapter);
+
+        proxy.executeProposal(id, abi.encode(newAdapter));
+        assertEq(proxy.lzAdapter(), newAdapter);
+    }
+
+    function test_proposeUpdateLZAdapter_canRotateToZero() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(newAdapter));
+        assertEq(proxy.lzAdapter(), newAdapter);
+
+        // Rotate back to zero — closes AdminExecuteAdapter path.
+        // proposalNonce auto-increments, so the second proposal lives at a different id.
+        bytes32 id2 = _proposeUpdateLZAdapter(address(0));
+        // Fresh timelock from the *second* proposal's proposedAt. Use a large
+        // absolute warp so the timelock check passes regardless of foundry's
+        // current block.timestamp evaluation quirks.
+        vm.warp(block.timestamp + 2 * TIMELOCK + 2);
+
+        proxy.executeProposal(id2, abi.encode(address(0)));
+        assertEq(proxy.lzAdapter(), address(0));
+    }
+
+    function test_proposeUpdateLZAdapter_revertsOnDataMismatch() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.DataMismatch.selector);
+        proxy.executeProposal(id, abi.encode(makeAddr('different')));
+    }
+
+    function test_proposeUpdateLZAdapter_canBeCancelled() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+
+        uint256 cNonce = proxy.proposalNonce();
+        uint256 cDeadline = block.timestamp + 1 hours;
+        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cNonce, cDeadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory cSigs = MultisigHelper.signAll(vm, cDigest, pks);
+
+        vm.expectEmit(true, false, false, false);
+        emit ProposalCancelled(id);
+        proxy.cancelProposal(id, cNonce, cDeadline, bitmap, cSigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.NotPending.selector);
+        proxy.executeProposal(id, abi.encode(newAdapter));
+        assertEq(proxy.lzAdapter(), address(0));
+    }
+
+    // ========================================================================
+    // Propose + Execute — AdminExecuteAdapter
+    // ========================================================================
+
+    function test_proposeAdminExecuteAdapter_revertsIfAdapterUnset() public {
+        // Register an arbitrary adapter call; lzAdapter is still address(0).
+        bytes memory callData = abi.encodeWithSignature('mint(address,uint256)', user, 1e18);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteAdapter(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.ZeroTarget.selector);
+        proxy.executeProposal(id, callData);
+    }
+
+    function test_proposeAdminExecuteAdapter_executesCallOnAdapter() public {
+        // 1. Set lzAdapter to a MockERC20 (its `mint(address,uint256)` is public).
+        MockERC20 adapter = new MockERC20('LZ Stub', 'LZS');
+        bytes32 idSet = _proposeUpdateLZAdapter(address(adapter));
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(idSet, abi.encode(address(adapter)));
+        assertEq(proxy.lzAdapter(), address(adapter));
+
+        // 2. Propose an AdminExecuteAdapter call: mint 1e18 to `recipient`.
+        bytes memory callData = abi.encodeWithSignature('mint(address,uint256)', recipient, 1e18);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteAdapter(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, callData);
+
+        assertEq(adapter.balanceOf(recipient), 1e18);
+    }
+
+    function test_proposeAdminExecuteAdapter_revertsOnEmptyCallData() public {
+        bytes memory callData = '';
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        // We can't really build a valid digest for empty calldata via the proxy's
+        // assembly-based selector load — just confirm the explicit guard fires.
+        bytes[] memory sigs = new bytes[](pks.length);
+        for (uint256 i = 0; i < pks.length; i++) sigs[i] = new bytes(65);
+
+        vm.expectRevert(IMultisigProxy.CallDataTooShort.selector);
+        proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeAdminExecuteAdapter_propagatesAdapterRevert() public {
+        // Adapter = MockERC20. Call a non-existent function so the fallback reverts.
+        MockERC20 adapter = new MockERC20('LZ Stub', 'LZS');
+        bytes32 idSet = _proposeUpdateLZAdapter(address(adapter));
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(idSet, abi.encode(address(adapter)));
+
+        bytes memory callData = abi.encodeWithSignature('nonExistent()');
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteAdapter(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        // MockERC20 has no fallback — call returns false and _propagateRevert bubbles up.
+        vm.expectRevert();
+        proxy.executeProposal(id, callData);
     }
 
     function test_domainSeparator_matchesHelper() public view {

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -89,7 +89,7 @@ contract MultisigProxyTest is Test {
     uint256 constant BTC_CONFIRMATIONS = 6;
 
     bytes4  constant FUNDS_OUT_SELECTOR = bytes4(keccak256(
-        'fundsOut(address,uint256,uint256,uint256,string,string,string,uint256,bytes32,uint256[])'
+        'fundsOut(address,uint256,uint256,uint256,uint256,uint256,string,uint256,bytes32,uint256[])'
     ));
 
     function setUp() public {
@@ -109,7 +109,7 @@ contract MultisigProxyTest is Test {
         cm = new CommissionManager(deployer);
 
         vm.prank(deployer);
-        bridge = new Bridge(address(token), address(btcRelay), payable(address(cm)), SOURCE_CHAIN);
+        bridge = new Bridge(address(token), address(btcRelay), payable(address(cm)), address(0));
 
         vm.prank(deployer);
         cm.setBridgeAddress(address(bridge));
@@ -142,7 +142,7 @@ contract MultisigProxyTest is Test {
         vm.prank(user);
         token.approve(address(bridge), type(uint256).max);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT * 5, DST_CHAIN, DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT * 5, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
     }
 
     // ========================================================================
@@ -171,7 +171,7 @@ contract MultisigProxyTest is Test {
     function _fundsOutCalldata() internal view returns (bytes memory) {
         return abi.encodeWithSelector(
             FUNDS_OUT_SELECTOR,
-            recipient, AMOUNT, TX_ID, BURN_ID, SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _fundsInIds()
+            recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _fundsInIds()
         );
     }
 
@@ -773,7 +773,7 @@ contract MultisigProxyTest is Test {
 
         uint256 depositAmount = 100e18;
         vm.prank(user);
-        bridge.fundsIn(depositAmount, DST_CHAIN, DST_ADDR, TX_ID + 1);
+        bridge.fundsIn(depositAmount, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID + 1);
 
         uint256 expectedCommission = (depositAmount * 400) / 100 / 100;
         assertEq(cm.tokenCommissionPool(address(token)), expectedCommission);

--- a/ethereum/test/helpers/MultisigHelper.sol
+++ b/ethereum/test/helpers/MultisigHelper.sol
@@ -74,6 +74,14 @@ library MultisigHelper {
         'ProposeUpdateCommissionManager(address newCommissionManager,uint256 nonce,uint256 deadline)'
     );
 
+    bytes32 internal constant PROPOSE_ADMIN_EXECUTE_ADAPTER_TYPEHASH = keccak256(
+        'ProposeAdminExecuteAdapter(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
+    );
+
+    bytes32 internal constant PROPOSE_UPDATE_LZ_ADAPTER_TYPEHASH = keccak256(
+        'ProposeUpdateLZAdapter(address newLZAdapter,uint256 nonce,uint256 deadline)'
+    );
+
     /// @dev Builds the EIP-712 domain separator the same way MultisigProxy does.
     function domainSeparator(address verifyingContract, uint256 chainId) internal pure returns (bytes32) {
         return keccak256(abi.encode(
@@ -261,6 +269,29 @@ library MultisigHelper {
     ) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(
             PROPOSE_UPDATE_COMMISSION_MANAGER_TYPEHASH, newCm, nonce, deadline
+        )));
+    }
+
+    function digestProposeAdminExecuteAdapter(
+        bytes32 domainSep,
+        bytes4 selector,
+        bytes memory callData,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(
+            PROPOSE_ADMIN_EXECUTE_ADAPTER_TYPEHASH, selector, keccak256(callData), nonce, deadline
+        )));
+    }
+
+    function digestProposeUpdateLZAdapter(
+        bytes32 domainSep,
+        address newLZAdapter,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(
+            PROPOSE_UPDATE_LZ_ADAPTER_TYPEHASH, newLZAdapter, nonce, deadline
         )));
     }
 


### PR DESCRIPTION
EVM endpoints use their native `block.chainid`, non-EVM endpoints (RGB, Bitcoin, …) are assigned numeric ids by the backend in a namespace reserved above the EVM range
Why
- Route keys can now key on `block.chainid` directly with no Bridge-side string registry.
- One CM API for both fundsIn and fundsOut (single key shape, single builder, single mapping).
- TEE backend signs uint256s instead of strings — smaller calldata and no Bridge-side string parsing.
- Type matches the natural identifier (EVM has a chainid; the previous string was an ad-hoc human alias).

Public API changes (BREAKING)
- ICommissionManager.calculateFundsInCommission and calculateFundsOutCommission now take `(uint256 sourceChainId, uint256 destChainId, address token, uint256 amount)`.
- setCommissionRule / clearCommissionRule / getCommissionRule / buildRouteKey use the same uint256 chain ids.
- CommissionRuleUpdated and CommissionRuleCleared events drop the string fields in favor of uint256s.
- Route key hash changes: existing storage entries (none in production yet) are unreachable from the new API and must be re-seeded.