### PR TITLE
Multisig router integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,27 +19,36 @@ The bridge transfers assets between the EVM side and Bitcoin-anchored networks (
 The EVM-side contracts in this repository are deployed on Arbitrum. Cross-chain delivery from other EVM networks is implemented by an external delivery layer that lives outside this repository — from the perspective of the contracts here, every deposit lands on Arbitrum and is treated identically regardless of where the user originated from.
 
 ```
-                 ┌─────────────────────────── Arbitrum ─────────────────────────────┐
-                 │                                                                  │
-                 │                                          Bridge ◀── BtcRelay     │
-                 │                                              │                   │
-                 │                              CommissionManager                   │
-                 │                                              ▲                   │
-                 │                                              │                   │
-                 │                                       MultisigProxy              │
-                 │                                  (TEE + Federation)              │
-                 └──────────────────────────────────────────────────────────────────┘
+        ┌──────────────────────────────── Arbitrum ─────────────────────────────────┐
+        │                                                                           │
+        │                       ┌─────────── RouteRegistry ────────────┐            │
+        │                       │  per-route (srcChainId, dstChainId): │            │
+        │                       │      FinalityVerifier + SettlementModule          │
+        │                       └──────────────────┬───────────────────┘            │
+        │                                          │                                │
+        │                                       Bridge                              │
+        │                                          │                                │
+        │                              CommissionManager                            │
+        │                                          ▲                                │
+        │                                          │                                │
+        │                                   MultisigProxy                           │
+        │                              (TEE + Federation)                           │
+        └───────────────────────────────────────────────────────────────────────────┘
 ```
 
 **Arbitrum — main contracts:**
 
-- **`Bridge`** — the value-holding contract. Locks the bridged ERC-20 on `fundsIn`, releases it on `fundsOut`. Emits the events that the backend watches to drive Bitcoin-side actions. Owned by `MultisigProxy`.
+- **`Bridge`** — the value-holding contract. Locks the bridged ERC-20 on `fundsIn`, releases it on `fundsOut`. Route-agnostic by design: it delegates all finality-verification and per-route bookkeeping to the registered plugin contracts (see `RouteRegistry` below), so adding a new destination chain (RGB, Arch, another EVM rollup, …) is a deploy-the-plugins + register-the-route operation rather than a Bridge upgrade. Emits the events that the backend watches to drive cross-chain actions. Owned by `MultisigProxy`.
+
+- **`RouteRegistry`** — the routing brain. For every supported `(sourceChainId, destChainId)` pair it stores two addresses: a `FinalityVerifier` and a `SettlementModule`. The `Bridge` calls into the registry on every transfer; the registry forwards to the right plugins. Routes are registered, paused, and rotated through federation governance (granular `SetRoute` proposals on `MultisigProxy`). Owned by `MultisigProxy`; `bridge` is immutable, so rotating the registry itself means redeploy + `UpdateRouteRegistry`.
+
+- **`FinalityVerifier`** — a per-route plugin consulted by `Bridge.fundsOut` to confirm that the source-side event justifying the release is final on its origin chain. The current production verifier is `RGBVerifier`, a wrapper around Atomiq's on-chain Bitcoin SPV light client (`BtcRelay`) — it stores Bitcoin block headers and validates proof-of-work continuity and the difficulty-retarget rules. This removes the need to trust any single oracle or off-chain attestation for Bitcoin finality: the EVM-side release is gated by Bitcoin's own consensus, observed on-chain. Routes that don't need finality verification (e.g. trusted-bridge EVM legs) use `NullVerifier`.
+
+- **`SettlementModule`** — a per-route plugin that owns route-specific state. For RGB-anchored transfers, `RgbSettlementModule` tracks per-`operationId` net deposit balances and consumes them on `fundsOut` (the double-spend / fake-event guard formerly built into `Bridge`). Routes whose settlement is handled entirely by an external delivery layer (e.g. LayerZero compose paths) use `NullSettlementModule`.
 
 - **`CommissionManager`** — a dedicated fee-accounting contract that holds the protocol's commissions strictly separated from bridge liquidity. The `Bridge` consults it on every transfer to determine the per-route commission (token vs. native; charged on `FundsIn` vs. `FundsOut`) and forwards the fee to it. Withdrawal is gated by federation governance through `MultisigProxy`. Owned by `MultisigProxy`.
 
-- **`MultisigProxy`** — the authorization layer. Owns both `Bridge` and `CommissionManager`. Two independent signer sets and two execution paths: TEE-authorized routine operations (`FundsOut`) execute immediately on M-of-N enclave signatures; federation-authorized administrative operations (signer rotation, configuration changes, commission withdrawal, contract address updates) go through a two-phase propose → timelock → execute flow. Emergency pause/unpause is the only federation operation that is instant.
-
-- **`BtcRelay`** — a trustless on-chain Bitcoin SPV light client. It stores Bitcoin block headers and validates them by checking proof-of-work continuity and the difficulty-retarget rules. The `Bridge` consults `BtcRelay` on `fundsOut` to confirm that the corresponding Bitcoin-side event (the RGB transfer that justifies the release) is anchored in a Bitcoin block with sufficient confirmations. This removes the need to trust any single oracle or off-chain attestation for Bitcoin finality: the EVM-side release of funds is gated by Bitcoin's own consensus, observed on-chain.
+- **`MultisigProxy`** — the authorization layer. Owns `Bridge`, `RouteRegistry`, and `CommissionManager`. Two independent signer sets and two execution paths: TEE-authorized routine operations (`FundsOut`) execute immediately on M-of-N enclave signatures; federation-authorized administrative operations (signer rotation, configuration changes, commission withdrawal, route registration, contract address updates) go through a two-phase propose → timelock → execute flow. Emergency pause/unpause is the only federation operation that is instant.
 
 ### Signing model
 
@@ -66,4 +75,4 @@ Each transfer deducts a service commission, configured per-route: source side (`
 
 ### Replay protection
 
-Each network enforces replay protection at the smart-contract level. On EVM the `Bridge` uses operation-id mappings for `FundsIn` and per-selector sequential nonces on `MultisigProxy.execute` (plus a sequential `batchNonce` on `executeBatch`) for `FundsOut`. In addition, every `FundsOut` call carries the `burnId` extracted from the source-side burn consignment; the `Bridge` records consumed `burnId`s on-chain and rejects any future `FundsOut` referencing the same id.
+Each network enforces replay protection at the smart-contract level. On EVM the `Bridge` records consumed `burnId`s on-chain (each `FundsOut` carries the `burnId` extracted from the source-side burn consignment and is rejected if already seen) and `MultisigProxy` enforces per-selector sequential nonces on `execute` plus a sequential `batchNonce` on `executeBatch`. Route-specific bookkeeping — e.g. matching `FundsOut` against the exact source-side deposits being settled — lives in the per-route `SettlementModule` (for the RGB route, `RgbSettlementModule` tracks net deposit balances and consumes them atomically with the release).

--- a/ethereum/.env.deploy.example
+++ b/ethereum/.env.deploy.example
@@ -45,6 +45,11 @@ LZ_ADAPTER=0x0000000000000000000000000000000000000000
 # computes it on the fly).
 COMMISSION_MANAGER=
 
+# RouteRegistry address — only needed for step-by-step Bridge redeploys against
+# an existing registry. DeployAll predicts and deploys a fresh registry pinned
+# to the predicted Bridge address.
+ROUTE_REGISTRY_ADDRESS=
+
 # -----------------------------------------------------------------------------
 # CommissionManager — Chainlink ETH/USD feed (NATIVE-currency commissions)
 # -----------------------------------------------------------------------------

--- a/ethereum/.env.interact.example
+++ b/ethereum/.env.interact.example
@@ -34,29 +34,49 @@ BASE_BRIDGE_ADDRESS=
 # Token base units (wei for 18-decimal tokens; for 6-decimal USDT0 → 1 USDT = 1_000_000)
 AMOUNT=
 
-# Backend-assigned operation identifier (replay-protected on Bridge.fundsIn /
-# referenced on Bridge.fundsOut as the recorded fundsIn id).
+# Backend-assigned operation identifier (recorded by the route's settlement
+# module on fundsIn; referenced from fundsOut.settlementData for routes that
+# consume deposits, e.g. RGB).
 OPERATION_ID=
 
-DESTINATION_CHAIN=rgb
+# Destination chain id (uint256). EVM legs = real chain id; non-EVM endpoints
+# use backend-assigned ids in a reserved namespace above 2^32 (RGB = 1000001).
+DESTINATION_CHAIN_ID=1000001
 DESTINATION_ADDRESS=
 
 # -----------------------------------------------------------------------------
-# fundsOut parameters (MultisigExecuteFundsOut.s.sol / BaseBridgeFundsOut.s.sol)
+# fundsOut parameters (MultisigExecuteFundsOut.s.sol)
 # -----------------------------------------------------------------------------
 
 RECIPIENT=
-SOURCE_CHAIN=rgb
-DEST_CHAIN=arbitrum
+SOURCE_CHAIN_ID=1000001
 SOURCE_ADDRESS=
 
-# Bitcoin-side burn replay guard + BtcRelay verification
+# Single-use burn consignment id from the source-side burn (Bridge-level
+# replay guard, route-agnostic).
 BURN_ID=
+
+# RGBVerifier proof inputs (packed as abi.encode(blockHeight, commitmentHash)
+# by MultisigExecuteFundsOut). Other verifiers use different blob layouts.
 BLOCK_HEIGHT=
 COMMITMENT_HASH=
 
-# Comma-separated list of fundsIn operationIds the fundsOut consumes (e.g. 42,43)
+# RgbSettlementModule settlementData inputs — comma-separated list of fundsIn
+# operationIds the fundsOut consumes (e.g. 42,43). Packed as
+# abi.encode(uint256[]) by the script. Other settlement modules use different
+# blob layouts.
 FUNDS_IN_IDS=
+
+# -----------------------------------------------------------------------------
+# MultisigProposeSetRoute parameters
+# -----------------------------------------------------------------------------
+
+# The (source, dest) pair the route key — same uint256 chain-id convention as above.
+# Reuses SOURCE_CHAIN_ID / DESTINATION_CHAIN_ID; just set ROUTE_ENABLED + plugin
+# addresses below.
+ROUTE_ENABLED=true
+FINALITY_VERIFIER=
+SETTLEMENT_MODULE=
 
 # -----------------------------------------------------------------------------
 # Multisig signing (TEE / Federation simulation for testnet)

--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -21,39 +21,52 @@ Minimal bridge for integrators. Inherits `BridgeBase`.
 - `fundsIn(amount, operationId)` — open, no signature required. Locks tokens and emits `FundsIn`.
 - `fundsOut(recipient, amount, operationId, sourceAddress)` — `onlyOwner`. Releases tokens and emits `FundsOut`.
 
-No TEE verification, no destination chain field, **no commission integration**. Suitable for integrations where the owner is a standard multisig or EOA.
+No TEE verification, no destination chain field, **no commission integration**, **no route plugins**. Suitable for integrations where the owner is a standard multisig or EOA.
 
 ### Bridge (`src/Bridge.sol`)
 
-Production bridge for UTEXO. Inherits `BridgeBase`, implements `IBridge`.
+Production bridge for UTEXO. Inherits `BridgeBase`, implements `IBridge`. Route-agnostic: all per-route logic (finality verification, settlement bookkeeping) is delegated to plugins registered in `RouteRegistry`.
 
-Constructor takes four immutable addresses/values: the accepted ERC-20 token, the BtcRelay contract, the CommissionManager, and the initial LayerZero adapter (`address(0)` is allowed — wire it in later via federation governance). The bridge's own chain identifier is `block.chainid` — chain IDs are uint256 throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
+Constructor takes four addresses: the accepted ERC-20 token (immutable), the `RouteRegistry` (mutable — federation can rotate via `UpdateRouteRegistry`), the `CommissionManager` (immutable), and the initial LayerZero adapter (mutable; `address(0)` is allowed — wire it in later via federation governance). The bridge's own chain identifier is `block.chainid` — chain IDs are `uint256` throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
 
-- `fundsIn(amount, destinationChainId, destinationAddress, operationId)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must equal the quoted native commission. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and stores `operationId => netAmount` in `fundsInRecords`. Emits two events:
+- `fundsIn(amount, destinationChainId, destinationAddress, operationId, settlementData)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must equal the quoted native commission. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and dispatches to the route's `SettlementModule.onFundsIn(...)` via `RouteRegistry`. The `settlementData` blob is opaque to the bridge — its layout is dictated by the destination route's settlement module (empty for routes that don't consume extra data on inbound, e.g. RGB). Emits two events:
   - `FundsIn` (from `BridgeBase`) — minimal, uses `netAmount`.
   - `BridgeFundsIn` (from `IBridge`) — full, consumed by the UTEXO backend.
-- `fundsInFromAdapter(amount, destinationChainId, destinationAddress, operationId, sourceChainId)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating `msg.sender` on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` to the bridge. Otherwise identical semantics to `fundsIn`.
-- `setLZAdapter(adapter)` — `onlyOwner`. Rotates the address authorized to call `fundsInFromAdapter`. Set to `address(0)` to close the adapter path entirely.
-- `fundsOut(recipient, amount, operationId, burnId, sourceChainId, destChainId, sourceAddress, blockHeight, commitmentHash, fundsInIds)` — `onlyOwner`, called via `MultisigProxy.execute()` or `MultisigProxy.executeBatch()`. All ten parameters are `uint256` except `recipient` (address), `sourceAddress` (string), `commitmentHash` (bytes32), and the `fundsInIds` array. Checks `burnId` has not been consumed yet (single-use replay guard, marks it consumed before any external interaction), verifies referenced fundsIn operations exist on-chain (prevents double-spend and fake event attacks on TEE), verifies the Bitcoin block header via BtcRelay, quotes commission from `CommissionManager` using `(sourceChainId, destChainId, TOKEN)`, forwards any token commission to the pool, and releases `netAmount` to the recipient. Emits `BridgeFundsOut`. NATIVE commission on `fundsOut` is disallowed (the caller is the multisig, not a user) — the contract reverts `NativeCommissionNotAllowedOnFundsOut`.
+- `fundsIn(amount, sourceChainId, destinationChainId, destinationAddress, operationId, settlementData)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating `msg.sender` on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` to the bridge. Otherwise identical semantics to `fundsIn`.
+- `setLZAdapter(adapter)` — `onlyOwner`. Rotates the address authorized to call the adapter overload. Set to `address(0)` to close the adapter path entirely.
+- `setRouteRegistry(newRouteRegistry)` — `onlyOwner`. Rotates the `RouteRegistry` Bridge talks to. Used to migrate to a redeployed registry (the registry's `bridge` is immutable, so a new registry deploy is the only way to rotate). Reverts on `address(0)`.
+- `fundsOut(recipient, amount, burnId, sourceChainId, destChainId, sourceAddress, proof, settlementData)` — `onlyOwner`, called via `MultisigProxy.execute()` or `MultisigProxy.executeBatch()`. The four scalar amounts (`amount`, `burnId`, `sourceChainId`, `destChainId`) are `uint256`; `recipient` is an address; `sourceAddress` is a string; `proof` and `settlementData` are opaque `bytes` blobs whose layouts are dictated by the route's `FinalityVerifier` and `SettlementModule` respectively. Checks `burnId` has not been consumed yet (single-use replay guard, marks it consumed before any external interaction), calls `RouteRegistry.beforeFundsOut(...)` which routes into `FinalityVerifier.verify(proof)` and `SettlementModule.beforeFundsOut(settlementData, amount)`, quotes commission from `CommissionManager` using `(sourceChainId, destChainId, TOKEN)`, forwards any token commission to the pool, and releases `netAmount` to the recipient. Emits `BridgeFundsOut`. NATIVE commission on `fundsOut` is disallowed (the caller is the multisig, not a user) — the contract reverts `NativeCommissionNotAllowedOnFundsOut`.
 
 Owner **must** be `MultisigProxy`. `fundsOut` is only reachable through `MultisigProxy.execute()` (single-call) or `MultisigProxy.executeBatch()` (atomic multi-call, e.g. `Bridge.fundsOut` + `LZAdapter.sendOut` for outbound to non-Arbitrum), both of which require M-of-N TEE signatures.
 
-#### FundsIn records (double-spend protection)
-
-Every `fundsIn` stores `operationId => netAmount` in the `fundsInRecords` mapping. During `fundsOut`, TEE supplies an array of `fundsInIds` referencing specific deposits. The contract verifies each ID exists, then **partially consumes** them in order: full records are deleted; the last record on the chain is decremented if its remaining balance exceeds the requested `amount` so the surplus stays available for future `fundsOut` calls. This prevents:
-- **Fake event attacks:** a malicious node operator cannot feed fake `BridgeFundsIn` events to TEE — the contract is the source of truth.
-- **Double-spend:** every wei of net liquidity is referenced by exactly one record at all times.
-- **Liquidity loss:** partial consumption preserves the residual on the same `operationId` rather than discarding it.
-
-Note: records store the **net** amount (post-commission), i.e. the actual bridged liquidity. Gross amounts are available in the `BridgeFundsIn` event for backend bookkeeping.
-
 #### Burn-id replay guard (single-use)
 
-Every `fundsOut` call carries a `burnId` — an identifier the backend extracts from the source-side burn consignment. The `Bridge` keeps a `consumedBurnIds` mapping and **rejects** any call whose `burnId` is already recorded (`BurnIdAlreadyConsumed`). The flag is set before any token transfer (CEI ordering), so a revert anywhere downstream rolls the mark back together with the rest of the call. This complements `MultisigProxy`'s per-selector nonce: nonces stop a signature bundle from being executed twice, while `burnId` stops the same logical burn from being settled twice even under independent signature bundles.
+Every `fundsOut` call carries a `burnId` — an identifier the backend extracts from the source-side burn consignment. The `Bridge` keeps a `consumedBurnIds` mapping and **rejects** any call whose `burnId` is already recorded (`BurnIdAlreadyConsumed`). The flag is set before any token transfer (CEI ordering), so a revert anywhere downstream rolls the mark back together with the rest of the call. This complements `MultisigProxy`'s per-selector nonce: nonces stop a signature bundle from being executed twice, while `burnId` stops the same logical burn from being settled twice even under independent signature bundles. It also complements each route's `SettlementModule` bookkeeping (e.g. `RgbSettlementModule` consumes `fundsInIds`); `burnId` is the chain-agnostic guard, the module guard is route-specific.
 
-#### BtcRelay integration
+### RouteRegistry (`src/RouteRegistry.sol`)
 
-`fundsOut` calls `IBtcRelayView(btcRelay).verifyBlockheaderHash(blockHeight, commitmentHash)` and reverts if the block is unknown to the relay. The TEE backend supplies `blockHeight` and `commitmentHash` as part of the signed call data. This adds a trustless Bitcoin verification layer — the relay must have seen the block header before funds can be released.
+The routing brain. For every supported `(sourceChainId, destChainId)` pair it stores `(FinalityVerifier, SettlementModule, enabled)`. The `Bridge` calls `onFundsIn` and `beforeFundsOut` on the registry; the registry forwards to the right plugins after gating on `enabled`. The registry's `bridge` is **immutable** (set in the constructor) — rotating it means deploying a new registry and pointing the Bridge at it via `UpdateRouteRegistry`.
+
+- `setRoute(sourceChainId, destChainId, enabled, finalityVerifier, settlementModule)` — `onlyOwner`. Sets or updates a route. Pause-in-place: pass `enabled=false` to keep the plugin addresses on file but reject new traffic; re-enable later by passing `true` again with the same (or new) plugin addresses. Reverts on either plugin being `address(0)`.
+- `onFundsIn(ctx)` / `beforeFundsOut(ctx)` — `onlyBridge`. Dispatchers. Read the route for `(ctx.sourceChainId, ctx.destChainId)`, revert `RouteDisabled` if not enabled, then call into the route's plugins. Unknown route → `RouteNotFound`.
+
+Owned by `MultisigProxy`. Federation manages the route table through granular `SetRoute` proposals (see governance table below).
+
+### FinalityVerifier plugins (`src/verifiers/`)
+
+Per-route plugin called by `RouteRegistry.beforeFundsOut`. Interface: `function verify(bytes proof) external view`.
+
+- **`RGBVerifier`** — production verifier for the RGB route. Wraps Atomiq's on-chain Bitcoin SPV light client (`BtcRelay`): expects `proof = abi.encode(uint256 blockHeight, bytes32 commitmentHash)`, calls `IBtcRelayView(btcRelay).verifyBlockheaderHash(...)`, and reverts if the block is unknown to the relay. The TEE backend supplies `blockHeight` and `commitmentHash` as part of the signed call data.
+- **`NullVerifier`** — stateless no-op. Used by routes where finality is enforced upstream (e.g. trusted-bridge EVM legs delivered through LayerZero). Stateless ⇒ no auth; `verify` is a no-op.
+
+Adding a new finality source (e.g. an Arch light client) is just a new verifier contract + a `SetRoute` proposal.
+
+### SettlementModule plugins (`src/settlement/`)
+
+Per-route plugin that owns route-specific bookkeeping. Interface: `onFundsIn(ctx)` + `beforeFundsOut(ctx)`, both invoked by `RouteRegistry` on behalf of the Bridge.
+
+- **`RgbSettlementModule`** — production module for the RGB route. On `fundsIn`, stores `operationId => netAmount` so backend operators have an authoritative on-chain ledger of deposits. On `fundsOut`, expects `settlementData = abi.encode(uint256[] fundsInIds)`, walks the array, and partially consumes the referenced deposits in order: full records are deleted; the last record is decremented if its remaining balance exceeds the requested `amount` so the surplus stays available for future calls. This prevents (a) **fake event attacks** — a malicious node operator cannot feed fake `BridgeFundsIn` events to TEE because the contract is the source of truth; (b) **double-spend** — every wei of net liquidity is referenced by exactly one record at all times; (c) **liquidity loss** — partial consumption preserves the residual on the same `operationId`. Auth: `onlyRouteRegistry`.
+- **`NullSettlementModule`** — stateless no-op. Used by routes whose settlement is handled entirely by an external delivery layer (e.g. LayerZero compose) or by routes whose verifier already binds the release to a specific deposit. Stateless ⇒ no auth.
 
 ### CommissionManager (`src/CommissionManager.sol`)
 
@@ -61,15 +74,15 @@ Standalone fee contract. Holds protocol commissions separately from bridge liqui
 
 - **Route keys** are `keccak256(abi.encode(sourceChainId, destChainId, token))` where both chain IDs are `uint256` — directional, so each leg of a round trip can have its own config. EVM legs use `block.chainid`; non-EVM endpoints get backend-assigned IDs in a reserved namespace (e.g. `RGB = 1_000_001`).
 - **Config** selects per route: `side` (`FUNDS_IN` vs `FUNDS_OUT`), `currency` (`TOKEN` vs `NATIVE`), `stablePercent` (×100, capped at 9000 = 90%), and `multiplier`. Global defaults apply to any route without an override.
-- **NATIVE quotes** use an owner-set mock wei-per-token rate (global or per-token) and the token's `decimals()`.
+- **NATIVE quotes** use a Chainlink ETH/USD aggregator (`setEthUsdFeed(feed, heartbeat)`) and the token's `decimals()`. Heartbeat enforces staleness; absent feed ⇒ NATIVE quotes revert.
 - **Ingress:** `receiveTokenCommission(token)` and `receive()` are gated by `onlyBridge` — only `Bridge` may credit commissions. Pools are updated from balance deltas, so fee-on-transfer tokens are supported.
-- **Owner** (`MultisigProxy` in production) configures rules, updates `bridgeAddress`, and withdraws accumulated pools. `renounceOwnership` is blocked.
+- **Owner** (`MultisigProxy` in production) configures rules, updates `bridgeAddress`, wires the ETH/USD feed, and withdraws accumulated pools. `renounceOwnership` is blocked.
 
 ### MultisigProxy (`src/MultisigProxy.sol`)
 
-Owner of `Bridge` **and** `CommissionManager`. Two-level ECDSA M-of-N multisig:
+Owner of `Bridge`, `RouteRegistry`, **and** `CommissionManager`. Two-level ECDSA M-of-N multisig:
 
-- **Enclave signers (TEE)** — authorize `execute()` (single-call) and `executeBatch()` (atomic multi-call) calls (M-of-N, bitmap encoding). Used for `fundsOut` (and outbound `LZAdapter.sendOut` paired in a batch). Per-selector sequential nonces prevent replay on `execute`; a sequential `batchNonce` does the same for `executeBatch`. The TEE allowlist is keyed on `(target, selector)` pairs (`teeAllowedCalls`), enabling atomic multi-target batches without granting TEE blanket admin power.
+- **Enclave signers (TEE)** — authorize `execute()` (single-call) and `executeBatch()` (atomic multi-call) calls (M-of-N, bitmap encoding). Used for `fundsOut` (and outbound `LZAdapter.sendOut` paired in a batch). Per-selector sequential nonces prevent replay on `execute`; a sequential `batchNonce` does the same for `executeBatch`. The TEE allowlist is keyed on `(target, selector)` pairs (`teeAllowedCalls`), enabling atomic multi-target batches without granting TEE blanket admin power. Default allowlist seeded in the constructor: `Bridge.fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)`.
 - **Federation signers (governance)** — two-phase timelock for admin operations. Instant `emergencyPause` / `emergencyUnpause` bypass the timelock.
 
 Federation-controlled operations (`OperationType`):
@@ -83,36 +96,37 @@ Federation-controlled operations (`OperationType`):
 | `SetCommissionRecipient` | self | Change destination address for CM withdrawals |
 | `SetTeeAllowedCall` | self | Add/remove a `(target, selector)` pair from the TEE allowlist |
 | `SetTimelockDuration` | self | Adjust the timelock window |
-| `AdminExecuteCommissionManager` | CommissionManager | Generic call into CM (route rules, global defaults, mock rates, `transferOwnership`, …) |
+| `AdminExecuteCommissionManager` | CommissionManager | Generic call into CM (route rules, global defaults, ETH/USD feed, `transferOwnership`, …) |
 | `WithdrawTokenCommissionCM` | CommissionManager | Withdraw ERC-20 commission to `commissionRecipient` |
 | `WithdrawNativeCommissionCM` | CommissionManager | Withdraw native commission to `commissionRecipient` |
 | `UpdateCommissionManager` | self | Migrate to a redeployed CommissionManager |
 | `AdminExecuteAdapter` | LZAdapter | Generic call into the registered LayerZero adapter (`setTrustedEntrypoint`, `refundStuckFunds`, …). Reverts `ZeroTarget` if `MultisigProxy.lzAdapter` is unset. |
 | `UpdateLZAdapter` | self | Rotate `MultisigProxy.lzAdapter` — the routing target for `AdminExecuteAdapter`. Setting to `address(0)` closes the adapter-admin path. |
+| `SetRoute` | RouteRegistry | Register, update, pause, or re-enable a single `(sourceChainId, destChainId)` route on the registry. The opData encodes `(src, dst, enabled, verifier, module)`. |
+| `UpdateRouteRegistry` | Bridge | Rotate `Bridge.routeRegistry` to a redeployed registry. Used when a new registry must be deployed (the registry's `bridge` is immutable). |
 
-Note: `MultisigProxy.lzAdapter` and `Bridge.lzAdapter` are **separate** fields with different roles. `Bridge.lzAdapter` gates `fundsInFromAdapter` (data path); `MultisigProxy.lzAdapter` is the target of `AdminExecuteAdapter` proposals (governance path). Both default to `address(0)` and are wired in by federation after the adapter is deployed.
+Note: `MultisigProxy.lzAdapter` and `Bridge.lzAdapter` are **separate** fields with different roles. `Bridge.lzAdapter` gates the adapter `fundsIn` overload (data path); `MultisigProxy.lzAdapter` is the target of `AdminExecuteAdapter` proposals (governance path). Both default to `address(0)` and are wired in by federation after the adapter is deployed.
 
 ## How it works
 
 ### FundsIn (user deposits)
 
 1. The user (or frontend) quotes commission from `CommissionManager.calculateFundsInCommission(sourceChainId, destinationChainId, token, amount)`. EVM users pass `block.chainid` as `sourceChainId`.
-2. The user approves `amount` to `Bridge` and calls `Bridge.fundsIn{ value: nativeCommission }(amount, destinationChainId, destinationAddress, operationId)`. No signature required — any user can lock tokens. Cross-chain (LayerZero compose) deposits land through `Bridge.fundsInFromAdapter(...)` instead, called by the trusted `LZAdapter` with an authenticated `sourceChainId`. Validation of the destination address and chain happens off-chain on the UTEXO backend before minting on the other side.
-3. Bridge pulls `amount` in tokens, forwards `tokenCommission` and `nativeCommission` (if any) to `CommissionManager`, stores `netAmount = amount - tokenCommission` in `fundsInRecords`, and emits `FundsIn` + `BridgeFundsIn`.
+2. The user approves `amount` to `Bridge` and calls `Bridge.fundsIn{ value: nativeCommission }(amount, destinationChainId, destinationAddress, operationId, settlementData)`. No signature required — any user can lock tokens. `settlementData` is empty for the RGB route and any other route whose module ignores inbound data. Cross-chain (LayerZero compose) deposits land through the `fundsIn(amount, sourceChainId, ...)` adapter overload instead, called by the trusted `LZAdapter` with an authenticated `sourceChainId`.
+3. Bridge pulls `amount` in tokens, forwards `tokenCommission` and `nativeCommission` (if any) to `CommissionManager`, dispatches to the route's `SettlementModule.onFundsIn` via `RouteRegistry` (which may e.g. record the net deposit), and emits `FundsIn` + `BridgeFundsIn`.
 
 ### FundsOut (bridge withdrawals)
 
-`Bridge.fundsOut()` is `onlyOwner`, where the owner is `MultisigProxy`. The backend collects M-of-N ECDSA signatures from TEE signers over an EIP-712 `BridgeOperation` message (selector, callData, nonce, deadline). The call data includes `burnId` (replay guard for the source-side burn), `blockHeight` and `commitmentHash` for BtcRelay verification, plus `destChainId` so CommissionManager can pick the right outbound route. `MultisigProxy.execute()` verifies the signatures on-chain and forwards the call to `Bridge`, which then:
+`Bridge.fundsOut()` is `onlyOwner`, where the owner is `MultisigProxy`. The backend collects M-of-N ECDSA signatures from TEE signers over an EIP-712 `BridgeOperation` message (selector, callData, nonce, deadline). The call data includes `burnId` (chain-agnostic replay guard) plus the two opaque blobs `proof` (consumed by the route's `FinalityVerifier`) and `settlementData` (consumed by the route's `SettlementModule`), plus `sourceChainId` and `destChainId` so both `RouteRegistry` and `CommissionManager` can pick the right route. `MultisigProxy.execute()` verifies the signatures on-chain and forwards the call to `Bridge`, which then:
 
 1. Checks `burnId` has not been consumed yet and marks it consumed (replay guard).
-2. Verifies the referenced `fundsInIds` exist and consumes them.
-3. Verifies the Bitcoin block header against BtcRelay.
-4. Quotes outbound commission via `CommissionManager.calculateFundsOutCommission(sourceChainId, destChainId, token, amount)`.
-5. Forwards any token commission to `CommissionManager` and releases `netAmount` to the recipient.
+2. Calls `RouteRegistry.beforeFundsOut(...)` — which gates on the route being `enabled`, calls `FinalityVerifier.verify(proof)` (for RGB: `BtcRelay.verifyBlockheaderHash`), then `SettlementModule.beforeFundsOut(settlementData, amount)` (for RGB: consumes the referenced `fundsInIds`).
+3. Quotes outbound commission via `CommissionManager.calculateFundsOutCommission(sourceChainId, destChainId, token, amount)`.
+4. Forwards any token commission to `CommissionManager` and releases `netAmount` to the recipient.
 
 ### Federation governance (two-phase timelock)
 
-Administrative operations (signer rotation, configuration changes, commission withdrawals) go through:
+Administrative operations (signer rotation, configuration changes, commission withdrawals, route registration) go through:
 
 1. **Propose.** A federation member submits the operation with M-of-N federation signatures. `MultisigProxy` stores the operation hash and emits `ProposalCreated`. Nothing is executed yet.
 2. **Execute.** After `timelockDuration` elapses, anyone calls `executeProposal()` with the original data. `MultisigProxy` verifies the hash, confirms the timelock, and executes.
@@ -164,49 +178,70 @@ set -a && source .env.interact && set +a   # before interact scripts
 
 **Key deploy variables** (`.env.deploy`):
 - `USDT0_ADDRESS` — accepted ERC-20 token
-- `BTC_RELAY_ADDRESS` — Atomiq BtcRelay contract address
+- `BTC_RELAY_ADDRESS` — Atomiq BtcRelay contract address (consumed by `RGBVerifier`)
 - `LZ_ADAPTER` — initial LayerZero adapter address (optional; pass `0x0` if the adapter has not been deployed yet, then wire it in via federation governance after the adapter ships)
+- `ROUTE_REGISTRY_ADDRESS` — `RouteRegistry` address (step-by-step Bridge redeploys only; `DeployAll` predicts it)
 - `COMMISSION_MANAGER` — `CommissionManager` address (step-by-step deploys only)
 - `COMMISSION_RECIPIENT` — destination for CM withdrawals
+- `ETH_USD_FEED` / `ETH_USD_HEARTBEAT` — Chainlink ETH/USD aggregator + staleness window (required if any route uses NATIVE commission)
 - `ENCLAVE_SIGNERS` / `FEDERATION_SIGNERS` — comma-separated addresses, ordered by bitmap bit index
+- `ENCLAVE_THRESHOLD` / `FEDERATION_THRESHOLD` — M-of-N thresholds
 - `TIMELOCK_DURATION` — federation timelock window in seconds
 
-> Chain identifiers are `uint256` everywhere — `block.chainid` for EVM legs, backend-assigned values for non-EVM endpoints. There is no `SOURCE_CHAIN_NAME` env var anymore; the bridge reads `block.chainid` at runtime.
+> Chain identifiers are `uint256` everywhere — `block.chainid` for EVM legs, backend-assigned values for non-EVM endpoints (e.g. RGB = `1_000_001`). There is no `SOURCE_CHAIN_NAME` env var anymore; the bridge reads `block.chainid` at runtime.
 
 **Key interact variables** (`.env.interact`):
 - `BRIDGE_ADDRESS`, `PROXY_ADDRESS`, `BASE_BRIDGE_ADDRESS` — deployed contracts
-- `OPERATION_ID` — backend-assigned operation id (replay guard)
-- `BURN_ID`, `BLOCK_HEIGHT`, `COMMITMENT_HASH`, `FUNDS_IN_IDS` — fundsOut-only inputs
-- `DEST_CHAIN_ID` — destination chain id (`uint256`) used by `MultisigExecuteFundsOut.s.sol` when building calldata
+- `OPERATION_ID` — backend-assigned operation id
+- `BURN_ID` — single-use burn consignment id (fundsOut)
+- `SOURCE_CHAIN_ID` / `DESTINATION_CHAIN_ID` — `uint256` chain ids used when building calldata
+- `BLOCK_HEIGHT`, `COMMITMENT_HASH` — RGB-route `proof` inputs (packed as `abi.encode(blockHeight, commitmentHash)` by the script)
+- `FUNDS_IN_IDS` — RGB-route `settlementData` inputs (packed as `abi.encode(uint256[])` by the script)
+- `FINALITY_VERIFIER` / `SETTLEMENT_MODULE` / `ROUTE_ENABLED` / `DEADLINE_OFFSET` — `MultisigProposeSetRoute` inputs
 - `ENCLAVE_PKS` / `FED_PKS` — comma-separated private keys for local TEE/federation simulation
+- `ENCLAVE_BITMAP` / `FED_BITMAP` — participating-signer bitmaps
 
 ## Deployment
 
 All deploy scripts live in `script/deploy/`. They read their inputs from `.env.deploy`.
 
-### Option A — Full production (CM + Bridge + MultisigProxy + ownership transfer)
+### Option A — Full production (CM + RouteRegistry + Bridge + plugins + MultisigProxy + ownership transfer)
 
 ```sh
 forge script script/deploy/DeployAll.s.sol \
   --rpc-url $RPC_URL --broadcast --verify
 ```
 
-Predicts the Bridge address from the deployer's future nonce, deploys `CommissionManager` referencing that address, deploys `Bridge` with the live `CommissionManager`, deploys `MultisigProxy` owning both, and transfers ownership of `Bridge` and `CommissionManager` to `MultisigProxy` in a single tx batch.
+Predicts the Bridge address from the deployer's future nonce, deploys in order:
+
+1. `CommissionManager` (pinned to the predicted Bridge)
+2. `RouteRegistry` (pinned to the predicted Bridge, deployer-owned for this batch)
+3. `Bridge` (with the live `RouteRegistry` + `CommissionManager`)
+4. `RGBVerifier` (wraps the BtcRelay)
+5. `RgbSettlementModule` (paired with `RouteRegistry`)
+6. `MultisigProxy`
+7. (optional) `CommissionManager.setEthUsdFeed`
+8. `CommissionManager` / `Bridge` / `RouteRegistry` `transferOwnership` → `MultisigProxy`
+
+**Routes are not registered here.** Federation must run `MultisigProposeSetRoute` for each supported `(sourceChainId, destChainId)` pair before any traffic is accepted — mirrors the permanent governance path.
 
 ### Option B — Step-by-step
 
 ```sh
-# 1. Deploy Bridge, then deploy CommissionManager pointing at it (or deploy CM first
-#    with a placeholder address and call setBridgeAddress afterwards). Use DeployAll for
-#    production — the step-by-step path is for special cases.
-forge script script/deploy/DeployBridge.s.sol              --rpc-url $RPC_URL --broadcast --verify
-forge script script/deploy/DeployCommissionManager.s.sol   --rpc-url $RPC_URL --broadcast --verify
-forge script script/deploy/DeployMultisigProxy.s.sol       --rpc-url $RPC_URL --broadcast --verify
+forge script script/deploy/DeployCommissionManager.s.sol     --rpc-url $RPC_URL --broadcast --verify
+forge script script/deploy/DeployRouteRegistry.s.sol         --rpc-url $RPC_URL --broadcast --verify
+forge script script/deploy/DeployBridge.s.sol                --rpc-url $RPC_URL --broadcast --verify
+forge script script/deploy/DeployRGBVerifier.s.sol           --rpc-url $RPC_URL --broadcast --verify
+forge script script/deploy/DeployRgbSettlementModule.s.sol   --rpc-url $RPC_URL --broadcast --verify
+forge script script/deploy/DeployMultisigProxy.s.sol         --rpc-url $RPC_URL --broadcast --verify
 
-# 2. Transfer Bridge and CommissionManager ownership to MultisigProxy
-cast send $BRIDGE_ADDRESS     "transferOwnership(address)" $PROXY_ADDRESS --rpc-url $RPC_URL --private-key $PRIVATE_KEY
-cast send $COMMISSION_MANAGER "transferOwnership(address)" $PROXY_ADDRESS --rpc-url $RPC_URL --private-key $PRIVATE_KEY
+# Transfer ownerships to MultisigProxy
+cast send $BRIDGE_ADDRESS         "transferOwnership(address)" $PROXY_ADDRESS --rpc-url $RPC_URL --private-key $PRIVATE_KEY
+cast send $COMMISSION_MANAGER     "transferOwnership(address)" $PROXY_ADDRESS --rpc-url $RPC_URL --private-key $PRIVATE_KEY
+cast send $ROUTE_REGISTRY_ADDRESS "transferOwnership(address)" $PROXY_ADDRESS --rpc-url $RPC_URL --private-key $PRIVATE_KEY
 ```
+
+Note: `RouteRegistry.bridge` is immutable. The step-by-step path either (a) deploys `RouteRegistry` first against a predicted Bridge address, or (b) is reserved for replacing Bridge against an existing registry — uncommon. Use `DeployAll` for greenfield deployments.
 
 ### Option C — BaseBridge (integrators, e.g. Bitfinex)
 
@@ -214,7 +249,7 @@ cast send $COMMISSION_MANAGER "transferOwnership(address)" $PROXY_ADDRESS --rpc-
 forge script script/deploy/DeployBaseBridge.s.sol --rpc-url $RPC_URL --broadcast --verify
 ```
 
-Deploys `BaseBridge` with `TOKEN_ADDRESS`. The deployer becomes the initial owner; transfer to the integrator's multisig after deployment. `BaseBridge` has no dependency on `MultisigProxy` or `CommissionManager` — use any multisig or EOA as owner.
+Deploys `BaseBridge` with `TOKEN_ADDRESS`. The deployer becomes the initial owner; transfer to the integrator's multisig after deployment. `BaseBridge` has no dependency on `MultisigProxy`, `RouteRegistry`, or `CommissionManager` — use any multisig or EOA as owner.
 
 ## Interaction scripts
 
@@ -223,9 +258,8 @@ Scripts in `script/interact/` let you exercise contracts manually before the bac
 | Script | What it does |
 |---|---|
 | `BridgeFundsIn.s.sol` | Quotes commission from `CommissionManager`, approves tokens and calls `Bridge.fundsIn{ value: nativeCommission }(...)` |
-| `BaseBridgeFundsIn.s.sol` | Approves tokens and calls `BaseBridge.fundsIn(amount, operationId)` |
-| `BaseBridgeFundsOut.s.sol` | Calls `BaseBridge.fundsOut()` as owner |
-| `MultisigExecuteFundsOut.s.sol` | Signs a `Bridge.fundsOut()` locally with `ENCLAVE_PKS` (10-arg `uint256`-chain-id signature including `destChainId`, `sourceChainId` and `burnId`) and submits via `MultisigProxy.execute()` |
+| `MultisigExecuteFundsOut.s.sol` | Signs a `Bridge.fundsOut()` locally with `ENCLAVE_PKS` (8-arg signature: `recipient, amount, burnId, sourceChainId, destChainId, sourceAddress, proof, settlementData`) and submits via `MultisigProxy.execute()`. Packs `proof = abi.encode(blockHeight, commitmentHash)` (RGBVerifier layout) and `settlementData = abi.encode(fundsInIds[])` (RgbSettlementModule layout). |
+| `MultisigProposeSetRoute.s.sol` | Signs and submits a `proposeSetRoute(...)` federation proposal on `MultisigProxy`. Intentionally does **not** call `executeProposal` — prints the `proposalId` + the `opData` blob for the operator to run `cast send` after the timelock. First federation step after `DeployAll`. |
 | `EmergencyPause.s.sol` | Signs and submits `MultisigProxy.emergencyPause()` with `FED_PKS` |
 | `EmergencyUnpause.s.sol` | Signs and submits `MultisigProxy.emergencyUnpause()` with `FED_PKS` |
 
@@ -235,56 +269,76 @@ Example:
 forge script script/interact/BridgeFundsIn.s.sol --rpc-url $RPC_URL --broadcast
 ```
 
-> **Security note:** `MultisigExecuteFundsOut` signs with local private keys from `.env.interact`. Only use for testnet and local end-to-end checks. In production, TEE enclaves produce signatures; this script just simulates that flow.
+> **Security note:** `MultisigExecuteFundsOut` and `MultisigProposeSetRoute` sign with local private keys from `.env.interact`. Only use for testnet and local end-to-end checks. In production, TEE enclaves and federation members produce signatures; these scripts just simulate that flow.
 
 ## Post-deployment checklist
 
 1. Verify Bridge ownership: `Bridge.owner()` returns the `MultisigProxy` address.
-2. Verify CommissionManager ownership: `CommissionManager.owner()` returns the `MultisigProxy` address.
-3. Verify CommissionManager linkage: `CommissionManager.bridgeAddress()` returns the live `Bridge` address; `Bridge.commissionManager()` returns the live `CommissionManager` address.
-4. Verify BtcRelay: `Bridge.btcRelay()` returns the expected BtcRelay contract address.
-5. Verify LZ adapter wiring: `Bridge.lzAdapter()` and `MultisigProxy.lzAdapter()` both return `address(0)` immediately after deploy. Once the adapter is live, federation must run two timelocked proposals:
-   - `proposeAdminExecute` on the proxy with calldata `Bridge.setLZAdapter(adapter)` — opens the `fundsInFromAdapter` data path.
+2. Verify RouteRegistry ownership: `RouteRegistry.owner()` returns the `MultisigProxy` address.
+3. Verify CommissionManager ownership: `CommissionManager.owner()` returns the `MultisigProxy` address.
+4. Verify Bridge ↔ Registry linkage: `Bridge.routeRegistry()` returns the live `RouteRegistry`; `RouteRegistry.bridge()` returns the live `Bridge`.
+5. Verify Bridge ↔ CM linkage: `CommissionManager.bridgeAddress()` returns the live `Bridge`; `Bridge.commissionManager()` returns the live `CommissionManager`.
+6. Verify LZ adapter wiring: `Bridge.lzAdapter()` and `MultisigProxy.lzAdapter()` both return `address(0)` immediately after deploy. Once the adapter is live, federation must run two timelocked proposals:
+   - `proposeAdminExecute` on the proxy with calldata `Bridge.setLZAdapter(adapter)` — opens the adapter `fundsIn` data path.
    - `proposeUpdateLZAdapter(adapter)` — opens the `AdminExecuteAdapter` governance path on the proxy.
-6. Verify enclave signers: `MultisigProxy.getEnclaveSigners()` returns the TEE addresses.
-7. Verify federation signers: `MultisigProxy.getFederationSigners()` returns the governance addresses.
-8. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` (selector for the 10-arg `uint256`-chain-id `fundsOut` signature with `destChainId`, `sourceChainId` and `burnId`).
-9. Test `fundsIn` with a small amount (zero commission by default) to confirm token transfer and event emission.
+7. Verify enclave signers: `MultisigProxy.getEnclaveSigners()` returns the TEE addresses.
+8. Verify federation signers: `MultisigProxy.getFederationSigners()` returns the governance addresses.
+9. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` for the 8-arg `fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)` selector.
+10. **Register routes.** For each supported `(sourceChainId, destChainId)` pair, federation runs `MultisigProposeSetRoute` and — after the timelock — `executeProposal` with the printed `opData`. Verify with `RouteRegistry.routes(src, dst)` that the entry is `enabled` and the plugin addresses match.
+11. Test `fundsIn` with a small amount (zero commission by default) on a registered route to confirm token transfer and event emission.
 
 ## Project structure
 
 ```
 src/
