### PR TITLE
Multisig lz adapter update

### DIFF
--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -27,12 +27,14 @@ No TEE verification, no destination chain field, **no commission integration**. 
 
 Production bridge for UTEXO. Inherits `BridgeBase`, implements `IBridge`.
 
-Constructor takes four immutable addresses/values: the accepted ERC-20 token, the BtcRelay contract, the CommissionManager, and `sourceChainName` (this bridge's chain identifier as used in CommissionManager route keys, e.g. `"arbitrum"`).
+Constructor takes four immutable addresses/values: the accepted ERC-20 token, the BtcRelay contract, the CommissionManager, and the initial LayerZero adapter (`address(0)` is allowed — wire it in later via federation governance). The bridge's own chain identifier is `block.chainid` — chain IDs are uint256 throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
 
-- `fundsIn(amount, destinationChain, destinationAddress, operationId)` — open, **`payable`**. Quotes commission from `CommissionManager` using route key `(sourceChainName, destinationChain, TOKEN)`; if the route uses NATIVE currency, `msg.value` must equal the quoted native commission. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and stores `operationId => netAmount` in `fundsInRecords`. Emits two events:
+- `fundsIn(amount, destinationChainId, destinationAddress, operationId)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must equal the quoted native commission. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and stores `operationId => netAmount` in `fundsInRecords`. Emits two events:
   - `FundsIn` (from `BridgeBase`) — minimal, uses `netAmount`.
   - `BridgeFundsIn` (from `IBridge`) — full, consumed by the UTEXO backend.
-- `fundsOut(recipient, amount, operationId, burnId, sourceChain, destChain, sourceAddress, blockHeight, commitmentHash, fundsInIds)` — `onlyOwner`, called via `MultisigProxy.execute()` or `MultisigProxy.executeBatch()`. Checks `burnId` has not been consumed yet (single-use replay guard, marks it consumed before any external interaction), verifies referenced fundsIn operations exist on-chain (prevents double-spend and fake event attacks on TEE), verifies the Bitcoin block header via BtcRelay, quotes commission from `CommissionManager` using `(sourceChain, destChain, TOKEN)`, forwards any token commission to the pool, and releases `netAmount` to the recipient. Emits `BridgeFundsOut`. NATIVE commission on `fundsOut` is disallowed (the caller is the multisig, not a user) — the contract reverts `NativeCommissionNotAllowedOnFundsOut`.
+- `fundsInFromAdapter(amount, destinationChainId, destinationAddress, operationId, sourceChainId)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating `msg.sender` on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` to the bridge. Otherwise identical semantics to `fundsIn`.
+- `setLZAdapter(adapter)` — `onlyOwner`. Rotates the address authorized to call `fundsInFromAdapter`. Set to `address(0)` to close the adapter path entirely.
+- `fundsOut(recipient, amount, operationId, burnId, sourceChainId, destChainId, sourceAddress, blockHeight, commitmentHash, fundsInIds)` — `onlyOwner`, called via `MultisigProxy.execute()` or `MultisigProxy.executeBatch()`. All ten parameters are `uint256` except `recipient` (address), `sourceAddress` (string), `commitmentHash` (bytes32), and the `fundsInIds` array. Checks `burnId` has not been consumed yet (single-use replay guard, marks it consumed before any external interaction), verifies referenced fundsIn operations exist on-chain (prevents double-spend and fake event attacks on TEE), verifies the Bitcoin block header via BtcRelay, quotes commission from `CommissionManager` using `(sourceChainId, destChainId, TOKEN)`, forwards any token commission to the pool, and releases `netAmount` to the recipient. Emits `BridgeFundsOut`. NATIVE commission on `fundsOut` is disallowed (the caller is the multisig, not a user) — the contract reverts `NativeCommissionNotAllowedOnFundsOut`.
 
 Owner **must** be `MultisigProxy`. `fundsOut` is only reachable through `MultisigProxy.execute()` (single-call) or `MultisigProxy.executeBatch()` (atomic multi-call, e.g. `Bridge.fundsOut` + `LZAdapter.sendOut` for outbound to non-Arbitrum), both of which require M-of-N TEE signatures.
 
@@ -57,7 +59,7 @@ Every `fundsOut` call carries a `burnId` — an identifier the backend extracts 
 
 Standalone fee contract. Holds protocol commissions separately from bridge liquidity so that deployment, auditing, and withdrawal of fees are independent of bridge funds.
 
-- **Route keys** are `keccak256(abi.encode(sourceChain, destChain, token))` — directional, so each leg of a round trip can have its own config.
+- **Route keys** are `keccak256(abi.encode(sourceChainId, destChainId, token))` where both chain IDs are `uint256` — directional, so each leg of a round trip can have its own config. EVM legs use `block.chainid`; non-EVM endpoints get backend-assigned IDs in a reserved namespace (e.g. `RGB = 1_000_001`).
 - **Config** selects per route: `side` (`FUNDS_IN` vs `FUNDS_OUT`), `currency` (`TOKEN` vs `NATIVE`), `stablePercent` (×100, capped at 9000 = 90%), and `multiplier`. Global defaults apply to any route without an override.
 - **NATIVE quotes** use an owner-set mock wei-per-token rate (global or per-token) and the token's `decimals()`.
 - **Ingress:** `receiveTokenCommission(token)` and `receive()` are gated by `onlyBridge` — only `Bridge` may credit commissions. Pools are updated from balance deltas, so fee-on-transfer tokens are supported.
@@ -85,23 +87,27 @@ Federation-controlled operations (`OperationType`):
 | `WithdrawTokenCommissionCM` | CommissionManager | Withdraw ERC-20 commission to `commissionRecipient` |
 | `WithdrawNativeCommissionCM` | CommissionManager | Withdraw native commission to `commissionRecipient` |
 | `UpdateCommissionManager` | self | Migrate to a redeployed CommissionManager |
+| `AdminExecuteAdapter` | LZAdapter | Generic call into the registered LayerZero adapter (`setTrustedEntrypoint`, `refundStuckFunds`, …). Reverts `ZeroTarget` if `MultisigProxy.lzAdapter` is unset. |
+| `UpdateLZAdapter` | self | Rotate `MultisigProxy.lzAdapter` — the routing target for `AdminExecuteAdapter`. Setting to `address(0)` closes the adapter-admin path. |
+
+Note: `MultisigProxy.lzAdapter` and `Bridge.lzAdapter` are **separate** fields with different roles. `Bridge.lzAdapter` gates `fundsInFromAdapter` (data path); `MultisigProxy.lzAdapter` is the target of `AdminExecuteAdapter` proposals (governance path). Both default to `address(0)` and are wired in by federation after the adapter is deployed.
 
 ## How it works
 
 ### FundsIn (user deposits)
 
-1. The user (or frontend) quotes commission from `CommissionManager.calculateFundsInCommission(sourceChainName, destinationChain, token, amount)`.
-2. The user approves `amount` to `Bridge` and calls `Bridge.fundsIn{ value: nativeCommission }(...)`. No signature required — any user can lock tokens. Validation of the destination address and chain happens off-chain on the UTEXO backend before minting on the other side.
+1. The user (or frontend) quotes commission from `CommissionManager.calculateFundsInCommission(sourceChainId, destinationChainId, token, amount)`. EVM users pass `block.chainid` as `sourceChainId`.
+2. The user approves `amount` to `Bridge` and calls `Bridge.fundsIn{ value: nativeCommission }(amount, destinationChainId, destinationAddress, operationId)`. No signature required — any user can lock tokens. Cross-chain (LayerZero compose) deposits land through `Bridge.fundsInFromAdapter(...)` instead, called by the trusted `LZAdapter` with an authenticated `sourceChainId`. Validation of the destination address and chain happens off-chain on the UTEXO backend before minting on the other side.
 3. Bridge pulls `amount` in tokens, forwards `tokenCommission` and `nativeCommission` (if any) to `CommissionManager`, stores `netAmount = amount - tokenCommission` in `fundsInRecords`, and emits `FundsIn` + `BridgeFundsIn`.
 
 ### FundsOut (bridge withdrawals)
 
-`Bridge.fundsOut()` is `onlyOwner`, where the owner is `MultisigProxy`. The backend collects M-of-N ECDSA signatures from TEE signers over an EIP-712 `BridgeOperation` message (selector, callData, nonce, deadline). The call data includes `burnId` (replay guard for the source-side burn), `blockHeight` and `commitmentHash` for BtcRelay verification, plus `destChain` so CommissionManager can pick the right outbound route. `MultisigProxy.execute()` verifies the signatures on-chain and forwards the call to `Bridge`, which then:
+`Bridge.fundsOut()` is `onlyOwner`, where the owner is `MultisigProxy`. The backend collects M-of-N ECDSA signatures from TEE signers over an EIP-712 `BridgeOperation` message (selector, callData, nonce, deadline). The call data includes `burnId` (replay guard for the source-side burn), `blockHeight` and `commitmentHash` for BtcRelay verification, plus `destChainId` so CommissionManager can pick the right outbound route. `MultisigProxy.execute()` verifies the signatures on-chain and forwards the call to `Bridge`, which then:
 
 1. Checks `burnId` has not been consumed yet and marks it consumed (replay guard).
 2. Verifies the referenced `fundsInIds` exist and consumes them.
 3. Verifies the Bitcoin block header against BtcRelay.
-4. Quotes outbound commission via `CommissionManager.calculateFundsOutCommission(sourceChain, destChain, token, amount)`.
+4. Quotes outbound commission via `CommissionManager.calculateFundsOutCommission(sourceChainId, destChainId, token, amount)`.
 5. Forwards any token commission to `CommissionManager` and releases `netAmount` to the recipient.
 
 ### Federation governance (two-phase timelock)
@@ -159,17 +165,19 @@ set -a && source .env.interact && set +a   # before interact scripts
 **Key deploy variables** (`.env.deploy`):
 - `USDT0_ADDRESS` — accepted ERC-20 token
 - `BTC_RELAY_ADDRESS` — Atomiq BtcRelay contract address
-- `SOURCE_CHAIN_NAME` — this bridge's chain id used by `CommissionManager` route keys (e.g. `"arbitrum"`)
+- `LZ_ADAPTER` — initial LayerZero adapter address (optional; pass `0x0` if the adapter has not been deployed yet, then wire it in via federation governance after the adapter ships)
 - `COMMISSION_MANAGER` — `CommissionManager` address (step-by-step deploys only)
 - `COMMISSION_RECIPIENT` — destination for CM withdrawals
 - `ENCLAVE_SIGNERS` / `FEDERATION_SIGNERS` — comma-separated addresses, ordered by bitmap bit index
 - `TIMELOCK_DURATION` — federation timelock window in seconds
 
+> Chain identifiers are `uint256` everywhere — `block.chainid` for EVM legs, backend-assigned values for non-EVM endpoints. There is no `SOURCE_CHAIN_NAME` env var anymore; the bridge reads `block.chainid` at runtime.
+
 **Key interact variables** (`.env.interact`):
 - `BRIDGE_ADDRESS`, `PROXY_ADDRESS`, `BASE_BRIDGE_ADDRESS` — deployed contracts
 - `OPERATION_ID` — backend-assigned operation id (replay guard)
 - `BURN_ID`, `BLOCK_HEIGHT`, `COMMITMENT_HASH`, `FUNDS_IN_IDS` — fundsOut-only inputs
-- `DEST_CHAIN` — destination chain string used by `MultisigExecuteFundsOut.s.sol` when building calldata
+- `DEST_CHAIN_ID` — destination chain id (`uint256`) used by `MultisigExecuteFundsOut.s.sol` when building calldata
 - `ENCLAVE_PKS` / `FED_PKS` — comma-separated private keys for local TEE/federation simulation
 
 ## Deployment
@@ -217,7 +225,7 @@ Scripts in `script/interact/` let you exercise contracts manually before the bac
 | `BridgeFundsIn.s.sol` | Quotes commission from `CommissionManager`, approves tokens and calls `Bridge.fundsIn{ value: nativeCommission }(...)` |
 | `BaseBridgeFundsIn.s.sol` | Approves tokens and calls `BaseBridge.fundsIn(amount, operationId)` |
 | `BaseBridgeFundsOut.s.sol` | Calls `BaseBridge.fundsOut()` as owner |
-| `MultisigExecuteFundsOut.s.sol` | Signs a `Bridge.fundsOut()` locally with `ENCLAVE_PKS` (10-arg signature including `destChain` and `burnId`) and submits via `MultisigProxy.execute()` |
+| `MultisigExecuteFundsOut.s.sol` | Signs a `Bridge.fundsOut()` locally with `ENCLAVE_PKS` (10-arg `uint256`-chain-id signature including `destChainId`, `sourceChainId` and `burnId`) and submits via `MultisigProxy.execute()` |
 | `EmergencyPause.s.sol` | Signs and submits `MultisigProxy.emergencyPause()` with `FED_PKS` |
 | `EmergencyUnpause.s.sol` | Signs and submits `MultisigProxy.emergencyUnpause()` with `FED_PKS` |
 
@@ -235,10 +243,12 @@ forge script script/interact/BridgeFundsIn.s.sol --rpc-url $RPC_URL --broadcast
 2. Verify CommissionManager ownership: `CommissionManager.owner()` returns the `MultisigProxy` address.
 3. Verify CommissionManager linkage: `CommissionManager.bridgeAddress()` returns the live `Bridge` address; `Bridge.commissionManager()` returns the live `CommissionManager` address.
 4. Verify BtcRelay: `Bridge.btcRelay()` returns the expected BtcRelay contract address.
-5. Verify source chain name: `Bridge.sourceChainName()` matches the expected `SOURCE_CHAIN_NAME`.
+5. Verify LZ adapter wiring: `Bridge.lzAdapter()` and `MultisigProxy.lzAdapter()` both return `address(0)` immediately after deploy. Once the adapter is live, federation must run two timelocked proposals:
+   - `proposeAdminExecute` on the proxy with calldata `Bridge.setLZAdapter(adapter)` — opens the `fundsInFromAdapter` data path.
+   - `proposeUpdateLZAdapter(adapter)` — opens the `AdminExecuteAdapter` governance path on the proxy.
 6. Verify enclave signers: `MultisigProxy.getEnclaveSigners()` returns the TEE addresses.
 7. Verify federation signers: `MultisigProxy.getFederationSigners()` returns the governance addresses.
-8. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` (selector for the 10-arg `fundsOut` signature with `destChain` and `burnId`).
+8. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` (selector for the 10-arg `uint256`-chain-id `fundsOut` signature with `destChainId`, `sourceChainId` and `burnId`).
 9. Test `fundsIn` with a small amount (zero commission by default) to confirm token transfer and event emission.
 
 ## Project structure

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -20,10 +20,6 @@ import { MultisigProxy } from '../../src/MultisigProxy.sol';
 ///   FEDERATION_SIGNERS, FEDERATION_THRESHOLD,
 ///   COMMISSION_RECIPIENT, TIMELOCK_DURATION
 ///
-/// Note: the Bridge's `lzAdapter` is left as `address(0)` here. After this
-/// flow finishes the adapter is deployed in `utexo-usdt0-contracts` and
-/// federation governance points the Bridge at it via `setLZAdapter` on the
-/// MultisigProxy admin-execute path.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployAll.s.sol \

--- a/ethereum/script/deploy/DeployBridge.s.sol
+++ b/ethereum/script/deploy/DeployBridge.s.sol
@@ -15,9 +15,14 @@ import { Bridge } from '../../src/Bridge.sol';
 ///   BTC_RELAY_ADDRESS         — BtcRelay contract for Bitcoin header verification
 ///   COMMISSION_MANAGER        — CommissionManager contract (must already be deployed)
 ///   LZ_ADAPTER                — Optional initial LayerZero adapter address;
-///                               pass `0x0` if the adapter has not been deployed
-///                               yet, and wire it in later via federation
-///                               governance (`setLZAdapter`).
+///                               omit or pass `0x0` if the adapter has not been
+///                               deployed yet. Once the adapter exists in
+///                               `utexo-usdt0-contracts`, wire it in via
+///                               federation governance: `proposeAdminExecute`
+///                               on MultisigProxy with calldata
+///                               `Bridge.setLZAdapter(adapter)`. The Bridge
+///                               accepts adapter-only `fundsInFromAdapter`
+///                               calls *only* from the configured adapter.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployBridge.s.sol \

--- a/ethereum/script/deploy/DeployMultisigProxy.s.sol
+++ b/ethereum/script/deploy/DeployMultisigProxy.s.sol
@@ -54,8 +54,13 @@ contract DeployMultisigProxy is Script {
         console2.log('Commission recipient:     ', proxy.commissionRecipient());
         console2.log('Timelock duration (sec):  ', proxy.timelockDuration());
         console2.log('');
+        console2.log('lzAdapter (proxy):        ', proxy.lzAdapter());
+        console2.log('');
         console2.log('Next steps:');
         console2.log('  1) Transfer Bridge ownership to MultisigProxy.');
         console2.log('  2) Transfer CommissionManager ownership to MultisigProxy.');
+        console2.log('  3) Once the LayerZero adapter is deployed:');
+        console2.log('     a) propose Bridge.setLZAdapter(adapter) via proposeAdminExecute');
+        console2.log('     b) propose MultisigProxy.lzAdapter via proposeUpdateLZAdapter');
     }
 }

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -14,6 +14,11 @@ contract MultisigProxy is IMultisigProxy {
     address public bridge;
     address public commissionManager;
 
+    /// @notice Routing target for `AdminExecuteAdapter` proposals. Settable via
+    ///         `UpdateLZAdapter` after the adapter is deployed; `address(0)`
+    ///         until then (closes adapter-execute by default).
+    address public lzAdapter;
+
     address[] private _enclaveSigners;
     uint256 public enclaveThreshold;
 
@@ -102,6 +107,14 @@ contract MultisigProxy is IMultisigProxy {
         'ProposeUpdateCommissionManager(address newCommissionManager,uint256 nonce,uint256 deadline)'
     );
 
+    // Federation propose — LZAdapter side
+    bytes32 private constant _PROPOSE_ADMIN_EXECUTE_ADAPTER_TYPEHASH = keccak256(
+        'ProposeAdminExecuteAdapter(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
+    );
+    bytes32 private constant _PROPOSE_UPDATE_LZ_ADAPTER_TYPEHASH = keccak256(
+        'ProposeUpdateLZAdapter(address newLZAdapter,uint256 nonce,uint256 deadline)'
+    );
+
     // Cancel
     bytes32 private constant _CANCEL_PROPOSAL_TYPEHASH = keccak256(
         'CancelProposal(bytes32 proposalId,uint256 nonce,uint256 deadline)'
@@ -155,7 +168,7 @@ contract MultisigProxy is IMultisigProxy {
         // federation governance through `proposeSetTeeAllowedCall`.
         teeAllowedCalls[bridge_][
             bytes4(keccak256(
-                'fundsOut(address,uint256,uint256,uint256,string,string,string,uint256,bytes32,uint256[])'
+                'fundsOut(address,uint256,uint256,uint256,uint256,uint256,string,uint256,bytes32,uint256[])'
             ))
         ] = true;
 
@@ -532,6 +545,53 @@ contract MultisigProxy is IMultisigProxy {
     }
 
     // =========================================================================
+    // Federation propose (Phase 1) — LZAdapter side
+    // =========================================================================
+
+    /// @inheritdoc IMultisigProxy
+    function proposeAdminExecuteAdapter(
+        bytes calldata callData,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        if (callData.length < 4) revert CallDataTooShort();
+
+        bytes4 selector;
+        assembly { selector := calldataload(callData.offset) }
+
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_ADMIN_EXECUTE_ADAPTER_TYPEHASH, selector, keccak256(callData), nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.AdminExecuteAdapter,
+            callData,
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
+    /// @inheritdoc IMultisigProxy
+    function proposeUpdateLZAdapter(
+        address newLZAdapter,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_UPDATE_LZ_ADAPTER_TYPEHASH, newLZAdapter, nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.UpdateLZAdapter,
+            abi.encode(newLZAdapter),
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
+    // =========================================================================
     // Cancel
     // =========================================================================
 
@@ -743,6 +803,19 @@ contract MultisigProxy is IMultisigProxy {
             address old = commissionManager;
             commissionManager = newCm;
             emit CommissionManagerUpdated(old, newCm);
+
+        } else if (opType == OperationType.AdminExecuteAdapter) {
+            // opData = raw LZAdapter callData. The adapter must be wired in
+            // first via UpdateLZAdapter; a zero target closes the path.
+            if (lzAdapter == address(0)) revert ZeroTarget();
+            (bool ok, bytes memory ret) = lzAdapter.call(opData);
+            _propagateRevert(ok, ret);
+
+        } else if (opType == OperationType.UpdateLZAdapter) {
+            address newAdapter = abi.decode(opData, (address));
+            address oldAdapter = lzAdapter;
+            lzAdapter = newAdapter;
+            emit LZAdapterUpdated(oldAdapter, newAdapter);
 
         } else {
             revert UnknownOperationType();

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -56,6 +56,11 @@ contract MultisigProxy is IMultisigProxy {
     /// @notice Hard upper bound on `executeBatch` size to keep gas use bounded.
     uint256 public constant MAX_BATCH_SIZE = 3;
 
+    /// @notice Length of a Solidity function selector (`bytes4`) in bytes. Used
+    ///         to guard `callData` against payloads too short to even carry a
+    ///         selector before it is sliced via `calldataload`.
+    uint256 public constant SELECTOR_LENGTH = 4;
+
     bytes32 public immutable DOMAIN_SEPARATOR;
 
     bytes32 private constant _DOMAIN_TYPEHASH = keccak256(
@@ -194,7 +199,7 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata enclaveSigs
     ) external {
         if (block.timestamp > deadline) revert Expired();
-        if (callData.length < 4) revert CallDataTooShort();
+        if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
@@ -234,7 +239,7 @@ contract MultisigProxy is IMultisigProxy {
         bytes4[] memory selectors = new bytes4[](n);
         uint256 totalValue;
         for (uint256 i = 0; i < n; i++) {
-            if (callDatas[i].length < 4) revert CallDataTooShort();
+            if (callDatas[i].length < SELECTOR_LENGTH) revert CallDataTooShort();
 
             bytes calldata cd = callDatas[i];
             bytes4 sel;
@@ -324,7 +329,7 @@ contract MultisigProxy is IMultisigProxy {
         uint256 fedBitmap,
         bytes[] calldata fedSigs
     ) external returns (bytes32) {
-        if (callData.length < 4) revert CallDataTooShort();
+        if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
@@ -470,7 +475,7 @@ contract MultisigProxy is IMultisigProxy {
         uint256 fedBitmap,
         bytes[] calldata fedSigs
     ) external returns (bytes32) {
-        if (callData.length < 4) revert CallDataTooShort();
+        if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
@@ -556,7 +561,7 @@ contract MultisigProxy is IMultisigProxy {
         uint256 fedBitmap,
         bytes[] calldata fedSigs
     ) external returns (bytes32) {
-        if (callData.length < 4) revert CallDataTooShort();
+        if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -74,17 +74,19 @@ interface IMultisigProxy {
     // =========================================================================
 
     enum OperationType {
-        AdminExecute,                    // 0 — generic call into Bridge
+        AdminExecute,                    // 0  — generic call into Bridge
         UpdateEnclaveSigners,            // 1
         UpdateFederationSigners,         // 2
         UpdateBridge,                    // 3
         SetCommissionRecipient,          // 4
-        SetTeeAllowedCall,               // 5 — (target, selector, allowed) entry in TEE allowlist
+        SetTeeAllowedCall,               // 5  — (target, selector, allowed) entry in TEE allowlist
         SetTimelockDuration,             // 6
-        AdminExecuteCommissionManager,   // 7 — generic call into CommissionManager
-        WithdrawTokenCommissionCM,       // 8 — CM.withdrawTokenCommission -> commissionRecipient
-        WithdrawNativeCommissionCM,      // 9 — CM.withdrawNativeCommission -> commissionRecipient
-        UpdateCommissionManager          // 10 — migrate to a new CommissionManager address
+        AdminExecuteCommissionManager,   // 7  — generic call into CommissionManager
+        WithdrawTokenCommissionCM,       // 8  — CM.withdrawTokenCommission -> commissionRecipient
+        WithdrawNativeCommissionCM,      // 9  — CM.withdrawNativeCommission -> commissionRecipient
+        UpdateCommissionManager,         // 10 — migrate to a new CommissionManager address
+        AdminExecuteAdapter,             // 11 — generic call into LZAdapter (setTrustedEntrypoint, refundStuckFunds, …)
+        UpdateLZAdapter                  // 12 — rotate the routing target for AdminExecuteAdapter
     }
 
     enum ProposalStatus { None, Pending, Executed, Cancelled }
@@ -126,6 +128,7 @@ interface IMultisigProxy {
     event FederationSignersUpdated(address[] newSigners, uint256 newThreshold);
     event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
+    event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event CommissionRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
     event TeeAllowedCallUpdated(address indexed target, bytes4 indexed selector, bool allowed);
     event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
@@ -307,6 +310,32 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
+    // --- LZAdapter-targeted operations ---
+
+    /// @notice Propose an arbitrary call into the LZAdapter (routes through the
+    ///         stored `lzAdapter` address). Federation typically uses this for
+    ///         `setTrustedEntrypoint`, `refundStuckFunds`, and any other
+    ///         `onlyMultisigProxy`-gated adapter admin.
+    /// @dev opData = raw ABI-encoded LZAdapter callData (selector + args).
+    function proposeAdminExecuteAdapter(
+        bytes calldata callData,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
+    /// @notice Propose rotating the LZAdapter routing target stored on this proxy.
+    /// @dev opData = abi.encode(address newLZAdapter). `address(0)` is allowed
+    ///      and closes adapter-execute until set again.
+    function proposeUpdateLZAdapter(
+        address newLZAdapter,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
     // =========================================================================
     // Cancel & Execute
     // =========================================================================
@@ -339,6 +368,7 @@ interface IMultisigProxy {
     function getNonce(bytes4 selector) external view returns (uint256);
     function bridge() external view returns (address);
     function commissionManager() external view returns (address);
+    function lzAdapter() external view returns (address);
     function getEnclaveSigners() external view returns (address[] memory);
     function enclaveThreshold() external view returns (uint256);
     function getFederationSigners() external view returns (address[] memory);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -27,7 +27,8 @@ contract BridgeTest is Test {
         uint256 netAmount,
         uint256 tokenCommission,
         uint256 nativeCommission,
-        string  destinationChain,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
         string  destinationAddress
     );
     event BridgeFundsOut(
@@ -37,12 +38,13 @@ contract BridgeTest is Test {
         uint256 tokenCommission,
         uint256 operationId,
         uint256 burnId,
-        string  sourceChain,
-        string  destChain,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
         string  sourceAddress,
         uint256 blockHeight,
         bytes32 commitmentHash
     );
+    event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
 
     Bridge            bridge;
     MockERC20         usdt0;
@@ -54,16 +56,16 @@ contract BridgeTest is Test {
     address recipient = makeAddr('recipient');
     address multisig  = makeAddr('multisig');
 
-    string  constant SOURCE_CHAIN = 'arbitrum';
-    string  constant DST_CHAIN    = 'rgb';
-    string  constant DST_ADDR     = 'rgb:asset1qp0y3mq6h5k8d9f2e4j7n6c3w/utxo1abc123';
-    // For outbound, source is "rgb" coming to "arbitrum" (this chain).
-    string  constant SRC_CHAIN    = 'rgb';
-    string  constant DST_CHAIN_OUT = 'arbitrum';
-    string  constant SRC_ADDR     = 'rgb:sender/utxo1src';
-    uint256 constant AMOUNT       = 100e18;
-    uint256 constant TX_ID        = 42;
-    uint256 constant BURN_ID      = 9_001;
+    // Chain identifiers are uint256: real EVM uses block.chainid; non-EVM is
+    // assigned by backend convention (see README).
+    uint256 constant SOURCE_CHAIN_ID = 31337;     // foundry default block.chainid
+    uint256 constant RGB_CHAIN_ID    = 1_000_001; // backend-assigned for RGB
+    string  constant DST_ADDR        = 'rgb:asset1qp0y3mq6h5k8d9f2e4j7n6c3w/utxo1abc123';
+    // For outbound, source is the RGB side, destination is this chain.
+    string  constant SRC_ADDR        = 'rgb:sender/utxo1src';
+    uint256 constant AMOUNT          = 100e18;
+    uint256 constant TX_ID           = 42;
+    uint256 constant BURN_ID         = 9_001;
 
     // BtcRelay test data
     uint256 constant BLOCK_HEIGHT     = 850_000;
@@ -110,7 +112,7 @@ contract BridgeTest is Test {
     function _setFundsInTokenRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(usdt0),
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -124,7 +126,7 @@ contract BridgeTest is Test {
     function _setFundsInNativeRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(usdt0),
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -138,7 +140,7 @@ contract BridgeTest is Test {
     function _setFundsOutTokenRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), address(usdt0),
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -152,7 +154,7 @@ contract BridgeTest is Test {
     function _setFundsOutNativeRule(uint256 percent) internal {
         vm.prank(deployer);
         cm.setCommissionRule(
-            uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), address(usdt0),
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
                 multiplier: 100,
@@ -187,7 +189,74 @@ contract BridgeTest is Test {
     function test_constructor_revertsOnZeroCommissionManager() public {
         vm.expectRevert(IBridge.InvalidCommissionManagerAddress.selector);
         new Bridge(address(usdt0), address(btcRelay), payable(address(0)), address(0));
-    }    
+    }
+
+    function test_constructor_storesInitialLZAdapter() public {
+        address initialAdapter = makeAddr('initial-adapter');
+        vm.prank(deployer);
+        Bridge b = new Bridge(address(usdt0), address(btcRelay), payable(address(cm)), initialAdapter);
+        assertEq(b.lzAdapter(), initialAdapter, 'lzAdapter set in constructor');
+    }
+
+    // ========================================================================
+    // setLZAdapter
+    // ========================================================================
+
+    function test_setLZAdapter_ownerCanSetAndUnset() public {
+        address adapter = makeAddr('adapter');
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit LZAdapterUpdated(address(0), adapter);
+
+        vm.prank(multisig);
+        bridge.setLZAdapter(adapter);
+        assertEq(bridge.lzAdapter(), adapter, 'set');
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit LZAdapterUpdated(adapter, address(0));
+
+        vm.prank(multisig);
+        bridge.setLZAdapter(address(0));
+        assertEq(bridge.lzAdapter(), address(0), 'unset');
+    }
+
+    function test_setLZAdapter_revertsIfNotOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.setLZAdapter(makeAddr('adapter'));
+    }
+
+    // ========================================================================
+    // fundsIn — adapter overload (`onlyLZAdapter`)
+    // ========================================================================
+
+    function test_fundsInFromAdapter_revertsIfCallerIsNotLZAdapter() public {
+        // No adapter set in setUp — caller is `user`.
+        vm.prank(user);
+        vm.expectRevert(IBridge.NotLZAdapter.selector);
+        bridge.fundsIn(AMOUNT, 1, RGB_CHAIN_ID, DST_ADDR, TX_ID);
+    }
+
+    function test_fundsInFromAdapter_acceptsCustomSourceChainId() public {
+        // Register a mock adapter and prime it with tokens + approval.
+        address mockAdapter = makeAddr('mock-adapter');
+        vm.prank(multisig);
+        bridge.setLZAdapter(mockAdapter);
+
+        usdt0.mint(mockAdapter, AMOUNT);
+        vm.prank(mockAdapter);
+        usdt0.approve(address(bridge), AMOUNT);
+
+        uint256 customSrc = 137; // pretend Polygon
+
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit BridgeFundsIn(mockAdapter, TX_ID, AMOUNT, AMOUNT, 0, 0, customSrc, RGB_CHAIN_ID, DST_ADDR);
+
+        vm.prank(mockAdapter);
+        bridge.fundsIn(AMOUNT, customSrc, RGB_CHAIN_ID, DST_ADDR, TX_ID);
+
+        assertEq(bridge.fundsInRecords(TX_ID), AMOUNT, 'record stored');
+    }
 
     // ========================================================================
     // fundsIn — happy path (zero commission default)
@@ -197,7 +266,7 @@ contract BridgeTest is Test {
         uint256 userBefore = usdt0.balanceOf(user);
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
         assertEq(usdt0.balanceOf(user),            userBefore - AMOUNT);
@@ -205,7 +274,7 @@ contract BridgeTest is Test {
 
     function test_fundsIn_storesRecord() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(bridge.fundsInRecords(TX_ID), AMOUNT);
     }
@@ -214,10 +283,10 @@ contract BridgeTest is Test {
         vm.expectEmit(true, false, false, true);
         emit FundsIn(user, TX_ID, AMOUNT);
         vm.expectEmit(true, false, false, true);
-        emit BridgeFundsIn(user, TX_ID, AMOUNT, AMOUNT, 0, 0, DST_CHAIN, DST_ADDR);
+        emit BridgeFundsIn(user, TX_ID, AMOUNT, AMOUNT, 0, 0, SOURCE_CHAIN_ID, RGB_CHAIN_ID, DST_ADDR);
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     function test_fundsIn_anyUserCanCall() public {
@@ -227,7 +296,7 @@ contract BridgeTest is Test {
         usdt0.approve(address(bridge), AMOUNT);
 
         vm.prank(stranger);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
     }
@@ -239,7 +308,7 @@ contract BridgeTest is Test {
     function test_fundsIn_revertsOnEmptyDestinationAddress() public {
         vm.expectRevert(IBridge.InvalidDestinationAddress.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), '', TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, '', TX_ID);
     }
 
     function test_fundsIn_revertsOnEmptyDestinationChain() public {
@@ -254,16 +323,16 @@ contract BridgeTest is Test {
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     function test_fundsIn_revertsOnDuplicateOperationId() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.expectRevert(IBridge.DuplicateOperationId.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     // ========================================================================
@@ -272,16 +341,16 @@ contract BridgeTest is Test {
 
     function test_fundsOut_transfersAndEmits() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.expectEmit(true, false, false, true);
         emit BridgeFundsOut(
             recipient, AMOUNT, AMOUNT, 0, TX_ID, BURN_ID,
-            SRC_CHAIN, DST_CHAIN_OUT, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH
         );
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(usdt0.balanceOf(recipient),       AMOUNT);
         assertEq(usdt0.balanceOf(address(bridge)), 0);
@@ -289,10 +358,10 @@ contract BridgeTest is Test {
 
     function test_fundsOut_consumesFundsInRecord() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(bridge.fundsInRecords(TX_ID), 0);
     }
@@ -304,16 +373,16 @@ contract BridgeTest is Test {
         uint256 amount2 = 40e18;
 
         vm.prank(user);
-        bridge.fundsIn(amount1, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
+        bridge.fundsIn(amount1, RGB_CHAIN_ID, DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(amount2, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
+        bridge.fundsIn(amount2, RGB_CHAIN_ID, DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](2);
         ids[0] = txId1;
         ids[1] = txId2;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, amount1 + amount2, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, amount1 + amount2, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
 
         assertEq(usdt0.balanceOf(recipient), amount1 + amount2);
         assertEq(bridge.fundsInRecords(txId1), 0);
@@ -324,12 +393,12 @@ contract BridgeTest is Test {
         // Single fundsIn of 100. fundsOut for 60 should decrement the record to 40
         // (not delete it), preserving the residual liquidity for future fundsOut.
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         uint256 partialAmount = 60e18;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, partialAmount, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, partialAmount, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(usdt0.balanceOf(recipient), partialAmount);
         assertEq(bridge.fundsInRecords(TX_ID), AMOUNT - partialAmount, 'residual preserved');
@@ -342,16 +411,16 @@ contract BridgeTest is Test {
         uint256 txId2 = 101;
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](2);
         ids[0] = txId1;
         ids[1] = txId2;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, 150e18, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, 150e18, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
 
         assertEq(usdt0.balanceOf(recipient), 150e18);
         assertEq(bridge.fundsInRecords(txId1), 0,    'first id fully consumed');
@@ -365,9 +434,9 @@ contract BridgeTest is Test {
         uint256 txId2 = 101;
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](2);
         ids[0] = txId1;
@@ -375,7 +444,7 @@ contract BridgeTest is Test {
 
         // Amount of 50 < first record; second id should remain untouched.
         vm.prank(multisig);
-        bridge.fundsOut(recipient, 50e18, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, 50e18, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
 
         assertEq(bridge.fundsInRecords(txId1), 50e18,  'first decremented');
         assertEq(bridge.fundsInRecords(txId2), AMOUNT, 'second untouched');
@@ -387,14 +456,14 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnUnverifiedBlock() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         uint256 unknownHeight = 999_999;
         bytes32 unknownHash = keccak256('unknown-block');
 
         vm.expectRevert('verify: block commitment');
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, unknownHeight, unknownHash, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, unknownHeight, unknownHash, _singleFundsInId());
     }
 
     // ========================================================================
@@ -403,30 +472,30 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnUnknownFundsInId() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         uint256[] memory ids = new uint256[](1);
         ids[0] = 999;
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.FundsInNotFound.selector, 999));
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
     }
 
     function test_fundsOut_revertsOnAmountExceedsFundsIn() public {
         uint256 txId1 = 100;
         uint256 txId2 = 101;
         vm.prank(user);
-        bridge.fundsIn(50e18, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
+        bridge.fundsIn(50e18, RGB_CHAIN_ID, DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(50e18, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
+        bridge.fundsIn(50e18, RGB_CHAIN_ID, DST_ADDR, txId2);
 
         uint256[] memory ids = new uint256[](1);
         ids[0] = txId1;
 
         vm.expectRevert(IBridge.FundsOutAmountExceedsFundsIn.selector);
         vm.prank(multisig);
-        bridge.fundsOut(recipient, 60e18, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
+        bridge.fundsOut(recipient, 60e18, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids);
     }
 
     function test_fundsOut_revertsOnReplayedBurnId() public {
@@ -435,9 +504,9 @@ contract BridgeTest is Test {
         uint256 txId1 = 200;
         uint256 txId2 = 201;
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId1);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId1);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, txId2);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId2);
 
         uint256[] memory ids1 = new uint256[](1);
         ids1[0] = txId1;
@@ -446,13 +515,13 @@ contract BridgeTest is Test {
 
         // First fundsOut consumes BURN_ID.
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids1);
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids1);
         assertTrue(bridge.consumedBurnIds(BURN_ID), 'burnId recorded');
 
         // Second fundsOut uses fresh fundsIn record but the same burnId — must revert.
         vm.expectRevert(abi.encodeWithSelector(IBridge.BurnIdAlreadyConsumed.selector, BURN_ID));
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID + 100, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids2);
+        bridge.fundsOut(recipient, AMOUNT, TX_ID + 100, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, ids2);
 
         // Ensure the second call did not consume the underlying fundsIn record.
         assertEq(bridge.fundsInRecords(txId2), AMOUNT, 'fundsIn record preserved');
@@ -460,16 +529,16 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnDoubleSpendsConsumedFundsIn() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         usdt0.mint(address(bridge), AMOUNT);
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.FundsInNotFound.selector, TX_ID));
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID + 1, BURN_ID + 1, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID + 1, BURN_ID + 1, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     // ========================================================================
@@ -478,29 +547,29 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsIfNotOwner() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     function test_fundsOut_revertsOnZeroRecipient() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.expectRevert(BridgeBase.InvalidRecipientAddress.selector);
         vm.prank(multisig);
-        bridge.fundsOut(address(0), AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(address(0), AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     function test_fundsOut_revertsIfAmountExceedsPool() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         vm.expectRevert(BridgeBase.AmountExceedBridgePool.selector);
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT + 1, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT + 1, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     // ========================================================================
@@ -516,7 +585,7 @@ contract BridgeTest is Test {
         uint256 expectedNet        = AMOUNT - expectedCommission;
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), expectedNet, 'bridge net');
         assertEq(usdt0.balanceOf(address(cm)),     expectedCommission, 'cm pool');
@@ -541,14 +610,14 @@ contract BridgeTest is Test {
         cm.setMockTokenToNativeRate(rate);
 
         (uint256 tokenC, uint256 nativeC, uint256 net) =
-            cm.calculateFundsInCommission(uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(usdt0), AMOUNT);
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
         assertEq(tokenC, 0);
         assertGt(nativeC, 0);
         assertEq(net, AMOUNT);
 
         vm.deal(user, nativeC);
         vm.prank(user);
-        bridge.fundsIn{ value: nativeC }(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn{ value: nativeC }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         // Bridge received full amount in token (no token commission).
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
@@ -566,7 +635,7 @@ contract BridgeTest is Test {
     function test_fundsOut_tokenCommission_routesToCM() public {
         // Deposit at zero commission first.
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         uint256 percent = 500; // 5%
         _setFundsOutTokenRule(percent);
@@ -575,7 +644,7 @@ contract BridgeTest is Test {
         uint256 expectedNet        = AMOUNT - expectedCommission;
 
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
 
         assertEq(usdt0.balanceOf(recipient), expectedNet, 'recipient net');
         assertEq(usdt0.balanceOf(address(cm)), expectedCommission, 'cm pool');
@@ -588,7 +657,7 @@ contract BridgeTest is Test {
 
     function test_fundsOut_nativeCommission_reverts() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         _setFundsOutNativeRule(100);
         vm.prank(deployer);
@@ -596,7 +665,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(IBridge.NativeCommissionNotAllowedOnFundsOut.selector);
         vm.prank(multisig);
-        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
+        bridge.fundsOut(recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _singleFundsInId());
     }
 
     // ========================================================================
@@ -608,7 +677,7 @@ contract BridgeTest is Test {
         vm.deal(user, 1 ether);
         vm.expectRevert(IBridge.NativeValueMismatch.selector);
         vm.prank(user);
-        bridge.fundsIn{ value: 1 ether }(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn{ value: 1 ether }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     function test_fundsIn_revertsOnNativeValueMismatch_nativeRuleButNoValue() public {
@@ -618,7 +687,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(IBridge.NativeValueMismatch.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     // ========================================================================
@@ -652,7 +721,7 @@ contract BridgeTest is Test {
 
     function test_getContractBalance() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(bridge.getContractBalance(), AMOUNT);
     }
@@ -670,7 +739,7 @@ contract BridgeTest is Test {
         usdt0.mint(user, amount);
 
         vm.prank(user);
-        bridge.fundsIn(amount, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, TX_ID);
 
         assertEq(usdt0.balanceOf(address(bridge)), amount);
         assertEq(bridge.fundsInRecords(TX_ID), amount);

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -61,8 +61,8 @@ contract IntegrationTest is Test {
     // Constants
     // =========================================================================
 
-    string  constant SOURCE_CHAIN = 'arbitrum'; // this chain
-    string  constant RGB_CHAIN    = 'rgb';
+    uint256 constant SOURCE_CHAIN_ID = 31337;     // foundry default block.chainid
+    uint256 constant RGB_CHAIN_ID    = 1_000_001; // backend-assigned for RGB
 
     uint256 constant USER_DEPOSIT = 100 ether; // 100 tokens gross
     // FUNDS_IN route: 2% token commission (stablePercent = 200, multiplier = 100 → 200/100/100 = 2%).
@@ -83,7 +83,7 @@ contract IntegrationTest is Test {
     uint256 constant TIMELOCK = 1 hours;
 
     bytes4 constant FUNDS_OUT_SELECTOR = bytes4(keccak256(
-        'fundsOut(address,uint256,uint256,uint256,string,string,string,uint256,bytes32,uint256[])'
+        'fundsOut(address,uint256,uint256,uint256,uint256,uint256,string,uint256,bytes32,uint256[])'
     ));
 
     // =========================================================================
@@ -97,8 +97,8 @@ contract IntegrationTest is Test {
         uint256 tokenCommission,
         uint256 operationId,
         uint256 burnId,
-        string  sourceChain,
-        string  destChain,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
         string  sourceAddress,
         uint256 blockHeight,
         bytes32 commitmentHash
@@ -173,7 +173,7 @@ contract IntegrationTest is Test {
         _proposeAndExecuteCmAdminCall(
             abi.encodeWithSelector(
                 ICommissionManager.setCommissionRule.selector,
-                SOURCE_CHAIN, RGB_CHAIN, address(token),
+                SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token),
                 CommissionConfig({
                     stablePercent: FUNDS_IN_PERCENT,
                     multiplier:    FUNDS_IN_MULT,
@@ -187,7 +187,7 @@ contract IntegrationTest is Test {
         _proposeAndExecuteCmAdminCall(
             abi.encodeWithSelector(
                 ICommissionManager.setCommissionRule.selector,
-                RGB_CHAIN, SOURCE_CHAIN, address(token),
+                RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token),
                 CommissionConfig({
                     stablePercent: FUNDS_OUT_PERCENT,
                     multiplier:    FUNDS_OUT_MULT,
@@ -200,7 +200,7 @@ contract IntegrationTest is Test {
 
         // Sanity: CM now quotes commission for both routes.
         (uint256 tInQuote,, uint256 netIn) =
-            cm.calculateFundsInCommission(uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(RGB_CHAIN))), address(token), USER_DEPOSIT);
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token), USER_DEPOSIT);
         assertEq(tInQuote, USER_DEPOSIT * FUNDS_IN_PERCENT / FUNDS_IN_MULT / FUNDS_IN_MULT, 'quote in');
         assertEq(netIn,    USER_DEPOSIT - tInQuote, 'net in');
 
@@ -212,7 +212,7 @@ contract IntegrationTest is Test {
         vm.prank(user);
         bridge.fundsIn(
             USER_DEPOSIT,
-            uint256(keccak256(bytes(RGB_CHAIN))),
+            RGB_CHAIN_ID,
             'rgb:asset1qp0y3mq/utxo1abc',
             TX_ID_IN
         );
@@ -239,8 +239,8 @@ contract IntegrationTest is Test {
             netBridgedIn,          // amount = full bridged pool from this deposit
             TX_ID_OUT,
             BURN_ID,
-            RGB_CHAIN,
-            SOURCE_CHAIN,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
             'rgb:sender/utxo1src',
             BLOCK_HEIGHT,
             COMMITMENT_HASH,
@@ -265,8 +265,8 @@ contract IntegrationTest is Test {
             tokenCommissionOut,
             TX_ID_OUT,
             BURN_ID,
-            RGB_CHAIN,
-            SOURCE_CHAIN,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
             'rgb:sender/utxo1src',
             BLOCK_HEIGHT,
             COMMITMENT_HASH
@@ -341,7 +341,7 @@ contract IntegrationTest is Test {
         _proposeAndExecuteCmAdminCall(
             abi.encodeWithSelector(
                 ICommissionManager.setCommissionRule.selector,
-                SOURCE_CHAIN, RGB_CHAIN, address(token),
+                SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token),
                 CommissionConfig({
                     stablePercent: FUNDS_IN_PERCENT,
                     multiplier:    FUNDS_IN_MULT,
@@ -353,7 +353,7 @@ contract IntegrationTest is Test {
         );
 
         (, uint256 nativeQuote, uint256 netQuote) =
-            cm.calculateFundsInCommission(uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(RGB_CHAIN))), address(token), USER_DEPOSIT);
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token), USER_DEPOSIT);
         assertEq(netQuote,    USER_DEPOSIT,                                        'NATIVE: full amount bridges');
         assertEq(nativeQuote, USER_DEPOSIT * FUNDS_IN_PERCENT / FUNDS_IN_MULT / FUNDS_IN_MULT, 'native quote matches 1:1 rate');
 
@@ -362,7 +362,7 @@ contract IntegrationTest is Test {
         vm.prank(user);
         bridge.fundsIn{ value: nativeQuote }(
             USER_DEPOSIT,
-            uint256(keccak256(bytes(RGB_CHAIN))),
+            RGB_CHAIN_ID,
             'rgb:asset1qp0y3mq/utxo1abc',
             TX_ID_IN
         );

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -40,6 +40,7 @@ contract MultisigProxyTest is Test {
     event TeeAllowedCallUpdated(address indexed target, bytes4 indexed selector, bool allowed);
     event TimelockDurationUpdated(uint256 newDuration);
     event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
+    event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
 
     MultisigProxy     proxy;
     Bridge            bridge;
@@ -73,12 +74,11 @@ contract MultisigProxyTest is Test {
     bytes32 domainSep;
 
     // Canonical constants for Bridge calls
-    string  constant SOURCE_CHAIN = 'arbitrum';
-    string  constant DST_CHAIN    = 'rgb';
-    string  constant DST_ADDR     = 'rgb:asset/utxo1abc';
-    string  constant SRC_CHAIN    = 'rgb';
-    string  constant DST_CHAIN_OUT = 'arbitrum';
-    string  constant SRC_ADDR     = 'rgb:sender/utxo1src';
+    // Chain identifiers are uint256: foundry tests run with block.chainid = 31337.
+    uint256 constant SOURCE_CHAIN_ID = 31337;
+    uint256 constant RGB_CHAIN_ID    = 1_000_001;
+    string  constant DST_ADDR        = 'rgb:asset/utxo1abc';
+    string  constant SRC_ADDR        = 'rgb:sender/utxo1src';
     uint256 constant AMOUNT    = 100e18;
     uint256 constant TX_ID     = 42;
     uint256 constant BURN_ID   = 9_001;
@@ -142,7 +142,7 @@ contract MultisigProxyTest is Test {
         vm.prank(user);
         token.approve(address(bridge), type(uint256).max);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT * 5, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID);
+        bridge.fundsIn(AMOUNT * 5, RGB_CHAIN_ID, DST_ADDR, TX_ID);
     }
 
     // ========================================================================
@@ -171,7 +171,7 @@ contract MultisigProxyTest is Test {
     function _fundsOutCalldata() internal view returns (bytes memory) {
         return abi.encodeWithSelector(
             FUNDS_OUT_SELECTOR,
-            recipient, AMOUNT, TX_ID, BURN_ID, uint256(keccak256(bytes(SRC_CHAIN))), uint256(keccak256(bytes(DST_CHAIN_OUT))), SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _fundsInIds()
+            recipient, AMOUNT, TX_ID, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, BLOCK_HEIGHT, COMMITMENT_HASH, _fundsInIds()
         );
     }
 
@@ -761,7 +761,7 @@ contract MultisigProxyTest is Test {
         // Seed commission by setting a fundsIn TOKEN rule and doing a deposit.
         vm.prank(address(proxy));
         cm.setCommissionRule(
-            uint256(keccak256(bytes(SOURCE_CHAIN))), uint256(keccak256(bytes(DST_CHAIN))), address(token),
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token),
             CommissionConfig({
                 stablePercent: 400, // 4%
                 multiplier: 100,
@@ -773,7 +773,7 @@ contract MultisigProxyTest is Test {
 
         uint256 depositAmount = 100e18;
         vm.prank(user);
-        bridge.fundsIn(depositAmount, uint256(keccak256(bytes(DST_CHAIN))), DST_ADDR, TX_ID + 1);
+        bridge.fundsIn(depositAmount, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1);
 
         uint256 expectedCommission = (depositAmount * 400) / 100 / 100;
         assertEq(cm.tokenCommissionPool(address(token)), expectedCommission);
@@ -905,6 +905,173 @@ contract MultisigProxyTest is Test {
 
         vm.expectRevert(IMultisigProxy.IndexOutOfRange.selector);
         proxy.verifyEnclaveSignature(digest, sig, 99);
+    }
+
+    // ========================================================================
+    // Propose + Execute — UpdateLZAdapter
+    // ========================================================================
+
+    function _proposeUpdateLZAdapter(address newAdapter) internal returns (bytes32 id) {
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateLZAdapter(domainSep, newAdapter, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        id = proxy.proposeUpdateLZAdapter(newAdapter, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_lzAdapter_defaultsToZero() public view {
+        assertEq(proxy.lzAdapter(), address(0));
+    }
+
+    function test_proposeUpdateLZAdapter_executeSetsAdapter() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        vm.expectEmit(true, true, false, false);
+        emit LZAdapterUpdated(address(0), newAdapter);
+
+        proxy.executeProposal(id, abi.encode(newAdapter));
+        assertEq(proxy.lzAdapter(), newAdapter);
+    }
+
+    function test_proposeUpdateLZAdapter_canRotateToZero() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(newAdapter));
+        assertEq(proxy.lzAdapter(), newAdapter);
+
+        // Rotate back to zero — closes AdminExecuteAdapter path.
+        // proposalNonce auto-increments, so the second proposal lives at a different id.
+        bytes32 id2 = _proposeUpdateLZAdapter(address(0));
+        // Fresh timelock from the *second* proposal's proposedAt. Use a large
+        // absolute warp so the timelock check passes regardless of foundry's
+        // current block.timestamp evaluation quirks.
+        vm.warp(block.timestamp + 2 * TIMELOCK + 2);
+
+        proxy.executeProposal(id2, abi.encode(address(0)));
+        assertEq(proxy.lzAdapter(), address(0));
+    }
+
+    function test_proposeUpdateLZAdapter_revertsOnDataMismatch() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.DataMismatch.selector);
+        proxy.executeProposal(id, abi.encode(makeAddr('different')));
+    }
+
+    function test_proposeUpdateLZAdapter_canBeCancelled() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+
+        uint256 cNonce = proxy.proposalNonce();
+        uint256 cDeadline = block.timestamp + 1 hours;
+        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cNonce, cDeadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory cSigs = MultisigHelper.signAll(vm, cDigest, pks);
+
+        vm.expectEmit(true, false, false, false);
+        emit ProposalCancelled(id);
+        proxy.cancelProposal(id, cNonce, cDeadline, bitmap, cSigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.NotPending.selector);
+        proxy.executeProposal(id, abi.encode(newAdapter));
+        assertEq(proxy.lzAdapter(), address(0));
+    }
+
+    // ========================================================================
+    // Propose + Execute — AdminExecuteAdapter
+    // ========================================================================
+
+    function test_proposeAdminExecuteAdapter_revertsIfAdapterUnset() public {
+        // Register an arbitrary adapter call; lzAdapter is still address(0).
+        bytes memory callData = abi.encodeWithSignature('mint(address,uint256)', user, 1e18);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteAdapter(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.ZeroTarget.selector);
+        proxy.executeProposal(id, callData);
+    }
+
+    function test_proposeAdminExecuteAdapter_executesCallOnAdapter() public {
+        // 1. Set lzAdapter to a MockERC20 (its `mint(address,uint256)` is public).
+        MockERC20 adapter = new MockERC20('LZ Stub', 'LZS');
+        bytes32 idSet = _proposeUpdateLZAdapter(address(adapter));
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(idSet, abi.encode(address(adapter)));
+        assertEq(proxy.lzAdapter(), address(adapter));
+
+        // 2. Propose an AdminExecuteAdapter call: mint 1e18 to `recipient`.
+        bytes memory callData = abi.encodeWithSignature('mint(address,uint256)', recipient, 1e18);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteAdapter(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, callData);
+
+        assertEq(adapter.balanceOf(recipient), 1e18);
+    }
+
+    function test_proposeAdminExecuteAdapter_revertsOnEmptyCallData() public {
+        bytes memory callData = '';
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        // We can't really build a valid digest for empty calldata via the proxy's
+        // assembly-based selector load — just confirm the explicit guard fires.
+        bytes[] memory sigs = new bytes[](pks.length);
+        for (uint256 i = 0; i < pks.length; i++) sigs[i] = new bytes(65);
+
+        vm.expectRevert(IMultisigProxy.CallDataTooShort.selector);
+        proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeAdminExecuteAdapter_propagatesAdapterRevert() public {
+        // Adapter = MockERC20. Call a non-existent function so the fallback reverts.
+        MockERC20 adapter = new MockERC20('LZ Stub', 'LZS');
+        bytes32 idSet = _proposeUpdateLZAdapter(address(adapter));
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(idSet, abi.encode(address(adapter)));
+
+        bytes memory callData = abi.encodeWithSignature('nonExistent()');
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteAdapter(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        // MockERC20 has no fallback — call returns false and _propagateRevert bubbles up.
+        vm.expectRevert();
+        proxy.executeProposal(id, callData);
     }
 
     function test_domainSeparator_matchesHelper() public view {

--- a/ethereum/test/helpers/MultisigHelper.sol
+++ b/ethereum/test/helpers/MultisigHelper.sol
@@ -74,6 +74,14 @@ library MultisigHelper {
         'ProposeUpdateCommissionManager(address newCommissionManager,uint256 nonce,uint256 deadline)'
     );
 
+    bytes32 internal constant PROPOSE_ADMIN_EXECUTE_ADAPTER_TYPEHASH = keccak256(
+        'ProposeAdminExecuteAdapter(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
+    );
+
+    bytes32 internal constant PROPOSE_UPDATE_LZ_ADAPTER_TYPEHASH = keccak256(
+        'ProposeUpdateLZAdapter(address newLZAdapter,uint256 nonce,uint256 deadline)'
+    );
+
     /// @dev Builds the EIP-712 domain separator the same way MultisigProxy does.
     function domainSeparator(address verifyingContract, uint256 chainId) internal pure returns (bytes32) {
         return keccak256(abi.encode(
@@ -261,6 +269,29 @@ library MultisigHelper {
     ) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(
             PROPOSE_UPDATE_COMMISSION_MANAGER_TYPEHASH, newCm, nonce, deadline
+        )));
+    }
+
+    function digestProposeAdminExecuteAdapter(
+        bytes32 domainSep,
+        bytes4 selector,
+        bytes memory callData,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(
+            PROPOSE_ADMIN_EXECUTE_ADAPTER_TYPEHASH, selector, keccak256(callData), nonce, deadline
+        )));
+    }
+
+    function digestProposeUpdateLZAdapter(
+        bytes32 domainSep,
+        address newLZAdapter,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(
+            PROPOSE_UPDATE_LZ_ADAPTER_TYPEHASH, newLZAdapter, nonce, deadline
         )));
     }
 


### PR DESCRIPTION
Introduces two new federation-proposed operation types so **MultisigProxy** can govern the LZAdapter that routes Bridge.fundsIn calls from the LayerZero side:
  - AdminExecuteAdapter (opType=11): generic federation-controlled call into the registered lzAdapter (e.g. setTrustedEntrypoint, refundStuckFunds). Reverts ZeroTarget if lzAdapter is unset.
  - UpdateLZAdapter   (opType=12): rotates the stored lzAdapter address (zero is allowed and closes the AdminExecuteAdapter path).