-  BridgeBase.sol              — Abstract base: token, pause, shared event/errors
-  BaseBridge.sol              — Minimal bridge for integrators
-  Bridge.sol                  — Production bridge (MultisigProxy owner, BtcRelay, CommissionManager)
-  CommissionManager.sol       — Standalone commission quotes, custody and withdrawal
-  MultisigProxy.sol           — M-of-N multisig owner of Bridge and CommissionManager
+  BridgeBase.sol               — Abstract base: token, pause, shared event/errors
+  BaseBridge.sol               — Minimal bridge for integrators
+  Bridge.sol                   — Production bridge (MultisigProxy owner, RouteRegistry, CommissionManager)
+  RouteRegistry.sol            — Per-route plugin dispatcher (verifier + settlement module)
+  CommissionManager.sol        — Standalone commission quotes, custody and withdrawal
+  MultisigProxy.sol            — M-of-N multisig owner of Bridge, RouteRegistry and CommissionManager
+  verifiers/
+    RGBVerifier.sol            — Bitcoin SPV finality (wraps Atomiq BtcRelay)
+    NullVerifier.sol           — Stateless no-op (routes with upstream finality)
+  settlement/
+    RgbSettlementModule.sol    — RGB-route net-deposit ledger + consumption
+    NullSettlementModule.sol   — Stateless no-op (routes settled by external delivery)
   interfaces/
-    IBridge.sol               — Bridge interface, events, and custom errors
-    IBtcRelayView.sol         — Minimal read-only interface for Atomiq BtcRelay
-    ICommissionManager.sol    — CommissionManager interface, types and errors
-    IMultisigProxy.sol        — MultisigProxy interface and custom errors
+    IBridge.sol                — Bridge interface, events, and custom errors
+    IBtcRelayView.sol          — Minimal read-only interface for Atomiq BtcRelay
+    ICommissionManager.sol     — CommissionManager interface, types and errors
+    IFinalityVerifier.sol      — FinalityVerifier interface
+    ISettlementModule.sol      — SettlementModule interface
+    IRouteRegistry.sol         — RouteRegistry interface, events and errors
+    IMultisigProxy.sol         — MultisigProxy interface and custom errors
+    RouteTypes.sol             — Shared FundsInContext / FundsOutContext structs
 
 script/
-  deploy/                     — Deployment scripts (DeployBridge, DeployBaseBridge,
-                                DeployCommissionManager, DeployMultisigProxy, DeployAll)
-  interact/                   — Manual interaction scripts (fundsIn, fundsOut,
-                                execute, emergencyPause, emergencyUnpause)
+  deploy/                      — DeployAll, DeployBridge, DeployBaseBridge,
+                                 DeployRouteRegistry, DeployRGBVerifier,
+                                 DeployRgbSettlementModule, DeployCommissionManager,
+                                 DeployMultisigProxy
+  interact/                    — BridgeFundsIn, MultisigExecuteFundsOut,
+                                 MultisigProposeSetRoute, EmergencyPause, EmergencyUnpause
 
 test/
-  Bridge.t.sol                — Bridge tests (incl. BtcRelay + commission routing)
-  BaseBridge.t.sol            — BaseBridge tests
-  CommissionManager.t.sol     — CommissionManager tests (rules, pools, withdrawals)
-  MultisigProxy.t.sol         — MultisigProxy tests (EIP-712, bitmap sigs, proposals)
-  Integration.t.sol           — End-to-end: user → Bridge → TEE multisig → fundsOut → CM withdrawal
-  helpers/
-    MockERC20.sol             — Mintable ERC-20 for tests
-    MockBtcRelay.sol          — Mock BtcRelay for tests
-    MultisigHelper.sol        — EIP-712 digest builders and signAll helper
+  Bridge.t.sol                 — Bridge tests (routing through RouteRegistry, burnId, commission)
+  BaseBridge.t.sol             — BaseBridge tests
+  RouteRegistry.t.sol          — RouteRegistry tests (setRoute, dispatch, enabled gating)
+  RgbSettlementModule.t.sol    — RgbSettlementModule tests (ledger, partial consumption)
+  CommissionManager.t.sol      — CommissionManager tests (rules, pools, withdrawals, ETH/USD feed)
+  MultisigProxy.t.sol          — MultisigProxy tests (EIP-712, bitmap sigs, proposals incl. SetRoute / UpdateRouteRegistry)
+  Integration.t.sol            — End-to-end: user → Bridge → RouteRegistry → TEE multisig → fundsOut → CM withdrawal
+  mocks/
+    MockERC20.sol              — Mintable ERC-20 for tests
+    MockBtcRelay.sol           — Mock BtcRelay for tests
+    MockAggregatorV3.sol       — Mock Chainlink aggregator for tests
+    MockFinalityVerifier.sol   — Mock verifier for RouteRegistry / Bridge tests
+    MockSettlementModule.sol   — Mock settlement module for RouteRegistry / Bridge tests
+    MultisigHelper.sol         — EIP-712 digest builders and signAll helper
 
-lib/                          — Foundry submodules (forge-std, openzeppelin-contracts)
-foundry.toml                  — Foundry configuration
-.env.deploy.example           — Deploy environment template
-.env.interact.example         — Interaction environment template
+lib/                           — Foundry submodules (forge-std, openzeppelin-contracts)
+foundry.toml                   — Foundry configuration
+.env.deploy.example            — Deploy environment template
+.env.interact.example          — Interaction environment template
 ```

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -2,33 +2,49 @@
 pragma solidity 0.8.20;
 
 import { Script, console2 } from 'forge-std/Script.sol';
-import { Bridge } from '../../src/Bridge.sol';
-import { CommissionManager } from '../../src/CommissionManager.sol';
-import { MultisigProxy } from '../../src/MultisigProxy.sol';
+
+import { Bridge }              from '../../src/Bridge.sol';
+import { CommissionManager }   from '../../src/CommissionManager.sol';
+import { MultisigProxy }       from '../../src/MultisigProxy.sol';
+import { RouteRegistry }       from '../../src/RouteRegistry.sol';
+import { RGBVerifier }         from '../../src/verifiers/RGBVerifier.sol';
+import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.sol';
 
 /// @title DeployAll
-/// @notice Full production flow:
-///           1. Predict Bridge address (deployer nonce + 1).
-///           2. Deploy CommissionManager with predicted Bridge as `bridgeAddress`.
-///           3. Deploy Bridge with the already-deployed CommissionManager.
-///           4. Deploy MultisigProxy owning both.
-///           5. Transfer Bridge and CommissionManager ownership to MultisigProxy.
+/// @notice Full production deploy flow.
 ///
-/// Env:
+/// Deployer tx order (nonce n):
+///   n      → CommissionManager  (uses predicted Bridge for its
+///                                 `bridgeAddress`)
+///   n + 1  → RouteRegistry      (uses predicted Bridge for its `bridge_`
+///                                 immutable; deployer keeps ownership for
+///                                 this transaction batch — ownership is
+///                                 transferred to MultisigProxy at the end)
+///   n + 2  → Bridge             (uses the live RouteRegistry + CM)
+///   n + 3  → RGBVerifier        (wraps the BtcRelay)
+///   n + 4  → RgbSettlementModule (paired with RouteRegistry)
+///   n + 5  → MultisigProxy
+///   n + 6  → (optional) CommissionManager.setEthUsdFeed
+///   n + 7  → CommissionManager.transferOwnership → MultisigProxy
+///   n + 8  → Bridge.transferOwnership → MultisigProxy
+///   n + 9  → RouteRegistry.transferOwnership → MultisigProxy
+///
+/// Routes are NOT registered here. Federation configures them through
+/// `MultisigProxy.proposeSetRoute(...)` after deploy — this mirrors the
+/// permanent governance path and keeps the deploy script audit-clean.
+///
+/// Env (required):
 ///   PRIVATE_KEY, USDT0_ADDRESS, BTC_RELAY_ADDRESS,
 ///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD,
 ///   FEDERATION_SIGNERS, FEDERATION_THRESHOLD,
 ///   COMMISSION_RECIPIENT, TIMELOCK_DURATION
 ///
-///   ETH_USD_FEED      — Optional Chainlink ETH/USD aggregator address. When
-///                       supplied (non-zero) together with `ETH_USD_HEARTBEAT`
-///                       it is wired in *before* CM ownership transfer, so the
-///                       NATIVE-currency commission path is live the moment the
-///                       proxy takes over. If omitted, NATIVE commission quotes
-///                       revert `EthUsdFeedNotSet` until federation runs
-///                       `proposeAdminExecuteCM(setEthUsdFeed(feed, hb))`.
+/// Env (optional):
+///   ETH_USD_FEED      — Chainlink ETH/USD aggregator (wired in before CM
+///                       ownership transfer, so NATIVE commission quotes
+///                       are live the moment the proxy takes over).
 ///   ETH_USD_HEARTBEAT — Seconds before the feed answer is considered stale.
-///
+///                       Required when ETH_USD_FEED is provided.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployAll.s.sol \
@@ -36,15 +52,19 @@ import { MultisigProxy } from '../../src/MultisigProxy.sol';
 contract DeployAll is Script {
     function run()
         external
-        returns (Bridge bridge, CommissionManager cm, MultisigProxy proxy)
+        returns (
+            Bridge              bridge,
+            CommissionManager   cm,
+            RouteRegistry       routeRegistry,
+            RGBVerifier         rgbVerifier,
+            RgbSettlementModule rgbModule,
+            MultisigProxy       proxy
+        )
     {
+        // ---- 1. Load env --------------------------------------------------
         uint256 pk             = vm.envUint('PRIVATE_KEY');
         address usdt0          = vm.envAddress('USDT0_ADDRESS');
-        // TODO: rewrite the full deploy graph — RouteRegistry must be
-        // deployed before Bridge with Bridge's predicted address as its
-        // `bridge_` immutable. This temporary env var lets the script compile
-        // until PR7 reshapes the deployment order.
-        address routeRegistry  = vm.envAddress('ROUTE_REGISTRY_ADDRESS');
+        address btcRelay       = vm.envAddress('BTC_RELAY_ADDRESS');
         address[] memory enc   = vm.envAddress('ENCLAVE_SIGNERS', ',');
         uint256 encThr         = vm.envUint('ENCLAVE_THRESHOLD');
         address[] memory fed   = vm.envAddress('FEDERATION_SIGNERS', ',');
@@ -54,23 +74,36 @@ contract DeployAll is Script {
         address ethUsdFeed     = vm.envOr('ETH_USD_FEED', address(0));
         uint256 ethUsdHb       = vm.envOr('ETH_USD_HEARTBEAT', uint256(0));
 
-        address deployer = vm.addr(pk);
-        uint64 currentNonce = vm.getNonce(deployer);
+        address deployer    = vm.addr(pk);
+        uint64  startNonce  = vm.getNonce(deployer);
 
-        // In this script the deployer sends tx in order:
-        //   nonce  n   → CommissionManager
-        //   nonce n+1  → Bridge
-        //   nonce n+2  → MultisigProxy
-        //   nonce n+3  → (optional) CommissionManager.setEthUsdFeed
-        //   nonce n+4  → CommissionManager.transferOwnership
-        //   nonce n+5  → Bridge.transferOwnership
-        address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 1);
+        // Bridge sits at nonce + 2 (CM, RouteRegistry, then Bridge).
+        address predictedBridge = vm.computeCreateAddress(deployer, startNonce + 2);
 
         vm.startBroadcast(pk);
 
-        cm     = new CommissionManager(predictedBridge);
-        bridge = new Bridge(usdt0, routeRegistry, payable(address(cm)), address(0));
-        proxy  = new MultisigProxy(
+        // ---- 2. CommissionManager (nonce n) ------------------------------
+        cm = new CommissionManager(predictedBridge);
+
+        // ---- 3. RouteRegistry (nonce n+1) --------------------------------
+        // Owned by `deployer` for this batch; transferred to the proxy below
+        // after the proxy has been deployed.
+        routeRegistry = new RouteRegistry(predictedBridge, deployer);
+
+        // ---- 4. Bridge (nonce n+2) ---------------------------------------
+        bridge = new Bridge(
+            usdt0,
+            address(routeRegistry),
+            payable(address(cm)),
+            address(0)
+        );
+
+        // ---- 5. Route plugins (nonce n+3, n+4) ---------------------------
+        rgbVerifier = new RGBVerifier(btcRelay);
+        rgbModule   = new RgbSettlementModule(address(routeRegistry));
+
+        // ---- 6. MultisigProxy (nonce n+5) --------------------------------
+        proxy = new MultisigProxy(
             address(bridge),
             address(cm),
             enc, encThr,
@@ -79,36 +112,52 @@ contract DeployAll is Script {
             timelock
         );
 
-        // Wire the Chainlink feed *before* the proxy takes over. After
-        // ownership transfer the only way to change it is via federation
-        // governance (`proposeAdminExecuteCM(setEthUsdFeed)`).
+        // ---- 7. Wire optional ETH/USD feed before CM ownership transfer --
         if (ethUsdFeed != address(0)) {
             require(ethUsdHb != 0, 'ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided');
             cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
         }
 
+        // ---- 8. Hand over to federation ----------------------------------
         cm.transferOwnership(address(proxy));
         bridge.transferOwnership(address(proxy));
+        routeRegistry.transferOwnership(address(proxy));
 
         vm.stopBroadcast();
 
-        console2.log('CommissionManager deployed at:', address(cm));
-        console2.log('Bridge deployed at:           ', address(bridge));
-        console2.log('MultisigProxy deployed at:    ', address(proxy));
+        // ---- 9. Summary --------------------------------------------------
+        console2.log('CommissionManager deployed at:  ', address(cm));
+        console2.log('RouteRegistry deployed at:      ', address(routeRegistry));
+        console2.log('Bridge deployed at:             ', address(bridge));
+        console2.log('RGBVerifier deployed at:        ', address(rgbVerifier));
+        console2.log('RgbSettlementModule deployed at:', address(rgbModule));
+        console2.log('MultisigProxy deployed at:      ', address(proxy));
         if (ethUsdFeed != address(0)) {
-            console2.log('ETH/USD feed wired:           ', ethUsdFeed);
-            console2.log('ETH/USD heartbeat (s):        ', ethUsdHb);
+            console2.log('ETH/USD feed wired:             ', ethUsdFeed);
+            console2.log('ETH/USD heartbeat (s):          ', ethUsdHb);
         } else {
-            console2.log('ETH/USD feed:                 ', 'UNSET (NATIVE quotes will revert until governance wires one)');
+            console2.log('ETH/USD feed:                   ', 'UNSET (NATIVE quotes will revert until governance wires one)');
         }
 
-        require(address(bridge) == predictedBridge, 'Bridge address prediction mismatch');
-        require(cm.bridgeAddress() == address(bridge), 'CM.bridgeAddress mismatch');
-        require(bridge.owner() == address(proxy), 'Bridge ownership transfer failed');
-        require(cm.owner()     == address(proxy), 'CM ownership transfer failed');
+        // ---- 10. Invariant checks ---------------------------------------
+        require(address(bridge) == predictedBridge,         'Bridge address prediction mismatch');
+        require(routeRegistry.bridge() == address(bridge),  'RouteRegistry.bridge mismatch');
+        require(rgbModule.routeRegistry() == address(routeRegistry), 'RgbSettlementModule.routeRegistry mismatch');
+        require(bridge.routeRegistry() == address(routeRegistry),    'Bridge.routeRegistry mismatch');
+        require(cm.bridgeAddress() == address(bridge),      'CM.bridgeAddress mismatch');
+        require(bridge.owner() == address(proxy),           'Bridge ownership transfer failed');
+        require(cm.owner()     == address(proxy),           'CM ownership transfer failed');
+        require(routeRegistry.owner() == address(proxy),    'RouteRegistry ownership transfer failed');
         if (ethUsdFeed != address(0)) {
-            require(cm.ethUsdFeed() == ethUsdFeed, 'CM.ethUsdFeed mismatch');
-            require(cm.ethUsdHeartbeat() == ethUsdHb, 'CM.ethUsdHeartbeat mismatch');
+            require(cm.ethUsdFeed() == ethUsdFeed,          'CM.ethUsdFeed mismatch');
+            require(cm.ethUsdHeartbeat() == ethUsdHb,       'CM.ethUsdHeartbeat mismatch');
         }
+
+        // ---- 11. Post-deploy reminder -----------------------------------
+        console2.log('');
+        console2.log('Next step: federation must register routes via');
+        console2.log('  MultisigProxy.proposeSetRoute(src, dst, true, verifier, module)');
+        console2.log('for each supported (sourceChainId, destChainId) pair');
+        console2.log('before any fundsIn / fundsOut traffic is accepted.');
     }
 }

--- a/ethereum/script/deploy/DeployBridge.s.sol
+++ b/ethereum/script/deploy/DeployBridge.s.sol
@@ -13,9 +13,12 @@ import { Bridge } from '../../src/Bridge.sol';
 ///   PRIVATE_KEY               — deployer private key
 ///   USDT0_ADDRESS             — accepted ERC-20 token
 ///   ROUTE_REGISTRY_ADDRESS    — RouteRegistry contract paired with this Bridge.
-///                               FIXME(PR7): full deploy flow rewrite — registry
-///                               must be deployed before Bridge with Bridge's
-///                               predicted address as its `bridge_` immutable.
+///                               For a fresh stack use `DeployAll.s.sol` — it
+///                               predicts Bridge's CREATE address and wires the
+///                               registry's `bridge_` immutable to it in the
+///                               same transaction batch. Standalone deploy is
+///                               for replacing Bridge while keeping the
+///                               existing registry (rare).
 ///   COMMISSION_MANAGER        — CommissionManager contract (must already be deployed)
 ///   LZ_ADAPTER                — Optional initial LayerZero adapter address;
 ///                               omit or pass `0x0` if the adapter has not been

--- a/ethereum/script/deploy/DeployRGBVerifier.s.sol
+++ b/ethereum/script/deploy/DeployRGBVerifier.s.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import { Script, console2 } from 'forge-std/Script.sol';
+import { RGBVerifier } from '../../src/verifiers/RGBVerifier.sol';
+
+/// @title DeployRGBVerifier
+/// @notice Deploys the RGB-route finality verifier (thin wrapper around the
+///         Atomiq `IBtcRelayView` SPV header relay). The verifier is
+///         stateless apart from the immutable `btcRelay` reference; rotation
+///         = redeploy + federation `proposeSetRoute` pointing the RGB route
+///         at the new verifier.
+///
+/// Env:
+///   PRIVATE_KEY        — deployer private key
+///   BTC_RELAY_ADDRESS  — deployed `IBtcRelayView` instance
+///
+/// Usage:
+///   forge script script/deploy/DeployRGBVerifier.s.sol \
+///     --rpc-url $RPC_URL --broadcast --verify
+contract DeployRGBVerifier is Script {
+    function run() external returns (RGBVerifier verifier) {
+        uint256 pk       = vm.envUint('PRIVATE_KEY');
+        address btcRelay = vm.envAddress('BTC_RELAY_ADDRESS');
+
+        vm.startBroadcast(pk);
+        verifier = new RGBVerifier(btcRelay);
+        vm.stopBroadcast();
+
+        console2.log('RGBVerifier deployed at:', address(verifier));
+        console2.log('BtcRelay (immutable):   ', verifier.btcRelay());
+    }
+}

--- a/ethereum/script/deploy/DeployRgbSettlementModule.s.sol
+++ b/ethereum/script/deploy/DeployRgbSettlementModule.s.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import { Script, console2 } from 'forge-std/Script.sol';
+import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.sol';
+
+/// @title DeployRgbSettlementModule
+/// @notice Deploys the RGB-route settlement module. Holds the `fundsInRecords`
+///         ledger and the partial-consumption loop that used to live inside
+///         Bridge. Paired with one specific `RouteRegistry` instance via the
+///         immutable `routeRegistry` field — auth on `onFundsIn` /
+///         `beforeFundsOut` is `onlyRouteRegistry`.
+///
+///         Re-pointing at a different registry = redeploy + federation
+///         `proposeSetRoute(RGB → SOURCE, …, newModule)` (and the reverse
+///         direction). The legacy module retains its ledger but never gets
+///         called again.
+///
+/// Env:
+///   PRIVATE_KEY            — deployer private key
+///   ROUTE_REGISTRY_ADDRESS — `RouteRegistry` deployment that will drive
+///                            this module
+///
+/// Usage:
+///   forge script script/deploy/DeployRgbSettlementModule.s.sol \
+///     --rpc-url $RPC_URL --broadcast --verify
+contract DeployRgbSettlementModuleScript is Script {
+    function run() external returns (RgbSettlementModule module) {
+        uint256 pk            = vm.envUint('PRIVATE_KEY');
+        address routeRegistry = vm.envAddress('ROUTE_REGISTRY_ADDRESS');
+
+        vm.startBroadcast(pk);
+        module = new RgbSettlementModule(routeRegistry);
+        vm.stopBroadcast();
+
+        console2.log('RgbSettlementModule deployed at:', address(module));
+        console2.log('RouteRegistry (immutable):      ', module.routeRegistry());
+    }
+}

--- a/ethereum/script/deploy/DeployRouteRegistry.s.sol
+++ b/ethereum/script/deploy/DeployRouteRegistry.s.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import { Script, console2 } from 'forge-std/Script.sol';
+import { RouteRegistry } from '../../src/RouteRegistry.sol';
+
+/// @title DeployRouteRegistry
+/// @notice Standalone deployment of `RouteRegistry`. Used when adding a new
+///         registry to an existing Bridge (followed by federation governance:
+///         `proposeUpdateRouteRegistry(newRegistry)` on MultisigProxy).
+///
+///         For a fresh stack use `DeployAll.s.sol` — it predicts Bridge's
+///         CREATE address and wires the registry's `bridge_` immutable to it
+///         in the same transaction batch.
+///
+/// Env:
+///   PRIVATE_KEY    — deployer private key
+///   BRIDGE_ADDRESS — Bridge instance this registry will serve. The registry
+///                    stores it as `immutable`, so it MUST already exist and
+///                    match the Bridge that will hold this registry as its
+///                    `routeRegistry` pointer.
+///   OWNER_ADDRESS  — Initial owner of the registry. Production uses the
+///                    MultisigProxy address so route administration is
+///                    federation-governed from t=0.
+///
+/// Usage:
+///   forge script script/deploy/DeployRouteRegistry.s.sol \
+///     --rpc-url $RPC_URL --broadcast --verify
+contract DeployRouteRegistry is Script {
+    function run() external returns (RouteRegistry registry) {
+        uint256 pk     = vm.envUint('PRIVATE_KEY');
+        address bridge = vm.envAddress('BRIDGE_ADDRESS');
+        address owner  = vm.envAddress('OWNER_ADDRESS');
+
+        vm.startBroadcast(pk);
+        registry = new RouteRegistry(bridge, owner);
+        vm.stopBroadcast();
+
+        console2.log('RouteRegistry deployed at:', address(registry));
+        console2.log('Bridge (immutable):       ', registry.bridge());
+        console2.log('Owner:                    ', registry.owner());
+    }
+}

--- a/ethereum/script/interact/BridgeFundsIn.s.sol
+++ b/ethereum/script/interact/BridgeFundsIn.s.sol
@@ -40,10 +40,9 @@ contract BridgeFundsIn is Script {
 
         vm.startBroadcast(pk);
         IERC20(token).approve(bridgeAddr, amount);
-        // TODO: settlementData is currently empty (RGB-route settlement
-        // module needs no extra data on fundsIn). When other routes register
-        // modules that consume settlementData on the inbound path, this
-        // script must source the blob from env.
+        // `settlementData` is empty for the RGB route — its settlement
+        // module ignores inbound data. Other routes whose modules consume
+        // extra data on `onFundsIn` would need to source the blob from env.
         bridge.fundsIn{ value: nativeCommission }(amount, destChainId, dAddr, operationId, '');
         vm.stopBroadcast();
 

--- a/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
+++ b/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
@@ -6,64 +6,78 @@ import { MultisigProxy } from '../../src/MultisigProxy.sol';
 import { MultisigHelper } from '../../test/mocks/MultisigHelper.sol';
 
 /// @title MultisigExecuteFundsOut
-/// @notice Signs a Bridge.fundsOut() call locally with enclave private keys from env
-///         and submits it via MultisigProxy.execute(). For manual end-to-end testing
-///         before the backend is wired up.
+/// @notice Signs a Bridge.fundsOut() call locally with enclave private keys
+///         and submits it via MultisigProxy.execute(). For manual end-to-end
+///         testing before the backend is wired up.
+///
+/// @dev RGB-route specific: `proof` and `settlementData` are packed for the
+///      Atomiq BtcRelay + RgbSettlementModule plugins. Other routes will
+///      need different blob layouts.
 ///
 /// Env:
-///   PRIVATE_KEY             — tx submitter (anyone)
-///   PROXY_ADDRESS           — MultisigProxy address
-///   RECIPIENT               — destination address
-///   AMOUNT (wei)            — gross amount to release (before commission)
-///   OPERATION_ID            — backend-assigned operation id
-///   BURN_ID                 — burn consignment id (single-use replay guard)
-///   SOURCE_CHAIN            — source chain string
-///   DEST_CHAIN              — destination chain string (used for commission routing)
-///   SOURCE_ADDRESS          — source address string
-///   BLOCK_HEIGHT            — Bitcoin block height (verified by BtcRelay)
-///   COMMITMENT_HASH         — Bitcoin block commitment hash (verified by BtcRelay)
-///   FUNDS_IN_IDS            — comma-separated fundsIn transaction IDs to reference
-///   ENCLAVE_PKS             — comma-separated hex private keys (ordered by signer index)
-///   ENCLAVE_BITMAP          — bitmap of participating signers (hex or decimal)
-///   DEADLINE_OFFSET         — seconds from now (e.g. 3600)
+///   PRIVATE_KEY              — tx submitter (anyone)
+///   PROXY_ADDRESS            — MultisigProxy address
+///   RECIPIENT                — release recipient on this chain
+///   AMOUNT (wei)             — gross amount to release (pre-commission)
+///   BURN_ID                  — burn consignment id (single-use replay guard)
+///   SOURCE_CHAIN_ID (uint)   — source chain id (RGB-side for inbound releases)
+///   DESTINATION_CHAIN_ID     — destination chain id (this chain)
+///   SOURCE_ADDRESS (string)  — source-side sender address
+///   BLOCK_HEIGHT             — Bitcoin block height (consumed by RGBVerifier)
+///   COMMITMENT_HASH (bytes32)— Bitcoin block commitment hash
+///   FUNDS_IN_IDS             — comma-separated fundsIn op ids referenced by
+///                              RgbSettlementModule
+///   ENCLAVE_PKS              — comma-separated hex private keys (ordered by
+///                              signer index)
+///   ENCLAVE_BITMAP           — bitmap of participating signers (hex/decimal)
+///   DEADLINE_OFFSET          — seconds from now (e.g. 3600)
 contract MultisigExecuteFundsOut is Script {
-    // 10-arg fundsOut signature (adds destChain + burnId).
+    /// @dev 8-arg fundsOut selector — must match the TEE allowlist entry
+    ///      seeded by `MultisigProxy`'s constructor.
     bytes4 constant FUNDS_OUT_SELECTOR = bytes4(keccak256(
-        'fundsOut(address,uint256,uint256,uint256,string,string,string,uint256,bytes32,uint256[])'
+        'fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)'
     ));
 
     struct Params {
         address recipient;
         uint256 amount;
-        uint256 operationId;
         uint256 burnId;
-        string  srcChain;
-        string  dstChain;
-        string  srcAddr;
-        uint256 blockHeight;
-        bytes32 commitmentHash;
-        uint256[] fundsInIds;
+        uint256 sourceChainId;
+        uint256 destChainId;
+        string  sourceAddress;
+        bytes   proof;
+        bytes   settlementData;
     }
 
     function _loadParams() internal view returns (Params memory p) {
-        p.recipient      = vm.envAddress('RECIPIENT');
-        p.amount         = vm.envUint('AMOUNT');
-        p.operationId    = vm.envUint('OPERATION_ID');
-        p.burnId         = vm.envUint('BURN_ID');
-        p.srcChain       = vm.envString('SOURCE_CHAIN');
-        p.dstChain       = vm.envString('DEST_CHAIN');
-        p.srcAddr        = vm.envString('SOURCE_ADDRESS');
-        p.blockHeight    = vm.envUint('BLOCK_HEIGHT');
-        p.commitmentHash = vm.envBytes32('COMMITMENT_HASH');
-        p.fundsInIds     = vm.envUint('FUNDS_IN_IDS', ',');
+        p.recipient     = vm.envAddress('RECIPIENT');
+        p.amount        = vm.envUint('AMOUNT');
+        p.burnId        = vm.envUint('BURN_ID');
+        p.sourceChainId = vm.envUint('SOURCE_CHAIN_ID');
+        p.destChainId   = vm.envUint('DESTINATION_CHAIN_ID');
+        p.sourceAddress = vm.envString('SOURCE_ADDRESS');
+
+        // proof = abi.encode(blockHeight, commitmentHash) — RGBVerifier layout.
+        p.proof = abi.encode(
+            vm.envUint('BLOCK_HEIGHT'),
+            vm.envBytes32('COMMITMENT_HASH')
+        );
+
+        // settlementData = abi.encode(uint256[] fundsInIds) — RgbSettlementModule layout.
+        p.settlementData = abi.encode(vm.envUint('FUNDS_IN_IDS', ','));
     }
 
     function _buildCallData(Params memory p) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(
             FUNDS_OUT_SELECTOR,
-            p.recipient, p.amount, p.operationId, p.burnId,
-            p.srcChain, p.dstChain, p.srcAddr,
-            p.blockHeight, p.commitmentHash, p.fundsInIds
+            p.recipient,
+            p.amount,
+            p.burnId,
+            p.sourceChainId,
+            p.destChainId,
+            p.sourceAddress,
+            p.proof,
+            p.settlementData
         );
     }
 

--- a/ethereum/script/interact/MultisigProposeSetRoute.s.sol
+++ b/ethereum/script/interact/MultisigProposeSetRoute.s.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import { Script, console2 } from 'forge-std/Script.sol';
+import { MultisigProxy } from '../../src/MultisigProxy.sol';
+import { MultisigHelper } from '../../test/mocks/MultisigHelper.sol';
+
+/// @title MultisigProposeSetRoute
+/// @notice Signs and submits a `proposeSetRoute(...)` federation proposal
+///         against MultisigProxy. The first federation-side step after
+///         DeployAll — registers or updates a route entry in the Bridge's
+///         RouteRegistry once the timelock elapses.
+///
+/// @dev    The matching `executeProposal(...)` call (which is permissionless)
+///         is intentionally NOT submitted by this script — operators run it
+///         manually with `cast send` after the timelock window passes. The
+///         `opData` payload required by `executeProposal` is printed below.
+///
+/// Env:
+///   PRIVATE_KEY              — tx submitter (anyone)
+///   PROXY_ADDRESS            — MultisigProxy address
+///   SOURCE_CHAIN_ID (uint)   — source chain id of the route key
+///   DEST_CHAIN_ID   (uint)   — destination chain id of the route key
+///   ROUTE_ENABLED   (bool)   — `true` to (re)enable, `false` to pause-in-place
+///   FINALITY_VERIFIER (addr) — verifier deployment (e.g. RGBVerifier)
+///   SETTLEMENT_MODULE (addr) — settlement module deployment
+///   FED_PKS                  — comma-separated federation private keys
+///   FED_BITMAP               — participating signer bitmap
+///   DEADLINE_OFFSET          — seconds from now (e.g. 7 days)
+contract MultisigProposeSetRoute is Script {
+    function run() external returns (bytes32 proposalId) {
+        uint256 pk                  = vm.envUint('PRIVATE_KEY');
+        address proxyAddr           = vm.envAddress('PROXY_ADDRESS');
+        uint256 sourceChainId       = vm.envUint('SOURCE_CHAIN_ID');
+        uint256 destChainId         = vm.envUint('DEST_CHAIN_ID');
+        bool    enabled             = vm.envBool('ROUTE_ENABLED');
+        address finalityVerifier    = vm.envAddress('FINALITY_VERIFIER');
+        address settlementModule    = vm.envAddress('SETTLEMENT_MODULE');
+        uint256[] memory ks         = vm.envUint('FED_PKS', ',');
+        uint256 bitmap              = vm.envUint('FED_BITMAP');
+        uint256 offset              = vm.envUint('DEADLINE_OFFSET');
+
+        MultisigProxy proxy = MultisigProxy(proxyAddr);
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + offset;
+
+        bytes32 digest = MultisigHelper.digestProposeSetRoute(
+            proxy.DOMAIN_SEPARATOR(),
+            sourceChainId, destChainId, enabled, finalityVerifier, settlementModule,
+            nonce, deadline
+        );
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, ks);
+
+        vm.startBroadcast(pk);
+        proposalId = proxy.proposeSetRoute(
+            sourceChainId, destChainId, enabled, finalityVerifier, settlementModule,
+            nonce, deadline, bitmap, sigs
+        );
+        vm.stopBroadcast();
+
+        console2.log('proposeSetRoute submitted');
+        console2.log('  proposalId:        ');
+        console2.logBytes32(proposalId);
+        console2.log('  nonce:             ', nonce);
+        console2.log('  deadline (unix s): ', deadline);
+        console2.log('');
+        console2.log('After the timelock elapses, run:');
+        console2.log('  cast send <PROXY_ADDRESS> "executeProposal(bytes32,bytes)" <proposalId> <opData>');
+        console2.log('where opData =');
+        console2.logBytes(abi.encode(
+            sourceChainId, destChainId, enabled, finalityVerifier, settlementModule
+        ));
+    }
+}

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -43,10 +43,11 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     /// @notice CommissionManager that receives and custodies protocol fees.
     ICommissionManager public immutable commissionManager;
 
-    /// @notice Per-Bridge route directory. Dispatches `onFundsIn` /
-    ///         `beforeFundsOut` to the route-specific verifier + settlement
-    ///         module configured by federation governance.
-    IRouteRegistry public immutable routeRegistry;
+    /// @inheritdoc IBridge
+    /// @dev Mutable so federation can rotate registry deployments via
+    ///      `UpdateRouteRegistry` governance op without redeploying the
+    ///      Bridge.
+    address public override routeRegistry;
 
     /// @inheritdoc IBridge
     address public override lzAdapter;
@@ -88,7 +89,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (routeRegistry_     == address(0)) revert InvalidRouteRegistryAddress();
         if (commissionManager_ == address(0)) revert InvalidCommissionManagerAddress();
 
-        routeRegistry     = IRouteRegistry(routeRegistry_);
+        routeRegistry     = routeRegistry_;
         commissionManager = ICommissionManager(commissionManager_);
         lzAdapter         = lzAdapter_;
     }
@@ -104,6 +105,16 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         address old = lzAdapter;
         lzAdapter = newAdapter;
         emit LZAdapterUpdated(old, newAdapter);
+    }
+
+    /// @inheritdoc IBridge
+    /// @dev Owner is `MultisigProxy`; federation gates this on its M-of-N
+    ///      timelock flow via `proposeUpdateRouteRegistry`.
+    function setRouteRegistry(address newRouteRegistry) external override onlyOwner {
+        if (newRouteRegistry == address(0)) revert InvalidRouteRegistryAddress();
+        address old = routeRegistry;
+        routeRegistry = newRouteRegistry;
+        emit RouteRegistryUpdated(old, newRouteRegistry);
     }
 
     // =========================================================================
@@ -192,7 +203,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // Delegate route-specific finality verification + settlement-state
         // mutation to the configured plugins. The registry runs the verifier
         // (view-only) first; if it reverts, no settlement-module write happens.
-        routeRegistry.beforeFundsOut(
+        IRouteRegistry(routeRegistry).beforeFundsOut(
             FundsOutContext({
                 token:         TOKEN,
                 recipient:     recipient,
@@ -273,7 +284,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         IERC20(TOKEN).safeTransferFrom(from, address(this), amount);
 
         // Delegate per-route inbound bookkeeping.
-        routeRegistry.onFundsIn(
+        IRouteRegistry(routeRegistry).onFundsIn(
             FundsInContext({
                 token:         TOKEN,
                 sender:        from,

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.20;
 
 import { ECDSA } from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import { IMultisigProxy } from './interfaces/IMultisigProxy.sol';
+import { IBridge }        from './interfaces/IBridge.sol';
+import { IRouteRegistry } from './interfaces/IRouteRegistry.sol';
 
 contract MultisigProxy is IMultisigProxy {
     using ECDSA for bytes32;
@@ -120,6 +122,14 @@ contract MultisigProxy is IMultisigProxy {
         'ProposeUpdateLZAdapter(address newLZAdapter,uint256 nonce,uint256 deadline)'
     );
 
+    // Federation propose — RouteRegistry side
+    bytes32 private constant _PROPOSE_SET_ROUTE_TYPEHASH = keccak256(
+        'ProposeSetRoute(uint256 sourceChainId,uint256 destChainId,bool enabled,address finalityVerifier,address settlementModule,uint256 nonce,uint256 deadline)'
+    );
+    bytes32 private constant _PROPOSE_UPDATE_ROUTE_REGISTRY_TYPEHASH = keccak256(
+        'ProposeUpdateRouteRegistry(address newRouteRegistry,uint256 nonce,uint256 deadline)'
+    );
+
     // Cancel
     bytes32 private constant _CANCEL_PROPOSAL_TYPEHASH = keccak256(
         'CancelProposal(bytes32 proposalId,uint256 nonce,uint256 deadline)'
@@ -173,7 +183,7 @@ contract MultisigProxy is IMultisigProxy {
         // federation governance through `proposeSetTeeAllowedCall`.
         teeAllowedCalls[bridge_][
             bytes4(keccak256(
-                'fundsOut(address,uint256,uint256,uint256,uint256,uint256,string,uint256,bytes32,uint256[])'
+                'fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)'
             ))
         ] = true;
 
@@ -597,6 +607,54 @@ contract MultisigProxy is IMultisigProxy {
     }
 
     // =========================================================================
+    // Federation propose — RouteRegistry side
+    // =========================================================================
+
+    /// @inheritdoc IMultisigProxy
+    function proposeSetRoute(
+        uint256 sourceChainId,
+        uint256 destChainId,
+        bool    enabled,
+        address finalityVerifier,
+        address settlementModule,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_SET_ROUTE_TYPEHASH,
+            sourceChainId, destChainId, enabled, finalityVerifier, settlementModule,
+            nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.SetRoute,
+            abi.encode(sourceChainId, destChainId, enabled, finalityVerifier, settlementModule),
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
+    /// @inheritdoc IMultisigProxy
+    function proposeUpdateRouteRegistry(
+        address newRouteRegistry,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_UPDATE_ROUTE_REGISTRY_TYPEHASH, newRouteRegistry, nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.UpdateRouteRegistry,
+            abi.encode(newRouteRegistry),
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
+    // =========================================================================
     // Cancel
     // =========================================================================
 
@@ -821,6 +879,31 @@ contract MultisigProxy is IMultisigProxy {
             address oldAdapter = lzAdapter;
             lzAdapter = newAdapter;
             emit LZAdapterUpdated(oldAdapter, newAdapter);
+
+        } else if (opType == OperationType.SetRoute) {
+            // Forwards to RouteRegistry, looked up dynamically from Bridge to
+            // keep registry pointer as a single source of truth.
+            (
+                uint256 sourceChainId,
+                uint256 destChainId,
+                bool    enabled,
+                address finalityVerifier,
+                address settlementModule
+            ) = abi.decode(opData, (uint256, uint256, bool, address, address));
+
+            address registry = IBridge(bridge).routeRegistry();
+            if (registry == address(0)) revert ZeroTarget();
+            IRouteRegistry(registry).setRoute(
+                sourceChainId, destChainId, enabled, finalityVerifier, settlementModule
+            );
+
+        } else if (opType == OperationType.UpdateRouteRegistry) {
+            // Rotates Bridge's `routeRegistry` immutable-shaped slot. The new
+            // registry MUST be deployed with Bridge's address as its
+            // constructor `bridge_`; otherwise dispatcher calls revert
+            // `NotBridge` and the route plane goes dark.
+            address newRegistry = abi.decode(opData, (address));
+            IBridge(bridge).setRouteRegistry(newRegistry);
 
         } else {
             revert UnknownOperationType();

--- a/ethereum/src/RouteRegistry.sol
+++ b/ethereum/src/RouteRegistry.sol
@@ -98,7 +98,7 @@ contract RouteRegistry is IRouteRegistry, Ownable {
         bool    enabled,
         address finalityVerifier,
         address settlementModule
-    ) external onlyOwner {
+    ) external override onlyOwner {
         if (finalityVerifier == address(0)) revert ZeroFinalityVerifier();
         if (settlementModule == address(0)) revert ZeroSettlementModule();
 

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -25,6 +25,12 @@ interface IBridge {
     /// @param newAdapter New trusted adapter (zero disables the adapter overload).
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
 
+    /// @notice Emitted on every successful `setRouteRegistry`.
+    /// @param oldRegistry Previous registry (the constructor-supplied value
+    ///                    before the first rotation).
+    /// @param newRegistry New registry (non-zero by `setRouteRegistry` guard).
+    event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+
     /// @param sender             Address that deposited the tokens (the EOA on the
     ///                           public overload, or the LZ adapter on the
     ///                           adapter-only overload).
@@ -139,9 +145,16 @@ interface IBridge {
     ///         the adapter overload until a non-zero address is set again.
     function setLZAdapter(address newAdapter) external;
 
+    /// @notice Updates the `RouteRegistry` reference Bridge dispatches
+    ///         `onFundsIn` / `beforeFundsOut` through. Owner-only.
+    function setRouteRegistry(address newRouteRegistry) external;
+
     /// @notice Current trusted adapter; `address(0)` means the adapter
     ///         overload is closed.
     function lzAdapter() external view returns (address);
+
+    /// @notice Current `RouteRegistry` Bridge uses for route dispatch.
+    function routeRegistry() external view returns (address);
 
     /// @notice Permanently blocked — ownership cannot be renounced.
     function renounceOwnership() external view;

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -86,7 +86,9 @@ interface IMultisigProxy {
         WithdrawNativeCommissionCM,      // 9  — CM.withdrawNativeCommission -> commissionRecipient
         UpdateCommissionManager,         // 10 — migrate to a new CommissionManager address
         AdminExecuteAdapter,             // 11 — generic call into LZAdapter (setTrustedEntrypoint, refundStuckFunds, …)
-        UpdateLZAdapter                  // 12 — rotate the routing target for AdminExecuteAdapter
+        UpdateLZAdapter,                 // 12 — rotate the routing target for AdminExecuteAdapter
+        SetRoute,                        // 13 — RouteRegistry.setRoute(src, dst, enabled, verifier, module)
+        UpdateRouteRegistry              // 14 — Bridge.setRouteRegistry(newRouteRegistry)
     }
 
     enum ProposalStatus { None, Pending, Executed, Cancelled }
@@ -330,6 +332,41 @@ interface IMultisigProxy {
     ///      and closes adapter-execute until set again.
     function proposeUpdateLZAdapter(
         address newLZAdapter,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
+    /// @notice Propose registering or updating a route in the Bridge's
+    ///         RouteRegistry.
+    /// @dev opData = abi.encode(uint256 sourceChainId, uint256 destChainId,
+    ///      bool enabled, address finalityVerifier, address settlementModule).
+    ///      The proxy forwards the call to
+    ///      `IRouteRegistry(bridge.routeRegistry()).setRoute(...)`.
+    ///      Both plugin addresses MUST be non-zero — registry rejects
+    ///      `address(0)`; routes that need no proof/settlement use the
+    ///      explicit `NullVerifier` / `NullSettlementModule` deployments.
+    function proposeSetRoute(
+        uint256 sourceChainId,
+        uint256 destChainId,
+        bool    enabled,
+        address finalityVerifier,
+        address settlementModule,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
+    /// @notice Propose rotating the RouteRegistry pointer on Bridge.
+    /// @dev opData = abi.encode(address newRouteRegistry). The new registry
+    ///      MUST be deployed with this Bridge's address as its `bridge_`
+    ///      immutable — otherwise dispatcher calls from Bridge revert
+    ///      `NotBridge` and inbound/outbound traffic on every route
+    ///      simultaneously breaks.
+    function proposeUpdateRouteRegistry(
+        address newRouteRegistry,
         uint256 nonce,
         uint256 deadline,
         uint256 fedBitmap,

--- a/ethereum/src/interfaces/IRouteRegistry.sol
+++ b/ethereum/src/interfaces/IRouteRegistry.sol
@@ -63,6 +63,26 @@ interface IRouteRegistry {
     );
 
     // =========================================================================
+    // Owner-only: route administration
+    // =========================================================================
+
+    /// @notice Adds or updates a route. Owner-only. Both plugin slots MUST be
+    ///         non-zero — explicit `NullVerifier` / `NullSettlementModule`
+    ///         deployments cover routes that deliberately opt out of a layer.
+    /// @param sourceChainId    Source chain id of the route key.
+    /// @param destChainId      Destination chain id of the route key.
+    /// @param enabled          New `enabled` flag.
+    /// @param finalityVerifier Verifier contract for this route.
+    /// @param settlementModule Settlement module contract for this route.
+    function setRoute(
+        uint256 sourceChainId,
+        uint256 destChainId,
+        bool    enabled,
+        address finalityVerifier,
+        address settlementModule
+    ) external;
+
+    // =========================================================================
     // Views
     // =========================================================================
 

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -3,13 +3,810 @@ pragma solidity 0.8.20;
 
 import { Test } from 'forge-std/Test.sol';
 
-/// @title BridgeTest — placeholder
-/// @notice TODO: full rewrite for the new Bridge surface
-///         (RouteRegistry wiring, 5-arg fundsIn, 8-arg fundsOut with
-///         `bytes proof` / `bytes settlementData`, removed btcRelay()
-///         and fundsInRecords() views) lands in a follow-up commit on
-///         the same branch. The previous Bridge.t.sol contents are
-///         preserved in git history at the previous commit.
+import { Bridge }              from '../src/Bridge.sol';
+import { IBridge }             from '../src/interfaces/IBridge.sol';
+import { BridgeBase }          from '../src/BridgeBase.sol';
+import { CommissionManager }   from '../src/CommissionManager.sol';
+import { RouteRegistry }       from '../src/RouteRegistry.sol';
+import { RGBVerifier }         from '../src/verifiers/RGBVerifier.sol';
+import { RgbSettlementModule } from '../src/settlement/RgbSettlementModule.sol';
+import {
+    CommissionConfig,
+    CommissionSide,
+    CommissionCurrency,
+    ICommissionManager
+} from '../src/interfaces/ICommissionManager.sol';
+
+import { MockERC20 }        from './mocks/MockERC20.sol';
+import { MockBtcRelay }     from './mocks/MockBtcRelay.sol';
+import { MockAggregatorV3 } from './mocks/MockAggregatorV3.sol';
+
+import { Ownable }   from '@openzeppelin/contracts/access/Ownable.sol';
+import { Pausable }  from '@openzeppelin/contracts/utils/Pausable.sol';
+
 contract BridgeTest is Test {
-    function test_FIXME_PR5_full_rewrite_pending() public pure {}
+    // Events re-declared locally for vm.expectEmit
+    event FundsIn(address indexed sender, uint256 operationId, uint256 amount);
+    event BridgeFundsIn(
+        address indexed sender,
+        uint256 operationId,
+        uint256 amount,
+        uint256 netAmount,
+        uint256 tokenCommission,
+        uint256 nativeCommission,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string  destinationAddress
+    );
+    event BridgeFundsOut(
+        address indexed recipient,
+        uint256 amount,
+        uint256 netAmount,
+        uint256 tokenCommission,
+        uint256 burnId,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string  sourceAddress
+    );
+    event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
+    event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+
+    Bridge              bridge;
+    MockERC20           usdt0;
+    MockBtcRelay        btcRelay;
+    CommissionManager   cm;
+    RouteRegistry       routeRegistry;
+    RGBVerifier         rgbVerifier;
+    RgbSettlementModule rgbModule;
+    MockAggregatorV3    ethUsdFeed;
+
+    address deployer  = makeAddr('deployer');
+    address user      = makeAddr('user');
+    address recipient = makeAddr('recipient');
+    address multisig  = makeAddr('multisig');
+
+    uint256 constant SOURCE_CHAIN_ID = 31337;     // foundry block.chainid
+    uint256 constant RGB_CHAIN_ID    = 1_000_001; // backend-assigned for RGB
+    string  constant DST_ADDR        = 'rgb:asset1qp0y3mq6h5k8d9f2e4j7n6c3w/utxo1abc123';
+    string  constant SRC_ADDR        = 'rgb:sender/utxo1src';
+    uint256 constant AMOUNT          = 100e18;
+    uint256 constant TX_ID           = 42;
+    uint256 constant BURN_ID         = 9_001;
+
+    // BtcRelay test data
+    uint256 constant BLOCK_HEIGHT     = 850_000;
+    bytes32 constant COMMITMENT_HASH  = keccak256('test-btc-block-commitment');
+    uint256 constant CONFIRMATIONS    = 6;
+
+    function setUp() public {
+        usdt0    = new MockERC20('Mock USDT0', 'USDT0');
+        btcRelay = new MockBtcRelay();
+        btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, CONFIRMATIONS);
+
+        // DeployAll-style deploy with predicted Bridge address:
+        //   nonce n      → CommissionManager (uses predicted Bridge)
+        //   nonce n+1    → RouteRegistry     (uses predicted Bridge,
+        //                                     deployer = owner)
+        //   nonce n+2    → Bridge            (uses RouteRegistry, CM)
+        //   nonce n+3    → RGBVerifier
+        //   nonce n+4    → RgbSettlementModule
+        // Routes are then registered by deployer before ownership transfer.
+        vm.startPrank(deployer);
+        uint64  currentNonce    = vm.getNonce(deployer);
+        address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
+
+        cm            = new CommissionManager(predictedBridge);
+        routeRegistry = new RouteRegistry(predictedBridge, deployer);
+        bridge        = new Bridge(
+            address(usdt0),
+            address(routeRegistry),
+            payable(address(cm)),
+            address(0)
+        );
+
+        rgbVerifier = new RGBVerifier(address(btcRelay));
+        rgbModule   = new RgbSettlementModule(address(routeRegistry));
+
+        // Both directions of the RGB route share the same verifier + module.
+        routeRegistry.setRoute(
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID,
+            true, address(rgbVerifier), address(rgbModule)
+        );
+        routeRegistry.setRoute(
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID,
+            true, address(rgbVerifier), address(rgbModule)
+        );
+
+        // Wire a Chainlink ETH/USD feed ($2000 / ETH, 8 decimals, fresh) so
+        // the NATIVE commission path quotes a positive value.
+        ethUsdFeed = new MockAggregatorV3(8, 2_000e8, block.timestamp);
+        cm.setEthUsdFeed(address(ethUsdFeed), 1 hours);
+
+        // Production-flow ownership transfer of Bridge → multisig. CM and
+        // RouteRegistry stay owned by deployer for this suite so individual
+        // tests can configure commission rules and routes inline. The
+        // governance-driven paths live in MultisigProxy.t.sol / Integration.t.sol.
+        bridge.transferOwnership(multisig);
+        vm.stopPrank();
+
+        // fund user and approve bridge
+        usdt0.mint(user, AMOUNT * 10);
+        vm.prank(user);
+        usdt0.approve(address(bridge), type(uint256).max);
+    }
+
+    // ========================================================================
+    // helpers
+    // ========================================================================
+
+    function _singleFundsInId() internal pure returns (uint256[] memory ids) {
+        ids = new uint256[](1);
+        ids[0] = TX_ID;
+    }
+
+    function _proof() internal pure returns (bytes memory) {
+        return abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
+    }
+
+    function _settlement(uint256[] memory ids) internal pure returns (bytes memory) {
+        return abi.encode(ids);
+    }
+
+    function _setFundsInTokenRule(uint256 percent) internal {
+        vm.prank(deployer);
+        cm.setCommissionRule(
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0),
+            CommissionConfig({
+                stablePercent: percent,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_IN,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+    }
+
+    function _setFundsInNativeRule(uint256 percent) internal {
+        vm.prank(deployer);
+        cm.setCommissionRule(
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0),
+            CommissionConfig({
+                stablePercent: percent,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_IN,
+                currency: CommissionCurrency.NATIVE,
+                isSet: true
+            })
+        );
+    }
+
+    function _setFundsOutTokenRule(uint256 percent) internal {
+        vm.prank(deployer);
+        cm.setCommissionRule(
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(usdt0),
+            CommissionConfig({
+                stablePercent: percent,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_OUT,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+    }
+
+    function _setFundsOutNativeRule(uint256 percent) internal {
+        vm.prank(deployer);
+        cm.setCommissionRule(
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(usdt0),
+            CommissionConfig({
+                stablePercent: percent,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_OUT,
+                currency: CommissionCurrency.NATIVE,
+                isSet: true
+            })
+        );
+    }
+
+    // ========================================================================
+    // Constructor
+    // ========================================================================
+
+    function test_constructor_setsTokenOwnerAndRouteRegistry() public view {
+        assertEq(bridge.TOKEN(),                       address(usdt0));
+        assertEq(bridge.owner(),                       multisig);
+        assertEq(bridge.routeRegistry(),               address(routeRegistry));
+        assertEq(address(bridge.commissionManager()),  address(cm));
+    }
+
+    function test_constructor_revertsOnZeroToken() public {
+        vm.expectRevert(BridgeBase.InvalidTokenAddress.selector);
+        new Bridge(address(0), address(routeRegistry), payable(address(cm)), address(0));
+    }
+
+    function test_constructor_revertsOnZeroRouteRegistry() public {
+        vm.expectRevert(IBridge.InvalidRouteRegistryAddress.selector);
+        new Bridge(address(usdt0), address(0), payable(address(cm)), address(0));
+    }
+
+    function test_constructor_revertsOnZeroCommissionManager() public {
+        vm.expectRevert(IBridge.InvalidCommissionManagerAddress.selector);
+        new Bridge(address(usdt0), address(routeRegistry), payable(address(0)), address(0));
+    }
+
+    function test_constructor_storesInitialLZAdapter() public {
+        address initialAdapter = makeAddr('initial-adapter');
+        vm.prank(deployer);
+        Bridge b = new Bridge(
+            address(usdt0), address(routeRegistry), payable(address(cm)), initialAdapter
+        );
+        assertEq(b.lzAdapter(), initialAdapter, 'lzAdapter set in constructor');
+    }
+
+    // ========================================================================
+    // setLZAdapter
+    // ========================================================================
+
+    function test_setLZAdapter_ownerCanSetAndUnset() public {
+        address adapter = makeAddr('adapter');
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit LZAdapterUpdated(address(0), adapter);
+
+        vm.prank(multisig);
+        bridge.setLZAdapter(adapter);
+        assertEq(bridge.lzAdapter(), adapter, 'set');
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit LZAdapterUpdated(adapter, address(0));
+
+        vm.prank(multisig);
+        bridge.setLZAdapter(address(0));
+        assertEq(bridge.lzAdapter(), address(0), 'unset');
+    }
+
+    function test_setLZAdapter_revertsIfNotOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.setLZAdapter(makeAddr('adapter'));
+    }
+
+    // ========================================================================
+    // setRouteRegistry (new in PR6)
+    // ========================================================================
+
+    function test_setRouteRegistry_ownerCanRotate() public {
+        // Deploy a NEW registry paired with the same Bridge (the documented
+        // invariant). In production the new registry must already be wired
+        // with this Bridge as its `bridge_` immutable.
+        RouteRegistry newReg = new RouteRegistry(address(bridge), multisig);
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit RouteRegistryUpdated(address(routeRegistry), address(newReg));
+
+        vm.prank(multisig);
+        bridge.setRouteRegistry(address(newReg));
+        assertEq(bridge.routeRegistry(), address(newReg));
+    }
+
+    function test_setRouteRegistry_revertsOnZero() public {
+        vm.prank(multisig);
+        vm.expectRevert(IBridge.InvalidRouteRegistryAddress.selector);
+        bridge.setRouteRegistry(address(0));
+    }
+
+    function test_setRouteRegistry_revertsIfNotOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.setRouteRegistry(makeAddr('newReg'));
+    }
+
+    // ========================================================================
+    // fundsIn — adapter overload (`onlyLZAdapter`)
+    // ========================================================================
+
+    function test_fundsInFromAdapter_revertsIfCallerIsNotLZAdapter() public {
+        // No adapter set in setUp — caller is `user`.
+        vm.prank(user);
+        vm.expectRevert(IBridge.NotLZAdapter.selector);
+        bridge.fundsIn(AMOUNT, 1, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+    }
+
+    function test_fundsInFromAdapter_acceptsCustomSourceChainId() public {
+        address mockAdapter = makeAddr('mock-adapter');
+        vm.prank(multisig);
+        bridge.setLZAdapter(mockAdapter);
+
+        usdt0.mint(mockAdapter, AMOUNT);
+        vm.prank(mockAdapter);
+        usdt0.approve(address(bridge), AMOUNT);
+
+        uint256 customSrc = 137; // pretend Polygon
+
+        // Register a route for the custom (Polygon, RGB) pair — the adapter
+        // overload simply forwards whatever sourceChainId the composeMsg
+        // carries; both directions need real routes wired in the registry.
+        vm.prank(deployer);
+        routeRegistry.setRoute(
+            customSrc, RGB_CHAIN_ID,
+            true, address(rgbVerifier), address(rgbModule)
+        );
+
+        // Drop the emitter filter so Forge's expectEmit scans past the token's
+        // Transfer event (emitter = usdt0) and matches BridgeFundsIn by topic0.
+        vm.expectEmit(true, false, false, true);
+        emit BridgeFundsIn(mockAdapter, TX_ID, AMOUNT, AMOUNT, 0, 0, customSrc, RGB_CHAIN_ID, DST_ADDR);
+
+        vm.prank(mockAdapter);
+        bridge.fundsIn(AMOUNT, customSrc, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertEq(rgbModule.fundsInRecords(TX_ID), AMOUNT, 'record stored on module');
+    }
+
+    // ========================================================================
+    // fundsIn — happy path (zero commission default)
+    // ========================================================================
+
+    function test_fundsIn_transfersTokens() public {
+        uint256 userBefore = usdt0.balanceOf(user);
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
+        assertEq(usdt0.balanceOf(user),            userBefore - AMOUNT);
+    }
+
+    function test_fundsIn_storesRecordOnModule() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertEq(rgbModule.fundsInRecords(TX_ID), AMOUNT);
+    }
+
+    function test_fundsIn_emitsBothEvents() public {
+        vm.expectEmit(true, false, false, true);
+        emit FundsIn(user, TX_ID, AMOUNT);
+        vm.expectEmit(true, false, false, true);
+        emit BridgeFundsIn(user, TX_ID, AMOUNT, AMOUNT, 0, 0, SOURCE_CHAIN_ID, RGB_CHAIN_ID, DST_ADDR);
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+    }
+
+    function test_fundsIn_anyUserCanCall() public {
+        address stranger = makeAddr('stranger');
+        usdt0.mint(stranger, AMOUNT);
+        vm.prank(stranger);
+        usdt0.approve(address(bridge), AMOUNT);
+
+        vm.prank(stranger);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
+    }
+
+    // ========================================================================
+    // fundsIn — reverts
+    // ========================================================================
+
+    function test_fundsIn_revertsOnEmptyDestinationAddress() public {
+        vm.expectRevert(IBridge.InvalidDestinationAddress.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, '', TX_ID, '');
+    }
+
+    function test_fundsIn_revertsOnEmptyDestinationChain() public {
+        vm.expectRevert(IBridge.InvalidDestinationChainId.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, 0, DST_ADDR, TX_ID, '');
+    }
+
+    function test_fundsIn_revertsWhenPaused() public {
+        vm.prank(multisig);
+        bridge.pause();
+
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+    }
+
+    function test_fundsIn_revertsOnDuplicateOperationId() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        // Duplicate-operationId guard moved into RgbSettlementModule. The
+        // revert propagates up through routeRegistry → Bridge unchanged.
+        vm.expectRevert(RgbSettlementModule.DuplicateOperationId.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+    }
+
+    // ========================================================================
+    // fundsOut — happy path
+    // ========================================================================
+
+    function test_fundsOut_transfersAndEmits() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        vm.expectEmit(true, false, false, true);
+        emit BridgeFundsOut(
+            recipient, AMOUNT, AMOUNT, 0, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR
+        );
+
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+
+        assertEq(usdt0.balanceOf(recipient),       AMOUNT);
+        assertEq(usdt0.balanceOf(address(bridge)), 0);
+    }
+
+    function test_fundsOut_consumesRecord() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+
+        assertEq(rgbModule.fundsInRecords(TX_ID), 0);
+    }
+
+    function test_fundsOut_multipleFundsInIds() public {
+        uint256 txId1 = 100;
+        uint256 txId2 = 101;
+        uint256 amount1 = 60e18;
+        uint256 amount2 = 40e18;
+
+        vm.prank(user);
+        bridge.fundsIn(amount1, RGB_CHAIN_ID, DST_ADDR, txId1, '');
+        vm.prank(user);
+        bridge.fundsIn(amount2, RGB_CHAIN_ID, DST_ADDR, txId2, '');
+
+        uint256[] memory ids = new uint256[](2);
+        ids[0] = txId1;
+        ids[1] = txId2;
+
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, amount1 + amount2, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(ids)
+        );
+
+        assertEq(usdt0.balanceOf(recipient), amount1 + amount2);
+        assertEq(rgbModule.fundsInRecords(txId1), 0);
+        assertEq(rgbModule.fundsInRecords(txId2), 0);
+    }
+
+    // ========================================================================
+    // fundsOut — verifier reverts
+    // ========================================================================
+
+    function test_fundsOut_revertsOnUnverifiedBlock() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        bytes memory badProof = abi.encode(uint256(999_999), keccak256('unknown-block'));
+
+        // RGBVerifier → BtcRelay reverts with the relay's string message.
+        vm.expectRevert('verify: block commitment');
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            badProof, _settlement(_singleFundsInId())
+        );
+    }
+
+    // ========================================================================
+    // fundsOut — settlement-module reverts (delegated to RgbSettlementModule
+    // but surfaced through Bridge)
+    // ========================================================================
+
+    function test_fundsOut_revertsOnUnknownFundsInId() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 999;
+
+        vm.expectRevert(abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, 999));
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(ids)
+        );
+    }
+
+    function test_fundsOut_revertsOnAmountExceedsFundsIn() public {
+        uint256 txId1 = 100;
+        uint256 txId2 = 101;
+        vm.prank(user);
+        bridge.fundsIn(50e18, RGB_CHAIN_ID, DST_ADDR, txId1, '');
+        vm.prank(user);
+        bridge.fundsIn(50e18, RGB_CHAIN_ID, DST_ADDR, txId2, '');
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = txId1;
+
+        vm.expectRevert(RgbSettlementModule.FundsOutAmountExceedsFundsIn.selector);
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, 60e18, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(ids)
+        );
+    }
+
+    function test_fundsOut_revertsOnReplayedBurnId() public {
+        uint256 txId1 = 200;
+        uint256 txId2 = 201;
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId1, '');
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId2, '');
+
+        uint256[] memory ids1 = new uint256[](1); ids1[0] = txId1;
+        uint256[] memory ids2 = new uint256[](1); ids2[0] = txId2;
+
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(ids1)
+        );
+        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burnId recorded');
+
+        // Second fundsOut with the same burnId — must revert before any
+        // module mutation, leaving the second record untouched.
+        vm.expectRevert(abi.encodeWithSelector(IBridge.BurnIdAlreadyConsumed.selector, BURN_ID));
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(ids2)
+        );
+        assertEq(rgbModule.fundsInRecords(txId2), AMOUNT, 'second fundsIn record preserved');
+    }
+
+    function test_fundsOut_revertsOnDoubleSpendsConsumedFundsIn() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+
+        // Top up the bridge directly (simulates a fresh pool) and try a second
+        // release against the same — now consumed — fundsIn record.
+        usdt0.mint(address(bridge), AMOUNT);
+
+        vm.expectRevert(abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, TX_ID));
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID + 1,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+    }
+
+    // ========================================================================
+    // fundsOut — other reverts
+    // ========================================================================
+
+    function test_fundsOut_revertsIfNotOwner() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+    }
+
+    function test_fundsOut_revertsOnZeroRecipient() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        vm.expectRevert(BridgeBase.InvalidRecipientAddress.selector);
+        vm.prank(multisig);
+        bridge.fundsOut(
+            address(0), AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+    }
+
+    function test_fundsOut_revertsIfAmountExceedsPool() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        vm.expectRevert(BridgeBase.AmountExceedBridgePool.selector);
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT + 1, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+    }
+
+    // ========================================================================
+    // Commission — fundsIn TOKEN
+    // ========================================================================
+
+    function test_fundsIn_tokenCommission_routesToCM() public {
+        uint256 percent = 400; // 4%
+        _setFundsInTokenRule(percent);
+
+        uint256 expectedCommission = (AMOUNT * percent) / 100 / 100;
+        uint256 expectedNet        = AMOUNT - expectedCommission;
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertEq(usdt0.balanceOf(address(bridge)),         expectedNet,         'bridge net');
+        assertEq(usdt0.balanceOf(address(cm)),             expectedCommission,  'cm pool');
+        assertEq(cm.tokenCommissionPool(address(usdt0)),   expectedCommission,  'cm recorded');
+        assertEq(rgbModule.fundsInRecords(TX_ID),          expectedNet,         'record = net');
+    }
+
+    // ========================================================================
+    // Commission — fundsIn NATIVE
+    // ========================================================================
+
+    function test_fundsIn_nativeCommission_routesToCM() public {
+        uint256 percent = 100; // 1%
+        _setFundsInNativeRule(percent);
+
+        (uint256 tokenC, uint256 nativeC, uint256 net) =
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
+        assertEq(tokenC, 0);
+        assertGt(nativeC, 0);
+        assertEq(net, AMOUNT);
+
+        vm.deal(user, nativeC);
+        vm.prank(user);
+        bridge.fundsIn{ value: nativeC }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
+        assertEq(address(cm).balance,              nativeC);
+        assertEq(cm.nativeCommissionPool(),        nativeC);
+        assertEq(rgbModule.fundsInRecords(TX_ID),  AMOUNT);
+    }
+
+    // ========================================================================
+    // Commission — fundsOut TOKEN
+    // ========================================================================
+
+    function test_fundsOut_tokenCommission_routesToCM() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        uint256 percent = 500; // 5%
+        _setFundsOutTokenRule(percent);
+
+        uint256 expectedCommission = (AMOUNT * percent) / 100 / 100;
+        uint256 expectedNet        = AMOUNT - expectedCommission;
+
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+
+        assertEq(usdt0.balanceOf(recipient),              expectedNet,         'recipient net');
+        assertEq(usdt0.balanceOf(address(cm)),            expectedCommission,  'cm pool');
+        assertEq(cm.tokenCommissionPool(address(usdt0)),  expectedCommission,  'cm recorded');
+    }
+
+    // ========================================================================
+    // Commission — fundsOut NATIVE reverts
+    // ========================================================================
+
+    function test_fundsOut_nativeCommission_reverts() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        _setFundsOutNativeRule(100);
+
+        vm.expectRevert(IBridge.NativeCommissionNotAllowedOnFundsOut.selector);
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+    }
+
+    // ========================================================================
+    // Commission — NativeValueMismatch
+    // ========================================================================
+
+    function test_fundsIn_revertsOnNativeValueMismatch_zeroRuleButValueSent() public {
+        vm.deal(user, 1 ether);
+        vm.expectRevert(IBridge.NativeValueMismatch.selector);
+        vm.prank(user);
+        bridge.fundsIn{ value: 1 ether }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+    }
+
+    function test_fundsIn_revertsOnNativeValueMismatch_nativeRuleButNoValue() public {
+        _setFundsInNativeRule(100);
+
+        vm.expectRevert(IBridge.NativeValueMismatch.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+    }
+
+    // ========================================================================
+    // pause / unpause / renounceOwnership
+    // ========================================================================
+
+    function test_pause_onlyOwner() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.pause();
+    }
+
+    function test_unpause_onlyOwner() public {
+        vm.prank(multisig);
+        bridge.pause();
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.unpause();
+    }
+
+    function test_renounceOwnership_alwaysReverts() public {
+        vm.expectRevert(BridgeBase.RenounceOwnershipBlocked.selector);
+        vm.prank(multisig);
+        bridge.renounceOwnership();
+    }
+
+    // ========================================================================
+    // views
+    // ========================================================================
+
+    function test_getContractBalance() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertEq(bridge.getContractBalance(), AMOUNT);
+    }
+
+    function test_getChainId() public view {
+        assertEq(bridge.getChainId(), block.chainid);
+    }
+
+    // ========================================================================
+    // Fuzz
+    // ========================================================================
+
+    function testFuzz_fundsIn_validAmount(uint128 amount) public {
+        vm.assume(amount > 0);
+        usdt0.mint(user, amount);
+
+        vm.prank(user);
+        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertEq(usdt0.balanceOf(address(bridge)), amount);
+        assertEq(rgbModule.fundsInRecords(TX_ID),  amount);
+    }
 }

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -255,13 +255,6 @@ contract IntegrationTest is Test {
             )
         );
 
-        // Authorise the new 8-arg fundsOut selector on the TEE allowlist. The
-        // MultisigProxy constructor still seeds the legacy 10-arg selector by
-        // default — PR6 swaps the default; until then the test wires the new
-        // one through the federation governance flow it would use in
-        // production anyway.
-        _authorizeNewFundsOutSelector();
-
         // Sanity: CM now quotes commission for both routes.
         (uint256 tInQuote,, uint256 netIn) =
             cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token), USER_DEPOSIT);
@@ -490,25 +483,6 @@ contract IntegrationTest is Test {
 
         vm.warp(block.timestamp + TIMELOCK + 1);
         proxy.executeProposal(proposalId, callData);
-    }
-
-    /// @dev Adds `FUNDS_OUT_SELECTOR` to the TEE allowlist via a
-    ///      `proposeSetTeeAllowedCall` proposal. Used in the token-commission
-    ///      e2e test so the proxy accepts the new 8-arg fundsOut signature.
-    function _authorizeNewFundsOutSelector() internal {
-        uint256 nonce    = proxy.proposalNonce();
-        uint256 deadline = block.timestamp + 7 days;
-        bytes32 digest   = MultisigHelper.digestProposeSetTeeAllowedCall(
-            domainSep, address(bridge), FUNDS_OUT_SELECTOR, true, nonce, deadline
-        );
-        bytes[] memory sigs = _signFed2of3(digest);
-
-        bytes32 proposalId = proxy.proposeSetTeeAllowedCall(
-            address(bridge), FUNDS_OUT_SELECTOR, true,
-            nonce, deadline, 3, sigs
-        );
-        vm.warp(block.timestamp + TIMELOCK + 1);
-        proxy.executeProposal(proposalId, abi.encode(address(bridge), FUNDS_OUT_SELECTOR, true));
     }
 
     function _signEnclave2of3(bytes32 digest) internal view returns (bytes[] memory sigs) {

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -3,13 +3,1287 @@ pragma solidity 0.8.20;
 
 import { Test } from 'forge-std/Test.sol';
 
-/// @title MultisigProxyTest — placeholder
-/// @notice TODO: full rewrite for the new Bridge surface
-///         (RouteRegistry wiring, 5-arg fundsIn, 8-arg fundsOut with
-///         `bytes proof` / `bytes settlementData`, FUNDS_OUT_SELECTOR
-///         updated to the new shape) lands in a follow-up commit on
-///         the same branch. The previous MultisigProxy.t.sol contents
-///         are preserved in git history at the previous commit.
+import { MultisigProxy }  from '../src/MultisigProxy.sol';
+import { IMultisigProxy } from '../src/interfaces/IMultisigProxy.sol';
+import { Bridge }              from '../src/Bridge.sol';
+import { CommissionManager }   from '../src/CommissionManager.sol';
+import { RouteRegistry }       from '../src/RouteRegistry.sol';
+import { IRouteRegistry }      from '../src/interfaces/IRouteRegistry.sol';
+import { RGBVerifier }         from '../src/verifiers/RGBVerifier.sol';
+import { RgbSettlementModule } from '../src/settlement/RgbSettlementModule.sol';
+import { RouteConfig }         from '../src/interfaces/RouteTypes.sol';
+import {
+    CommissionConfig,
+    CommissionSide,
+    CommissionCurrency,
+    ICommissionManager
+} from '../src/interfaces/ICommissionManager.sol';
+
+import { MockERC20 }       from './mocks/MockERC20.sol';
+import { MockBtcRelay }    from './mocks/MockBtcRelay.sol';
+import { MultisigHelper }  from './mocks/MultisigHelper.sol';
+
 contract MultisigProxyTest is Test {
-    function test_FIXME_PR5_full_rewrite_pending() public pure {}
+    using MultisigHelper for bytes32;
+
+    // ---- Re-declared events ------------------------------------------------
+    event Executed(bytes4 indexed selector, uint256 nonce, uint256 enclaveBitmap);
+    event EmergencyPaused(uint256 nonce, uint256 fedBitmap);
+    event EmergencyUnpaused(uint256 nonce, uint256 fedBitmap);
+    event ProposalCreated(
+        bytes32 indexed proposalId,
+        IMultisigProxy.OperationType indexed opType,
+        bytes operationData,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap
+    );
+    event ProposalCancelled(bytes32 indexed proposalId);
+    event ProposalExecuted(bytes32 indexed proposalId, IMultisigProxy.OperationType indexed opType);
+    event EnclaveSignersUpdated(address[] newSigners, uint256 newThreshold);
+    event FederationSignersUpdated(address[] newSigners, uint256 newThreshold);
+    event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
+    event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
+    event TeeAllowedCallUpdated(address indexed target, bytes4 indexed selector, bool allowed);
+    event TimelockDurationUpdated(uint256 newDuration);
+    event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
+    event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
+    event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+    event RouteSet(
+        uint256 indexed sourceChainId,
+        uint256 indexed destChainId,
+        bool            enabled,
+        address         finalityVerifier,
+        address         settlementModule
+    );
+
+    MultisigProxy       proxy;
+    Bridge              bridge;
+    CommissionManager   cm;
+    RouteRegistry       routeRegistry;
+    RGBVerifier         rgbVerifier;
+    RgbSettlementModule rgbModule;
+    MockERC20           token;
+    MockBtcRelay        btcRelay;
+
+    // Enclave signers (3-of-N with threshold 2)
+    uint256 encPk1 = 0xE1;
+    uint256 encPk2 = 0xE2;
+    uint256 encPk3 = 0xE3;
+    address encA1;
+    address encA2;
+    address encA3;
+
+    // Federation signers (3-of-N with threshold 2)
+    uint256 fedPk1 = 0xF1;
+    uint256 fedPk2 = 0xF2;
+    uint256 fedPk3 = 0xF3;
+    address fedA1;
+    address fedA2;
+    address fedA3;
+
+    address deployer           = makeAddr('deployer');
+    address user               = makeAddr('user');
+    address recipient          = makeAddr('recipient');
+    address commissionReceiver = makeAddr('commissionReceiver');
+
+    uint256 constant TIMELOCK = 1 hours;
+
+    bytes32 domainSep;
+
+    // Chain identifiers + canonical fundsOut args
+    uint256 constant SOURCE_CHAIN_ID = 31337;     // foundry block.chainid
+    uint256 constant RGB_CHAIN_ID    = 1_000_001; // backend-assigned for RGB
+    string  constant DST_ADDR        = 'rgb:asset/utxo1abc';
+    string  constant SRC_ADDR        = 'rgb:sender/utxo1src';
+    uint256 constant AMOUNT  = 100e18;
+    uint256 constant TX_ID   = 42;
+    uint256 constant BURN_ID = 9_001;
+
+    // BtcRelay test data
+    uint256 constant BLOCK_HEIGHT      = 850_000;
+    bytes32 constant COMMITMENT_HASH   = keccak256('test-btc-block-commitment');
+    uint256 constant BTC_CONFIRMATIONS = 6;
+
+    /// @dev 8-arg fundsOut selector:
+    ///        fundsOut(address recipient, uint256 amount, uint256 burnId,
+    ///                 uint256 sourceChainId, uint256 destinationChainId,
+    ///                 string sourceAddress, bytes proof, bytes settlementData)
+    bytes4  constant FUNDS_OUT_SELECTOR = bytes4(keccak256(
+        'fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)'
+    ));
+
+    function setUp() public {
+        encA1 = vm.addr(encPk1);
+        encA2 = vm.addr(encPk2);
+        encA3 = vm.addr(encPk3);
+        fedA1 = vm.addr(fedPk1);
+        fedA2 = vm.addr(fedPk2);
+        fedA3 = vm.addr(fedPk3);
+
+        token    = new MockERC20('Mock USDT0', 'USDT0');
+        btcRelay = new MockBtcRelay();
+        btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, BTC_CONFIRMATIONS);
+
+        // DeployAll-style with predicted Bridge address. Deployer tx order:
+        //   nonce n      → CommissionManager (uses predicted Bridge)
+        //   nonce n+1    → RouteRegistry     (uses predicted Bridge; deployer
+        //                                     stays owner for initial route
+        //                                     registration, then transfers to
+        //                                     proxy)
+        //   nonce n+2    → Bridge            (uses RouteRegistry, CM)
+        //   nonce n+3    → RGBVerifier
+        //   nonce n+4    → RgbSettlementModule
+        //   nonce n+5    → MultisigProxy
+        vm.startPrank(deployer);
+
+        uint64  currentNonce    = vm.getNonce(deployer);
+        address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
+
+        cm            = new CommissionManager(predictedBridge);
+        routeRegistry = new RouteRegistry(predictedBridge, deployer);
+        bridge        = new Bridge(
+            address(token),
+            address(routeRegistry),
+            payable(address(cm)),
+            address(0)
+        );
+
+        rgbVerifier = new RGBVerifier(address(btcRelay));
+        rgbModule   = new RgbSettlementModule(address(routeRegistry));
+
+        // Register both directions of the RGB route while deployer still owns
+        // the registry. Inbound (SOURCE → RGB) never calls verify; outbound
+        // (RGB → SOURCE) runs the BtcRelay check.
+        routeRegistry.setRoute(
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID,
+            true, address(rgbVerifier), address(rgbModule)
+        );
+        routeRegistry.setRoute(
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID,
+            true, address(rgbVerifier), address(rgbModule)
+        );
+
+        address[] memory enc = new address[](3);
+        enc[0] = encA1; enc[1] = encA2; enc[2] = encA3;
+        address[] memory fed = new address[](3);
+        fed[0] = fedA1; fed[1] = fedA2; fed[2] = fedA3;
+
+        proxy = new MultisigProxy(
+            address(bridge),
+            address(cm),
+            enc, 2,
+            fed, 2,
+            commissionReceiver,
+            TIMELOCK
+        );
+
+        // Production-flow ownership transfer.
+        bridge.transferOwnership(address(proxy));
+        cm.transferOwnership(address(proxy));
+        routeRegistry.transferOwnership(address(proxy));
+        vm.stopPrank();
+
+        domainSep = proxy.DOMAIN_SEPARATOR();
+
+        // Fund user, lock tokens into the bridge so fundsOut has a pool.
+        token.mint(user, AMOUNT * 10);
+        vm.prank(user);
+        token.approve(address(bridge), type(uint256).max);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT * 5, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+    }
+
+    // ========================================================================
+    // helpers
+    // ========================================================================
+
+    function _encSigSet2of3() internal pure returns (uint256[] memory pks, uint256 bitmap) {
+        pks = new uint256[](2);
+        pks[0] = 0xE1;
+        pks[1] = 0xE2;
+        bitmap = 0x3;
+    }
+
+    function _fedSigSet2of3() internal pure returns (uint256[] memory pks, uint256 bitmap) {
+        pks = new uint256[](2);
+        pks[0] = 0xF1;
+        pks[1] = 0xF2;
+        bitmap = 0x3;
+    }
+
+    function _fundsInIds() internal pure returns (uint256[] memory ids) {
+        ids = new uint256[](1);
+        ids[0] = TX_ID;
+    }
+
+    function _fundsOutCalldata() internal view returns (bytes memory) {
+        bytes memory proof          = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
+        bytes memory settlementData = abi.encode(_fundsInIds());
+        return abi.encodeWithSelector(
+            FUNDS_OUT_SELECTOR,
+            recipient, AMOUNT, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            proof, settlementData
+        );
+    }
+
+    // ========================================================================
+    // Constructor
+    // ========================================================================
+
+    function test_constructor_setsState() public view {
+        assertEq(proxy.bridge(), address(bridge));
+        assertEq(proxy.commissionManager(), address(cm));
+        assertEq(proxy.enclaveThreshold(), 2);
+        assertEq(proxy.federationThreshold(), 2);
+        assertEq(proxy.commissionRecipient(), commissionReceiver);
+        assertEq(proxy.timelockDuration(), TIMELOCK);
+        assertEq(proxy.proposalNonce(), 0);
+        // Default TEE allowlist uses the new 8-arg fundsOut selector.
+        assertTrue(proxy.teeAllowedCalls(address(bridge), FUNDS_OUT_SELECTOR));
+
+        address[] memory enc = proxy.getEnclaveSigners();
+        assertEq(enc.length, 3);
+        assertEq(enc[0], encA1);
+
+        address[] memory fed = proxy.getFederationSigners();
+        assertEq(fed.length, 3);
+    }
+
+    function test_constructor_revertsOnZeroBridge() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.ZeroBridge.selector);
+        new MultisigProxy(address(0), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+    }
+
+    function test_constructor_revertsOnZeroCommissionManager() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.ZeroCommissionManager.selector);
+        new MultisigProxy(address(bridge), address(0), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+    }
+
+    function test_constructor_revertsOnNoEnclaveSigners() public {
+        address[] memory enc = new address[](0);
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.NoSigners.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+    }
+
+    function test_constructor_revertsOnBadEnclaveThreshold() public {
+        address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 3, fed, 1, commissionReceiver, TIMELOCK);
+    }
+
+    function test_constructor_revertsOnZeroCommission() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.ZeroCommissionRecipient.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, address(0), TIMELOCK);
+    }
+
+    function test_constructor_revertsOnTimelockTooLong() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.TimelockTooLong.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 30 days);
+    }
+
+    function test_constructor_revertsOnDuplicateSigner() public {
+        address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+    }
+
+    function test_constructor_revertsOnZeroAddressSigner() public {
+        address[] memory enc = new address[](1); enc[0] = address(0);
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+    }
+
+    // ========================================================================
+    // TEE execute — happy path
+    // ========================================================================
+
+    function test_execute_fundsOutViaBridge() public {
+        bytes memory callData = _fundsOutCalldata();
+        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectEmit(true, false, false, true);
+        emit Executed(FUNDS_OUT_SELECTOR, nonce, bitmap);
+
+        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+
+        assertEq(token.balanceOf(recipient), AMOUNT);
+        assertEq(proxy.getNonce(FUNDS_OUT_SELECTOR), nonce + 1);
+    }
+
+    function test_execute_revertsOnExpired() public {
+        bytes memory callData = _fundsOutCalldata();
+        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        uint256 deadline = block.timestamp - 1;
+
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.Expired.selector);
+        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_execute_revertsOnWrongNonce() public {
+        bytes memory callData = _fundsOutCalldata();
+        uint256 nonce = 99;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
+        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_execute_revertsOnDisallowedSelector() public {
+        bytes memory callData = abi.encodeWithSignature('pause()');
+        uint256 nonce = 0;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, bytes4(callData), callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IMultisigProxy.CallNotAllowed.selector, address(bridge), bytes4(callData)
+        ));
+        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+    }
+
+    // ========================================================================
+    // executeBatch
+    // ========================================================================
+
+    /// @dev Helper: build a single-element batch around the standard fundsOut call.
+    function _singleFundsOutBatch() internal view returns (
+        address[] memory targets,
+        bytes[]   memory callDatas,
+        uint256[] memory values
+    ) {
+        targets = new address[](1);
+        callDatas = new bytes[](1);
+        values = new uint256[](1);
+        targets[0]   = address(bridge);
+        callDatas[0] = _fundsOutCalldata();
+        values[0]    = 0;
+    }
+
+    function test_executeBatch_singleFundsOut_happyPath() public {
+        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
+
+        uint256 nonce    = proxy.batchNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
+            domainSep, targets, callDatas, values, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        proxy.executeBatch(targets, callDatas, values, nonce, deadline, bitmap, sigs);
+
+        assertEq(token.balanceOf(recipient), AMOUNT,    'fundsOut delivered');
+        assertEq(proxy.batchNonce(),         nonce + 1, 'batchNonce incremented');
+    }
+
+    function test_executeBatch_revertsOnEmpty() public {
+        address[] memory targets = new address[](0);
+        bytes[]   memory callDatas = new bytes[](0);
+        uint256[] memory values = new uint256[](0);
+
+        bytes[] memory sigs = new bytes[](2);
+
+        vm.expectRevert(IMultisigProxy.BatchEmpty.selector);
+        proxy.executeBatch(targets, callDatas, values, 0, block.timestamp + 1 hours, 0x3, sigs);
+    }
+
+    function test_executeBatch_revertsOnLengthMismatch() public {
+        address[] memory targets   = new address[](2);
+        bytes[]   memory callDatas = new bytes[](1);
+        uint256[] memory values    = new uint256[](2);
+        targets[0] = address(bridge); targets[1] = address(bridge);
+        callDatas[0] = _fundsOutCalldata();
+
+        bytes[] memory sigs = new bytes[](2);
+
+        vm.expectRevert(IMultisigProxy.BatchLengthMismatch.selector);
+        proxy.executeBatch(targets, callDatas, values, 0, block.timestamp + 1 hours, 0x3, sigs);
+    }
+
+    function test_executeBatch_revertsOnDisallowedTargetSelector() public {
+        address[] memory targets   = new address[](1);
+        bytes[]   memory callDatas = new bytes[](1);
+        uint256[] memory values    = new uint256[](1);
+        targets[0]   = makeAddr('random-target');
+        callDatas[0] = abi.encodeWithSignature('pause()');
+
+        uint256 nonce    = proxy.batchNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
+            domainSep, targets, callDatas, values, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IMultisigProxy.CallNotAllowed.selector, targets[0], bytes4(callDatas[0])
+        ));
+        proxy.executeBatch(targets, callDatas, values, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_executeBatch_revertsOnValueMismatch() public {
+        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
+        values[0] = 1 ether;
+
+        uint256 nonce    = proxy.batchNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
+            domainSep, targets, callDatas, values, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.BatchValueMismatch.selector);
+        proxy.executeBatch{ value: 0 }(targets, callDatas, values, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_executeBatch_revertsOnTooLarge() public {
+        uint256 size = proxy.MAX_BATCH_SIZE() + 1;
+        address[] memory targets   = new address[](size);
+        bytes[]   memory callDatas = new bytes[](size);
+        uint256[] memory values    = new uint256[](size);
+
+        bytes[] memory sigs = new bytes[](2);
+        vm.expectRevert(IMultisigProxy.BatchTooLarge.selector);
+        proxy.executeBatch(targets, callDatas, values, 0, block.timestamp + 1 hours, 0x3, sigs);
+    }
+
+    function test_executeBatch_revertsOnExpired() public {
+        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
+
+        bytes[] memory sigs = new bytes[](2);
+        vm.expectRevert(IMultisigProxy.Expired.selector);
+        proxy.executeBatch(targets, callDatas, values, 0, block.timestamp - 1, 0x3, sigs);
+    }
+
+    function test_executeBatch_revertsOnWrongNonce() public {
+        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
+
+        uint256 wrongNonce = 99;
+        uint256 deadline   = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
+            domainSep, targets, callDatas, values, wrongNonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
+        proxy.executeBatch(targets, callDatas, values, wrongNonce, deadline, bitmap, sigs);
+    }
+
+    function test_execute_revertsOnCallDataTooShort() public {
+        bytes memory callData = hex'aabb';
+        vm.expectRevert(IMultisigProxy.CallDataTooShort.selector);
+        proxy.execute(callData, 0, block.timestamp + 1 hours, 0x3, new bytes[](2));
+    }
+
+    function test_execute_revertsOnBelowThreshold() public {
+        bytes memory callData = _fundsOutCalldata();
+        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        uint256[] memory pks = new uint256[](1); pks[0] = encPk1;
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.BelowThreshold.selector);
+        proxy.execute(callData, nonce, deadline, 0x1, sigs);
+    }
+
+    function test_execute_revertsOnBadSignature() public {
+        bytes memory callData = _fundsOutCalldata();
+        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        uint256[] memory pks = new uint256[](2);
+        pks[0] = encPk1;
+        pks[1] = 0xBADBAD;
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.execute(callData, nonce, deadline, 0x3, sigs);
+    }
+
+    function test_execute_revertsOnSigCountMismatch() public {
+        bytes memory callData = _fundsOutCalldata();
+        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        uint256[] memory pks = new uint256[](3);
+        pks[0] = encPk1; pks[1] = encPk2; pks[2] = encPk3;
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.SigCountMismatch.selector);
+        proxy.execute(callData, nonce, deadline, 0x3, sigs);
+    }
+
+    function test_execute_revertsOnBitmapOutOfRange() public {
+        bytes memory callData = _fundsOutCalldata();
+        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        (uint256[] memory pks,) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.BitmapOutOfRange.selector);
+        proxy.execute(callData, nonce, deadline, 0x100, sigs);
+    }
+
+    // ========================================================================
+    // Emergency pause / unpause
+    // ========================================================================
+
+    function test_emergencyPause_works() public {
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectEmit(false, false, false, true);
+        emit EmergencyPaused(nonce, bitmap);
+
+        proxy.emergencyPause(nonce, deadline, bitmap, sigs);
+
+        assertTrue(bridge.paused());
+        assertEq(proxy.proposalNonce(), nonce + 1);
+    }
+
+    function test_emergencyPause_revertsOnExpired() public {
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp - 1;
+
+        bytes32 digest = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.Expired.selector);
+        proxy.emergencyPause(nonce, deadline, bitmap, sigs);
+    }
+
+    function test_emergencyPause_revertsOnWrongNonce() public {
+        uint256 nonce = 99;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
+        proxy.emergencyPause(nonce, deadline, bitmap, sigs);
+    }
+
+    function test_emergencyUnpause_works() public {
+        test_emergencyPause_works();
+
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestEmergencyUnpause(domainSep, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectEmit(false, false, false, true);
+        emit EmergencyUnpaused(nonce, bitmap);
+
+        proxy.emergencyUnpause(nonce, deadline, bitmap, sigs);
+        assertFalse(bridge.paused());
+    }
+
+    // ========================================================================
+    // Propose + Execute — UpdateBridge
+    // ========================================================================
+
+    function test_proposeUpdateBridge_andExecuteAfterTimelock() public {
+        address newBridge = makeAddr('newBridge');
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 proposalId = proxy.proposeUpdateBridge(newBridge, nonce, deadline, bitmap, sigs);
+
+        vm.expectRevert(IMultisigProxy.TimelockActive.selector);
+        proxy.executeProposal(proposalId, abi.encode(newBridge));
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        vm.expectEmit(true, true, false, false);
+        emit BridgeAddressUpdated(address(bridge), newBridge);
+
+        proxy.executeProposal(proposalId, abi.encode(newBridge));
+        assertEq(proxy.bridge(), newBridge);
+    }
+
+    function test_proposeUpdateBridge_revertsOnExpired() public {
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp - 1;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateBridge(domainSep, makeAddr('nb'), nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.Expired.selector);
+        proxy.proposeUpdateBridge(makeAddr('nb'), nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeUpdateBridge_revertsOnDeadlineTooFar() public {
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 31 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateBridge(domainSep, makeAddr('nb'), nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.DeadlineTooFar.selector);
+        proxy.proposeUpdateBridge(makeAddr('nb'), nonce, deadline, bitmap, sigs);
+    }
+
+    // ========================================================================
+    // Propose + Execute — UpdateEnclaveSigners
+    // ========================================================================
+
+    function test_proposeUpdateEnclaveSigners_execute() public {
+        address newSigner = makeAddr('newEncSigner');
+        address[] memory newSigners = new address[](2);
+        newSigners[0] = encA1; newSigners[1] = newSigner;
+        uint256 newThreshold = 2;
+
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, newSigners, newThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+
+        address[] memory after_ = proxy.getEnclaveSigners();
+        assertEq(after_.length, 2);
+        assertEq(after_[1], newSigner);
+        assertEq(proxy.enclaveThreshold(), newThreshold);
+    }
+
+    // ========================================================================
+    // Propose + Execute — SetTeeAllowedCall
+    // ========================================================================
+
+    function test_proposeSetTeeAllowedCall_execute() public {
+        address target = makeAddr('lzAdapter');
+        bytes4  sel    = bytes4(0xdeadbeef);
+        uint256 nonce  = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeSetTeeAllowedCall(
+            domainSep, target, sel, true, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeSetTeeAllowedCall(target, sel, true, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        vm.expectEmit(true, true, false, true);
+        emit TeeAllowedCallUpdated(target, sel, true);
+
+        proxy.executeProposal(id, abi.encode(target, sel, true));
+        assertTrue(proxy.teeAllowedCalls(target, sel));
+    }
+
+    // ========================================================================
+    // Propose + Execute — SetTimelockDuration
+    // ========================================================================
+
+    function test_proposeSetTimelockDuration_execute() public {
+        uint256 newDuration = 2 hours;
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeSetTimelockDuration(domainSep, newDuration, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeSetTimelockDuration(newDuration, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        vm.expectEmit(false, false, false, true);
+        emit TimelockDurationUpdated(newDuration);
+        proxy.executeProposal(id, abi.encode(newDuration));
+
+        assertEq(proxy.timelockDuration(), newDuration);
+    }
+
+    // ========================================================================
+    // Propose + Execute — AdminExecute
+    // ========================================================================
+
+    function test_proposeAdminExecute_canCallBridge() public {
+        bytes memory callData = abi.encodeWithSignature('pause()');
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeAdminExecute(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecute(callData, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, callData);
+
+        assertTrue(bridge.paused());
+    }
+
+    // ========================================================================
+    // Propose + Execute — UpdateCommissionManager
+    // ========================================================================
+
+    function test_proposeUpdateCommissionManager_execute() public {
+        address newCm = makeAddr('newCm');
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateCommissionManager(domainSep, newCm, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateCommissionManager(newCm, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        vm.expectEmit(true, true, false, false);
+        emit CommissionManagerUpdated(address(cm), newCm);
+
+        proxy.executeProposal(id, abi.encode(newCm));
+        assertEq(proxy.commissionManager(), newCm);
+    }
+
+    // ========================================================================
+    // Propose + Execute — WithdrawTokenCommissionCM
+    // ========================================================================
+
+    function test_proposeWithdrawTokenCommissionCM_execute() public {
+        // Seed commission by setting a fundsIn TOKEN rule and doing a deposit.
+        vm.prank(address(proxy));
+        cm.setCommissionRule(
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token),
+            CommissionConfig({
+                stablePercent: 400, // 4%
+                multiplier: 100,
+                side: CommissionSide.FUNDS_IN,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        uint256 depositAmount = 100e18;
+        vm.prank(user);
+        bridge.fundsIn(depositAmount, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
+
+        uint256 expectedCommission = (depositAmount * 400) / 100 / 100;
+        assertEq(cm.tokenCommissionPool(address(token)), expectedCommission);
+
+        // Propose withdrawal.
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeWithdrawTokenCommissionCM(
+            domainSep, address(token), expectedCommission, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeWithdrawTokenCommissionCM(
+            address(token), expectedCommission, nonce, deadline, bitmap, sigs
+        );
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        uint256 recipientBefore = token.balanceOf(commissionReceiver);
+
+        vm.expectEmit(true, true, false, true);
+        emit CommissionWithdrawn(address(token), expectedCommission, commissionReceiver);
+
+        proxy.executeProposal(id, abi.encode(address(token), expectedCommission));
+
+        assertEq(token.balanceOf(commissionReceiver), recipientBefore + expectedCommission);
+        assertEq(cm.tokenCommissionPool(address(token)), 0);
+    }
+
+    // ========================================================================
+    // Cancel
+    // ========================================================================
+
+    function test_cancelProposal_cancels() public {
+        address newBridge = makeAddr('newBridge');
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateBridge(newBridge, nonce, deadline, bitmap, sigs);
+
+        uint256 cNonce = proxy.proposalNonce();
+        uint256 cDeadline = block.timestamp + 1 hours;
+        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cNonce, cDeadline);
+        bytes[] memory cSigs = MultisigHelper.signAll(vm, cDigest, pks);
+
+        vm.expectEmit(true, false, false, false);
+        emit ProposalCancelled(id);
+        proxy.cancelProposal(id, cNonce, cDeadline, bitmap, cSigs);
+
+        IMultisigProxy.Proposal memory p = proxy.getProposal(id);
+        assertEq(uint8(p.status), uint8(IMultisigProxy.ProposalStatus.Cancelled));
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.NotPending.selector);
+        proxy.executeProposal(id, abi.encode(newBridge));
+    }
+
+    function test_cancelProposal_revertsOnNotPending() public {
+        bytes32 id = keccak256('ghost');
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 digest = MultisigHelper.digestCancelProposal(domainSep, id, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.NotPending.selector);
+        proxy.cancelProposal(id, nonce, deadline, bitmap, sigs);
+    }
+
+    // ========================================================================
+    // executeProposal reverts
+    // ========================================================================
+
+    function test_executeProposal_revertsOnDataMismatch() public {
+        address newBridge = makeAddr('newBridge');
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateBridge(newBridge, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.DataMismatch.selector);
+        proxy.executeProposal(id, abi.encode(makeAddr('different')));
+    }
+
+    function test_executeProposal_revertsOnExpiredDeadline() public {
+        address newBridge = makeAddr('newBridge');
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 2 hours;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateBridge(newBridge, nonce, deadline, bitmap, sigs);
+
+        vm.warp(deadline + 1);
+        vm.expectRevert(IMultisigProxy.ProposalExpired.selector);
+        proxy.executeProposal(id, abi.encode(newBridge));
+    }
+
+    // ========================================================================
+    // View
+    // ========================================================================
+
+    function test_verifyEnclaveSignature() public view {
+        bytes32 digest = keccak256('msg');
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(encPk1, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        assertTrue(proxy.verifyEnclaveSignature(digest, sig, 0));
+        assertFalse(proxy.verifyEnclaveSignature(digest, sig, 1));
+    }
+
+    function test_verifyEnclaveSignature_revertsOutOfRange() public {
+        bytes32 digest = keccak256('msg');
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(encPk1, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        vm.expectRevert(IMultisigProxy.IndexOutOfRange.selector);
+        proxy.verifyEnclaveSignature(digest, sig, 99);
+    }
+
+    // ========================================================================
+    // Propose + Execute — UpdateLZAdapter
+    // ========================================================================
+
+    function _proposeUpdateLZAdapter(address newAdapter) internal returns (bytes32 id) {
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateLZAdapter(domainSep, newAdapter, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        id = proxy.proposeUpdateLZAdapter(newAdapter, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_lzAdapter_defaultsToZero() public view {
+        assertEq(proxy.lzAdapter(), address(0));
+    }
+
+    function test_proposeUpdateLZAdapter_executeSetsAdapter() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        vm.expectEmit(true, true, false, false);
+        emit LZAdapterUpdated(address(0), newAdapter);
+
+        proxy.executeProposal(id, abi.encode(newAdapter));
+        assertEq(proxy.lzAdapter(), newAdapter);
+    }
+
+    function test_proposeUpdateLZAdapter_canRotateToZero() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(newAdapter));
+        assertEq(proxy.lzAdapter(), newAdapter);
+
+        bytes32 id2 = _proposeUpdateLZAdapter(address(0));
+        vm.warp(block.timestamp + 2 * TIMELOCK + 2);
+
+        proxy.executeProposal(id2, abi.encode(address(0)));
+        assertEq(proxy.lzAdapter(), address(0));
+    }
+
+    function test_proposeUpdateLZAdapter_revertsOnDataMismatch() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.DataMismatch.selector);
+        proxy.executeProposal(id, abi.encode(makeAddr('different')));
+    }
+
+    function test_proposeUpdateLZAdapter_canBeCancelled() public {
+        address newAdapter = makeAddr('lzAdapter');
+        bytes32 id = _proposeUpdateLZAdapter(newAdapter);
+
+        uint256 cNonce = proxy.proposalNonce();
+        uint256 cDeadline = block.timestamp + 1 hours;
+        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cNonce, cDeadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory cSigs = MultisigHelper.signAll(vm, cDigest, pks);
+
+        vm.expectEmit(true, false, false, false);
+        emit ProposalCancelled(id);
+        proxy.cancelProposal(id, cNonce, cDeadline, bitmap, cSigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.NotPending.selector);
+        proxy.executeProposal(id, abi.encode(newAdapter));
+        assertEq(proxy.lzAdapter(), address(0));
+    }
+
+    // ========================================================================
+    // Propose + Execute — AdminExecuteAdapter
+    // ========================================================================
+
+    function test_proposeAdminExecuteAdapter_revertsIfAdapterUnset() public {
+        bytes memory callData = abi.encodeWithSignature('mint(address,uint256)', user, 1e18);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteAdapter(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.ZeroTarget.selector);
+        proxy.executeProposal(id, callData);
+    }
+
+    function test_proposeAdminExecuteAdapter_executesCallOnAdapter() public {
+        MockERC20 adapter = new MockERC20('LZ Stub', 'LZS');
+        bytes32 idSet = _proposeUpdateLZAdapter(address(adapter));
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(idSet, abi.encode(address(adapter)));
+        assertEq(proxy.lzAdapter(), address(adapter));
+
+        bytes memory callData = abi.encodeWithSignature('mint(address,uint256)', recipient, 1e18);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteAdapter(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, callData);
+
+        assertEq(adapter.balanceOf(recipient), 1e18);
+    }
+
+    function test_proposeAdminExecuteAdapter_revertsOnEmptyCallData() public {
+        bytes memory callData = '';
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = new bytes[](pks.length);
+        for (uint256 i = 0; i < pks.length; i++) sigs[i] = new bytes(65);
+
+        vm.expectRevert(IMultisigProxy.CallDataTooShort.selector);
+        proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeAdminExecuteAdapter_propagatesAdapterRevert() public {
+        MockERC20 adapter = new MockERC20('LZ Stub', 'LZS');
+        bytes32 idSet = _proposeUpdateLZAdapter(address(adapter));
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(idSet, abi.encode(address(adapter)));
+
+        bytes memory callData = abi.encodeWithSignature('nonExistent()');
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteAdapter(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert();
+        proxy.executeProposal(id, callData);
+    }
+
+    // ========================================================================
+    // Propose + Execute — SetRoute
+    // ========================================================================
+
+    function _proposeSetRoute(
+        uint256 srcId,
+        uint256 dstId,
+        bool    enabled,
+        address verifier,
+        address module
+    ) internal returns (bytes32 id) {
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest   = MultisigHelper.digestProposeSetRoute(
+            domainSep, srcId, dstId, enabled, verifier, module, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        id = proxy.proposeSetRoute(
+            srcId, dstId, enabled, verifier, module,
+            nonce, deadline, bitmap, sigs
+        );
+    }
+
+    function test_proposeSetRoute_addsBrandNewRoute() public {
+        // Register a fresh (1234, 5678) route via governance.
+        uint256 newSrc = 1234;
+        uint256 newDst = 5678;
+        bytes32 id = _proposeSetRoute(
+            newSrc, newDst, true, address(rgbVerifier), address(rgbModule)
+        );
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        vm.expectEmit(true, true, false, true, address(routeRegistry));
+        emit RouteSet(newSrc, newDst, true, address(rgbVerifier), address(rgbModule));
+
+        proxy.executeProposal(
+            id,
+            abi.encode(newSrc, newDst, true, address(rgbVerifier), address(rgbModule))
+        );
+
+        RouteConfig memory cfg = routeRegistry.getRoute(newSrc, newDst);
+        assertTrue(cfg.enabled);
+        assertEq(cfg.finalityVerifier, address(rgbVerifier));
+        assertEq(cfg.settlementModule, address(rgbModule));
+    }
+
+    function test_proposeSetRoute_updatesExistingRoute() public {
+        // Re-point the existing RGB→SOURCE route at a brand new module
+        // (verifier stays). Validates governance can rotate plugins in place.
+        RgbSettlementModule newModule = new RgbSettlementModule(address(routeRegistry));
+
+        bytes32 id = _proposeSetRoute(
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, true,
+            address(rgbVerifier), address(newModule)
+        );
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(
+            id,
+            abi.encode(RGB_CHAIN_ID, SOURCE_CHAIN_ID, true,
+                      address(rgbVerifier), address(newModule))
+        );
+
+        RouteConfig memory cfg = routeRegistry.getRoute(RGB_CHAIN_ID, SOURCE_CHAIN_ID);
+        assertEq(cfg.settlementModule, address(newModule), 'module rotated');
+        assertEq(cfg.finalityVerifier, address(rgbVerifier), 'verifier unchanged');
+    }
+
+    function test_proposeSetRoute_canPauseRoute() public {
+        // Existing RGB→SOURCE route is enabled. Flip enabled = false in place.
+        bytes32 id = _proposeSetRoute(
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, false,
+            address(rgbVerifier), address(rgbModule)
+        );
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(
+            id,
+            abi.encode(RGB_CHAIN_ID, SOURCE_CHAIN_ID, false,
+                      address(rgbVerifier), address(rgbModule))
+        );
+
+        RouteConfig memory cfg = routeRegistry.getRoute(RGB_CHAIN_ID, SOURCE_CHAIN_ID);
+        assertFalse(cfg.enabled, 'route paused');
+        assertEq(cfg.finalityVerifier, address(rgbVerifier), 'verifier kept');
+        assertEq(cfg.settlementModule, address(rgbModule),   'module kept');
+    }
+
+    function test_proposeSetRoute_revertsOnZeroVerifier() public {
+        bytes32 id = _proposeSetRoute(
+            1234, 5678, true, address(0), address(rgbModule)
+        );
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        // Registry guard: ZeroFinalityVerifier propagates up through proxy.
+        vm.expectRevert(IRouteRegistry.ZeroFinalityVerifier.selector);
+        proxy.executeProposal(
+            id,
+            abi.encode(uint256(1234), uint256(5678), true, address(0), address(rgbModule))
+        );
+    }
+
+    function test_proposeSetRoute_revertsOnDataMismatch() public {
+        bytes32 id = _proposeSetRoute(
+            1234, 5678, true, address(rgbVerifier), address(rgbModule)
+        );
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.DataMismatch.selector);
+        // Wrong destChainId in opData.
+        proxy.executeProposal(
+            id,
+            abi.encode(uint256(1234), uint256(9999), true, address(rgbVerifier), address(rgbModule))
+        );
+    }
+
+    // ========================================================================
+    // Propose + Execute — UpdateRouteRegistry
+    // ========================================================================
+
+    function _proposeUpdateRouteRegistry(address newRegistry) internal returns (bytes32 id) {
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest   = MultisigHelper.digestProposeUpdateRouteRegistry(
+            domainSep, newRegistry, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        id = proxy.proposeUpdateRouteRegistry(newRegistry, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeUpdateRouteRegistry_rotatesBridgePointer() public {
+        // Deploy a NEW registry, owned by proxy, paired with the same Bridge.
+        // In production the new registry's `bridge_` immutable MUST match the
+        // live Bridge — otherwise dispatcher calls revert NotBridge.
+        RouteRegistry newRegistry = new RouteRegistry(address(bridge), address(proxy));
+
+        bytes32 id = _proposeUpdateRouteRegistry(address(newRegistry));
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        vm.expectEmit(true, true, false, false, address(bridge));
+        emit RouteRegistryUpdated(address(routeRegistry), address(newRegistry));
+
+        proxy.executeProposal(id, abi.encode(address(newRegistry)));
+        assertEq(bridge.routeRegistry(), address(newRegistry));
+    }
+
+    function test_proposeUpdateRouteRegistry_revertsOnZero() public {
+        // Bridge.setRouteRegistry rejects zero — the revert propagates up
+        // through `IBridge(bridge).setRouteRegistry(...)` in `_executeByType`.
+        bytes32 id = _proposeUpdateRouteRegistry(address(0));
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(); // Bridge.InvalidRouteRegistryAddress (custom)
+        proxy.executeProposal(id, abi.encode(address(0)));
+    }
+
+    function test_proposeUpdateRouteRegistry_revertsOnDataMismatch() public {
+        address bogus = makeAddr('bogus');
+        bytes32 id = _proposeUpdateRouteRegistry(bogus);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.DataMismatch.selector);
+        proxy.executeProposal(id, abi.encode(makeAddr('different')));
+    }
+
+    function test_domainSeparator_matchesHelper() public view {
+        assertEq(proxy.DOMAIN_SEPARATOR(), MultisigHelper.domainSeparator(address(proxy), block.chainid));
+    }
 }

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -82,6 +82,14 @@ library MultisigHelper {
         'ProposeUpdateLZAdapter(address newLZAdapter,uint256 nonce,uint256 deadline)'
     );
 
+    bytes32 internal constant PROPOSE_SET_ROUTE_TYPEHASH = keccak256(
+        'ProposeSetRoute(uint256 sourceChainId,uint256 destChainId,bool enabled,address finalityVerifier,address settlementModule,uint256 nonce,uint256 deadline)'
+    );
+
+    bytes32 internal constant PROPOSE_UPDATE_ROUTE_REGISTRY_TYPEHASH = keccak256(
+        'ProposeUpdateRouteRegistry(address newRouteRegistry,uint256 nonce,uint256 deadline)'
+    );
+
     /// @dev Builds the EIP-712 domain separator the same way MultisigProxy does.
     function domainSeparator(address verifyingContract, uint256 chainId) internal pure returns (bytes32) {
         return keccak256(abi.encode(
@@ -292,6 +300,34 @@ library MultisigHelper {
     ) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(
             PROPOSE_UPDATE_LZ_ADAPTER_TYPEHASH, newLZAdapter, nonce, deadline
+        )));
+    }
+
+    function digestProposeSetRoute(
+        bytes32 domainSep,
+        uint256 sourceChainId,
+        uint256 destChainId,
+        bool    enabled,
+        address finalityVerifier,
+        address settlementModule,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(
+            PROPOSE_SET_ROUTE_TYPEHASH,
+            sourceChainId, destChainId, enabled, finalityVerifier, settlementModule,
+            nonce, deadline
+        )));
+    }
+
+    function digestProposeUpdateRouteRegistry(
+        bytes32 domainSep,
+        address newRouteRegistry,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(
+            PROPOSE_UPDATE_ROUTE_REGISTRY_TYPEHASH, newRouteRegistry, nonce, deadline
         )));
     }
 


### PR DESCRIPTION
### Contracts

**`Bridge.sol` + `IBridge.sol`**
- `routeRegistry` is no longer immutable. Stored as `address public` so it can be swapped via governance.
- New `setRouteRegistry(address)` setter (owner-only, rejects zero) and the `RouteRegistryUpdated(oldRegistry, newRegistry)` event.

**`MultisigProxy.sol` + `IMultisigProxy.sol`**
- Two new `OperationType` values:
  - `SetRoute (13)` — granular `RouteRegistry.setRoute(src, dst, enabled, verifier, module)`.
  - `UpdateRouteRegistry (14)` — `Bridge.setRouteRegistry(newRouteRegistry)`.
- Matching EIP-712 typehashes:
  - `ProposeSetRoute(uint256 sourceChainId, uint256 destChainId, bool enabled, address finalityVerifier, address settlementModule, uint256 nonce, uint256 deadline)`
  - `ProposeUpdateRouteRegistry(address newRouteRegistry, uint256 nonce, uint256 deadline)`
- `proposeSetRoute(...)` / `proposeUpdateRouteRegistry(...)` external entrypoints + matching `_executeByType` branches.
- Constructor's default TEE allowlist is updated to the new 8-arg fundsOut selector `fundsOut(address, uint256, uint256, uint256, uint256, string, bytes, bytes)`, replacing the legacy 10-arg shape.
- `SetRoute` looks up the registry dynamically via `IBridge(bridge).routeRegistry()` to keep the registry pointer as a single source of truth.

**`IRouteRegistry.sol`**
- `setRoute(...)` is now declared on the interface (was concrete-only before). `RouteRegistry` marks its implementation `override`.

### Test

All three legacy test suites that left as placeholders are rewritten under the new Bridge surface. Plus a final cleanup commit removes the short-lived `_authorizeNewFundsOutSelector` workaround in `Integration.t.sol` (no longer needed once the proxy constructor uses the new selector by default).
