### PR TITLE
Update dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "ethereum/lib/openzeppelin-contracts"]
 	path = ethereum/lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-[submodule "ethereum/lib/chainlink-brownie-contracts"]
-	path = ethereum/lib/chainlink-brownie-contracts
-	url = https://github.com/smartcontractkit/chainlink-brownie-contracts

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -2,6 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+solc_version = "0.8.35"
 optimizer = true
 optimizer_runs = 200
 via_ir = true

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -10,5 +10,4 @@ via_ir = true
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 remappings = [
     "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
-    "@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/",
 ]

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 

--- a/ethereum/script/deploy/DeployBaseBridge.s.sol
+++ b/ethereum/script/deploy/DeployBaseBridge.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { BaseBridge } from '../../src/BaseBridge.sol';

--- a/ethereum/script/deploy/DeployBridge.s.sol
+++ b/ethereum/script/deploy/DeployBridge.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { Bridge } from '../../src/Bridge.sol';

--- a/ethereum/script/deploy/DeployCommissionManager.s.sol
+++ b/ethereum/script/deploy/DeployCommissionManager.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { CommissionManager } from '../../src/CommissionManager.sol';

--- a/ethereum/script/deploy/DeployMultisigProxy.s.sol
+++ b/ethereum/script/deploy/DeployMultisigProxy.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { MultisigProxy } from '../../src/MultisigProxy.sol';

--- a/ethereum/script/deploy/DeployRGBVerifier.s.sol
+++ b/ethereum/script/deploy/DeployRGBVerifier.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { RGBVerifier } from '../../src/verifiers/RGBVerifier.sol';

--- a/ethereum/script/deploy/DeployRgbSettlementModule.s.sol
+++ b/ethereum/script/deploy/DeployRgbSettlementModule.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.sol';

--- a/ethereum/script/deploy/DeployRouteRegistry.s.sol
+++ b/ethereum/script/deploy/DeployRouteRegistry.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { RouteRegistry } from '../../src/RouteRegistry.sol';

--- a/ethereum/script/interact/BridgeFundsIn.s.sol
+++ b/ethereum/script/interact/BridgeFundsIn.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';

--- a/ethereum/script/interact/EmergencyPause.s.sol
+++ b/ethereum/script/interact/EmergencyPause.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { MultisigProxy } from '../../src/MultisigProxy.sol';

--- a/ethereum/script/interact/EmergencyUnpause.s.sol
+++ b/ethereum/script/interact/EmergencyUnpause.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { MultisigProxy } from '../../src/MultisigProxy.sol';

--- a/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
+++ b/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { MultisigProxy } from '../../src/MultisigProxy.sol';

--- a/ethereum/script/interact/MultisigProposeSetRoute.s.sol
+++ b/ethereum/script/interact/MultisigProposeSetRoute.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { MultisigProxy } from '../../src/MultisigProxy.sol';

--- a/ethereum/src/BaseBridge.sol
+++ b/ethereum/src/BaseBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { SafeERC20 } from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';

--- a/ethereum/src/BaseBridge.sol
+++ b/ethereum/src/BaseBridge.sol
@@ -68,7 +68,7 @@ contract BaseBridge is BridgeBase {
         uint256 amount,
         uint256 operationId,
         string  calldata sourceAddress
-    ) external onlyOwner {
+    ) external onlyOwner whenOutflowNotPaused {
         if (recipient == address(0)) revert InvalidRecipientAddress();
         if (amount > IERC20(TOKEN).balanceOf(address(this))) revert AmountExceedBridgePool();
 

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IERC20 }            from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { SafeERC20 }         from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -174,7 +174,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         string  calldata sourceAddress,
         bytes   calldata proof,
         bytes   calldata settlementData
-    ) external override onlyOwner nonReentrant {
+    ) external override onlyOwner nonReentrant whenOutflowNotPaused {
         if (recipient          == address(0))                revert InvalidRecipientAddress();
         if (sourceChainId      == 0)                         revert InvalidSourceChainId();
         if (destinationChainId == 0)                         revert InvalidDestinationChainId();

--- a/ethereum/src/BridgeBase.sol
+++ b/ethereum/src/BridgeBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
 import { SafeERC20, IERC20 } from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';

--- a/ethereum/src/BridgeBase.sol
+++ b/ethereum/src/BridgeBase.sol
@@ -23,6 +23,15 @@ abstract contract BridgeBase is Ownable, Pausable {
     /// @notice The only accepted ERC-20 token. Immutable after deploy.
     address public immutable TOKEN;
 
+    /// @notice Outflow (withdrawal) freeze flag, independent of the inflow
+    ///         freeze. Inflow reuses OpenZeppelin `Pausable._paused` (gated by
+    ///         `whenNotPaused` on `fundsIn`); this second flag gates `fundsOut`
+    ///         via `whenOutflowNotPaused`. Two independent flags are required so
+    ///         that a planned inflow-only pause (deposits frozen, withdrawals
+    ///         still open for liquidity migration) and an emergency pause (both
+    ///         frozen) can be expressed separately.
+    bool private _outflowPaused;
+
     // =========================================================================
     // Events
     // =========================================================================
@@ -37,6 +46,14 @@ abstract contract BridgeBase is Ownable, Pausable {
         uint256 amount
     );
 
+    /// @notice Emitted when the outflow (withdrawal) path is frozen.
+    /// @dev The inflow path reuses OpenZeppelin `Pausable`, which emits its own
+    ///      `Paused` / `Unpaused` events.
+    event OutflowPaused(address account);
+
+    /// @notice Emitted when the outflow (withdrawal) path is unfrozen.
+    event OutflowUnpaused(address account);
+
     // =========================================================================
     // Errors
     // =========================================================================
@@ -45,6 +62,22 @@ abstract contract BridgeBase is Ownable, Pausable {
     error InvalidRecipientAddress();
     error AmountExceedBridgePool();
     error RenounceOwnershipBlocked();
+
+    /// @notice Thrown by `whenOutflowNotPaused` when the outflow path is frozen.
+    error OutflowEnforcedPause();
+
+    // =========================================================================
+    // Modifiers
+    // =========================================================================
+
+    /// @dev Reverts when the outflow path is frozen. Mirrors OpenZeppelin's
+    ///      `whenNotPaused` (which gates inflow) but for the independent
+    ///      `_outflowPaused` flag, so `fundsOut` can be frozen without freezing
+    ///      `fundsIn` and vice versa.
+    modifier whenOutflowNotPaused() {
+        if (_outflowPaused) revert OutflowEnforcedPause();
+        _;
+    }
 
     // =========================================================================
     // Constructor
@@ -59,11 +92,41 @@ abstract contract BridgeBase is Ownable, Pausable {
     // Owner-only
     // =========================================================================
 
-    /// @notice Pause all user-facing operations.
-    function pause() external onlyOwner { _pause(); }
+    /// @notice Freeze the inflow (deposit) path only; withdrawals stay open.
+    /// @dev Intended for planned operations such as a bridge upgrade or
+    ///      liquidity migration. On the production `Bridge` this is reached
+    ///      through the timelocked `MultisigProxy` propose -> execute path
+    ///      (`PauseInflow` operation), giving the federation an observation
+    ///      window before it takes effect.
+    function pauseInflow() external onlyOwner { _pause(); }
 
-    /// @notice Resume all user-facing operations.
-    function unpause() external onlyOwner { _unpause(); }
+    /// @notice Resume the inflow (deposit) path.
+    function unpauseInflow() external onlyOwner { _unpause(); }
+
+    /// @notice Emergency freeze of BOTH inflow and outflow, set atomically.
+    /// @dev No-timelock control for incident response. On the production
+    ///      `Bridge` it is reached through the federation-signed
+    ///      `MultisigProxy.emergencyPause` (multisig only, no propose step).
+    ///      Each flag is set idempotently, so the call does not revert if one
+    ///      side is already frozen (e.g. inflow already paused via the planned
+    ///      path). Freezing `fundsOut` also freezes the enclave/TEE release
+    ///      path, which routes through `fundsOut`.
+    function emergencyPauseAll() external onlyOwner {
+        if (!paused()) _pause(); // inflow (OpenZeppelin flag), guarded against double-pause
+        if (!_outflowPaused) {
+            _outflowPaused = true;
+            emit OutflowPaused(_msgSender());
+        }
+    }
+
+    /// @notice Lift the emergency freeze on BOTH inflow and outflow. Idempotent.
+    function emergencyUnpauseAll() external onlyOwner {
+        if (paused()) _unpause();
+        if (_outflowPaused) {
+            _outflowPaused = false;
+            emit OutflowUnpaused(_msgSender());
+        }
+    }
 
     /// @notice Permanently blocks renouncing ownership.
     function renounceOwnership() public view virtual override onlyOwner {
@@ -77,6 +140,12 @@ abstract contract BridgeBase is Ownable, Pausable {
     /// @notice Returns the token balance held by the contract (bridgeable liquidity).
     function getContractBalance() external view returns (uint256) {
         return IERC20(TOKEN).balanceOf(address(this));
+    }
+
+    /// @notice Whether the outflow (withdrawal) path is currently frozen.
+    /// @dev The inflow freeze is exposed by OpenZeppelin's `paused()`.
+    function outflowPaused() external view returns (bool) {
+        return _outflowPaused;
     }
 
     /// @notice Returns the current chain ID.

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -7,7 +7,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+import {AggregatorV3Interface} from "./interfaces/AggregatorV3Interface.sol";
 
 import {
     CommissionConfig,

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -48,6 +48,13 @@ contract MultisigProxy is IMultisigProxy {
     /// @notice Minimum delay (seconds) between proposal creation and execution.
     uint256 public timelockDuration;
 
+    /// @notice Lower bound for `timelockDuration`, fixed at deploy time.
+    /// @dev Immutable so the governance observation/veto window can never be
+    ///      reduced below this floor — not by a `SetTimelockDuration` proposal
+    ///      and not by any later action. Set in the constructor and validated to
+    ///      be in (0, MAX_PROPOSAL_LIFETIME).
+    uint256 public immutable MIN_TIMELOCK;
+
     // =========================================================================
     // Constants
     // =========================================================================
@@ -163,7 +170,8 @@ contract MultisigProxy is IMultisigProxy {
         address[] memory federationSigners_,
         uint256 federationThreshold_,
         address commissionRecipient_,
-        uint256 timelockDuration_
+        uint256 timelockDuration_,
+        uint256 minTimelock_
     ) {
         if (bridge_ == address(0)) revert ZeroBridge();
         if (commissionManager_ == address(0)) revert ZeroCommissionManager();
@@ -172,6 +180,8 @@ contract MultisigProxy is IMultisigProxy {
         if (federationSigners_.length == 0) revert NoSigners();
         if (federationThreshold_ == 0 || federationThreshold_ > federationSigners_.length) revert InvalidThreshold();
         if (commissionRecipient_ == address(0)) revert ZeroCommissionRecipient();
+        if (minTimelock_ == 0 || minTimelock_ >= MAX_PROPOSAL_LIFETIME) revert InvalidMinTimelock();
+        if (timelockDuration_ < minTimelock_) revert TimelockTooShort();
         if (timelockDuration_ >= MAX_PROPOSAL_LIFETIME) revert TimelockTooLong();
 
         _validateSigners(enclaveSigners_);
@@ -185,6 +195,7 @@ contract MultisigProxy is IMultisigProxy {
         federationThreshold = federationThreshold_;
         commissionRecipient = commissionRecipient_;
         timelockDuration = timelockDuration_;
+        MIN_TIMELOCK = minTimelock_;
 
         // Default TEE allowlist: Bridge.fundsOut. Additional (target, selector) pairs
         // (e.g. for the LayerZero adapter's outbound `sendOut`) are added later via
@@ -881,6 +892,7 @@ contract MultisigProxy is IMultisigProxy {
 
         } else if (opType == OperationType.SetTimelockDuration) {
             uint256 newDuration = abi.decode(opData, (uint256));
+            if (newDuration < MIN_TIMELOCK) revert TimelockTooShort();
             if (newDuration >= MAX_PROPOSAL_LIFETIME) revert TimelockTooLong();
             timelockDuration = newDuration;
             emit TimelockDurationUpdated(newDuration);

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -143,6 +143,14 @@ contract MultisigProxy is IMultisigProxy {
         'EmergencyUnpause(uint256 nonce,uint256 deadline)'
     );
 
+    // Federation propose — planned inflow-only pause (timelocked)
+    bytes32 private constant _PROPOSE_PAUSE_INFLOW_TYPEHASH = keccak256(
+        'ProposePauseInflow(uint256 nonce,uint256 deadline)'
+    );
+    bytes32 private constant _PROPOSE_UNPAUSE_INFLOW_TYPEHASH = keccak256(
+        'ProposeUnpauseInflow(uint256 nonce,uint256 deadline)'
+    );
+
     // =========================================================================
     // Constructor
     // =========================================================================
@@ -298,7 +306,10 @@ contract MultisigProxy is IMultisigProxy {
 
         proposalNonce++;
 
-        (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('pause()'));
+        // Emergency freeze of BOTH inflow and outflow — no timelock, federation
+        // signatures only. Also halts the enclave/TEE release path (it routes
+        // through Bridge.fundsOut, now gated by whenOutflowNotPaused).
+        (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('emergencyPauseAll()'));
         _propagateRevert(ok, ret);
 
         emit EmergencyPaused(nonce, fedBitmap);
@@ -321,7 +332,8 @@ contract MultisigProxy is IMultisigProxy {
 
         proposalNonce++;
 
-        (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('unpause()'));
+        // Lift the emergency freeze on BOTH inflow and outflow.
+        (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('emergencyUnpauseAll()'));
         _propagateRevert(ok, ret);
 
         emit EmergencyUnpaused(nonce, fedBitmap);
@@ -654,6 +666,48 @@ contract MultisigProxy is IMultisigProxy {
         );
     }
 
+    /// @inheritdoc IMultisigProxy
+    /// @dev Planned inflow-only pause: freezes deposits while leaving
+    ///      withdrawals open (e.g. to migrate liquidity during an upgrade).
+    ///      Runs through the timelocked propose -> execute path, so the
+    ///      federation has an observation window. The emergency, no-timelock
+    ///      freeze of BOTH paths is `emergencyPause` instead. Carries no payload.
+    function proposePauseInflow(
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_PAUSE_INFLOW_TYPEHASH, nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.PauseInflow,
+            '',
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
+    /// @inheritdoc IMultisigProxy
+    /// @dev Resumes the inflow path, reversing `proposePauseInflow`. Timelocked.
+    function proposeUnpauseInflow(
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_UNPAUSE_INFLOW_TYPEHASH, nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.UnpauseInflow,
+            '',
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
     // =========================================================================
     // Cancel
     // =========================================================================
@@ -904,6 +958,15 @@ contract MultisigProxy is IMultisigProxy {
             // `NotBridge` and the route plane goes dark.
             address newRegistry = abi.decode(opData, (address));
             IBridge(bridge).setRouteRegistry(newRegistry);
+
+        } else if (opType == OperationType.PauseInflow) {
+            // Planned inflow-only freeze (no payload). Withdrawals stay open.
+            (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('pauseInflow()'));
+            _propagateRevert(ok, ret);
+
+        } else if (opType == OperationType.UnpauseInflow) {
+            (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('unpauseInflow()'));
+            _propagateRevert(ok, ret);
 
         } else {
             revert UnknownOperationType();

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity 0.8.35;
 
 import { ECDSA } from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import { IMultisigProxy } from './interfaces/IMultisigProxy.sol';

--- a/ethereum/src/RouteRegistry.sol
+++ b/ethereum/src/RouteRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
 

--- a/ethereum/src/btc_relay/BtcRelay.sol
+++ b/ethereum/src/btc_relay/BtcRelay.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {ForkImpl, Fork} from "./state/Fork.sol";
 import {StoredBlockHeaderImpl, StoredBlockHeader, StoredBlockHeaderByteLength} from "./structs/StoredBlockHeader.sol";

--- a/ethereum/src/btc_relay/BtcRelayTestnet.sol
+++ b/ethereum/src/btc_relay/BtcRelayTestnet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {ForkImpl, Fork} from "./state/Fork.sol";
 import {StoredBlockHeaderImpl, StoredBlockHeader, StoredBlockHeaderByteLength} from "./structs/StoredBlockHeaderTestnet.sol";

--- a/ethereum/src/btc_relay/Constants.sol
+++ b/ethereum/src/btc_relay/Constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 //Interval (in blocks) of the difficulty adjustment
 uint256 constant DIFFICULTY_ADJUSTMENT_INTERVAL = 2016;

--- a/ethereum/src/btc_relay/Events.sol
+++ b/ethereum/src/btc_relay/Events.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 library Events {
     event StoreHeader(bytes32 indexed commitHash, bytes32 indexed blockHash);

--- a/ethereum/src/btc_relay/btc_utils/Endianness.sol
+++ b/ethereum/src/btc_relay/btc_utils/Endianness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 library Endianness {
     function reverseUint32(uint32 input) internal pure returns (uint32) {

--- a/ethereum/src/btc_relay/state/BtcRelayState.sol
+++ b/ethereum/src/btc_relay/state/BtcRelayState.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 struct BtcRelayState {
     uint32 blockHeight;

--- a/ethereum/src/btc_relay/state/Fork.sol
+++ b/ethereum/src/btc_relay/state/Fork.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 struct Fork {
     //Slot 0

--- a/ethereum/src/btc_relay/structs/CompactBlockHeader.sol
+++ b/ethereum/src/btc_relay/structs/CompactBlockHeader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {Endianness} from "../btc_utils/Endianness.sol";
 

--- a/ethereum/src/btc_relay/structs/StoredBlockHeader.sol
+++ b/ethereum/src/btc_relay/structs/StoredBlockHeader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {CompactBlockHeaderImpl} from "./CompactBlockHeader.sol";
 import {Nbits} from "../utils/Nbits.sol";

--- a/ethereum/src/btc_relay/structs/StoredBlockHeaderTestnet.sol
+++ b/ethereum/src/btc_relay/structs/StoredBlockHeaderTestnet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {CompactBlockHeaderImpl} from "./CompactBlockHeader.sol";
 import {Nbits} from "../utils/Nbits.sol";

--- a/ethereum/src/btc_relay/utils/Difficulty.sol
+++ b/ethereum/src/btc_relay/utils/Difficulty.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {Nbits} from "./Nbits.sol";
 import {

--- a/ethereum/src/btc_relay/utils/Nbits.sol
+++ b/ethereum/src/btc_relay/utils/Nbits.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 library Nbits {
 

--- a/ethereum/src/interfaces/AggregatorV3Interface.sol
+++ b/ethereum/src/interfaces/AggregatorV3Interface.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+// Vendored from @chainlink/contracts (chainlink-brownie-contracts v1.3.0),
+// src/v0.8/shared/interfaces/AggregatorV3Interface.sol. Inlined here to drop the
+// dependency on the deprecated/archived chainlink-brownie-contracts repository.
+// The interface is self-contained (no imports) and matches Chainlink upstream.
+
+// solhint-disable-next-line interface-starts-with-i
+interface AggregatorV3Interface {
+  function decimals() external view returns (uint8);
+
+  function description() external view returns (string memory);
+
+  function version() external view returns (uint256);
+
+  function getRoundData(
+    uint80 _roundId
+  ) external view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+
+  function latestRoundData()
+    external
+    view
+    returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 interface IBridge {
     // =========================================================================

--- a/ethereum/src/interfaces/IBtcRelayView.sol
+++ b/ethereum/src/interfaces/IBtcRelayView.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 /// @title IBtcRelayView
 /// @notice Read-only interface for the Atomiq BtcRelay contract.

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 /**
  * @title ICommissionManager types & interface

--- a/ethereum/src/interfaces/IFinalityVerifier.sol
+++ b/ethereum/src/interfaces/IFinalityVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { FundsOutContext } from './RouteTypes.sol';
 

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -43,6 +43,8 @@ interface IMultisigProxy {
     error InvalidThreshold();
     error ZeroCommissionRecipient();
     error TimelockTooLong();
+    error TimelockTooShort();
+    error InvalidMinTimelock();
     error Expired();
     error CallDataTooShort();
     error CallNotAllowed(address target, bytes4 selector);
@@ -439,5 +441,6 @@ interface IMultisigProxy {
     function DOMAIN_SEPARATOR() external view returns (bytes32);
     function proposalNonce() external view returns (uint256);
     function timelockDuration() external view returns (uint256);
+    function MIN_TIMELOCK() external view returns (uint256);
     function getProposal(bytes32 proposalId) external view returns (Proposal memory);
 }

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity 0.8.35;
 
 /// @title IMultisigProxy
 /// @notice Two-level ECDSA multisig proxy that owns the Bridge and the CommissionManager.

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -88,7 +88,9 @@ interface IMultisigProxy {
         AdminExecuteAdapter,             // 11 — generic call into LZAdapter (setTrustedEntrypoint, refundStuckFunds, …)
         UpdateLZAdapter,                 // 12 — rotate the routing target for AdminExecuteAdapter
         SetRoute,                        // 13 — RouteRegistry.setRoute(src, dst, enabled, verifier, module)
-        UpdateRouteRegistry              // 14 — Bridge.setRouteRegistry(newRouteRegistry)
+        UpdateRouteRegistry,             // 14 — Bridge.setRouteRegistry(newRouteRegistry)
+        PauseInflow,                     // 15 — Bridge.pauseInflow()  (planned inflow-only freeze, timelocked)
+        UnpauseInflow                    // 16 — Bridge.unpauseInflow()
     }
 
     enum ProposalStatus { None, Pending, Executed, Cancelled }
@@ -367,6 +369,27 @@ interface IMultisigProxy {
     ///      simultaneously breaks.
     function proposeUpdateRouteRegistry(
         address newRouteRegistry,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
+    /// @notice Propose a planned inflow-only pause on Bridge (`pauseInflow`).
+    /// @dev Freezes deposits while leaving withdrawals open — intended for a
+    ///      bridge upgrade / liquidity migration. Runs through the timelocked
+    ///      propose -> execute path. For an immediate freeze of BOTH paths use
+    ///      `emergencyPause`. Carries no payload (opData is empty).
+    function proposePauseInflow(
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
+    /// @notice Propose resuming the inflow path on Bridge (`unpauseInflow`).
+    /// @dev Reverses `proposePauseInflow`. Timelocked. Carries no payload.
+    function proposeUnpauseInflow(
         uint256 nonce,
         uint256 deadline,
         uint256 fedBitmap,

--- a/ethereum/src/interfaces/IRouteRegistry.sol
+++ b/ethereum/src/interfaces/IRouteRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { FundsInContext, FundsOutContext, RouteConfig } from './RouteTypes.sol';
 

--- a/ethereum/src/interfaces/ISettlementModule.sol
+++ b/ethereum/src/interfaces/ISettlementModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { FundsInContext, FundsOutContext } from './RouteTypes.sol';
 

--- a/ethereum/src/interfaces/RouteTypes.sol
+++ b/ethereum/src/interfaces/RouteTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 /// @title RouteTypes
 /// @notice Shared data shapes used by `IRouteRegistry`, `ISettlementModule`

--- a/ethereum/src/settlement/NullSettlementModule.sol
+++ b/ethereum/src/settlement/NullSettlementModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { ISettlementModule } from '../interfaces/ISettlementModule.sol';
 import { FundsInContext, FundsOutContext } from '../interfaces/RouteTypes.sol';

--- a/ethereum/src/settlement/RgbSettlementModule.sol
+++ b/ethereum/src/settlement/RgbSettlementModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { ISettlementModule } from '../interfaces/ISettlementModule.sol';
 import { FundsInContext, FundsOutContext } from '../interfaces/RouteTypes.sol';

--- a/ethereum/src/verifiers/NullVerifier.sol
+++ b/ethereum/src/verifiers/NullVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IFinalityVerifier }  from '../interfaces/IFinalityVerifier.sol';
 import { FundsOutContext }    from '../interfaces/RouteTypes.sol';

--- a/ethereum/src/verifiers/RGBVerifier.sol
+++ b/ethereum/src/verifiers/RGBVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IFinalityVerifier } from '../interfaces/IFinalityVerifier.sol';
 import { FundsOutContext }   from '../interfaces/RouteTypes.sol';

--- a/ethereum/test/BaseBridge.t.sol
+++ b/ethereum/test/BaseBridge.t.sol
@@ -95,7 +95,7 @@ contract BaseBridgeTest is Test {
 
     function test_fundsIn_revertsWhenPaused() public {
         vm.prank(owner);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
@@ -154,23 +154,23 @@ contract BaseBridgeTest is Test {
     function test_pause_onlyOwner() public {
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.pause();
+        bridge.pauseInflow();
     }
 
     function test_unpause_onlyOwner() public {
         vm.prank(owner);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.unpause();
+        bridge.unpauseInflow();
     }
 
     function test_unpause_ownerCanUnpause() public {
         vm.prank(owner);
-        bridge.pause();
+        bridge.pauseInflow();
         vm.prank(owner);
-        bridge.unpause();
+        bridge.unpauseInflow();
 
         // fundsIn works again
         vm.prank(user);
@@ -182,6 +182,118 @@ contract BaseBridgeTest is Test {
         vm.expectRevert(BridgeBase.RenounceOwnershipBlocked.selector);
         vm.prank(owner);
         bridge.renounceOwnership();
+    }
+
+    // ========================================================================
+    // R-W-05 — two-tier pause (inflow vs outflow / emergency)
+    // ========================================================================
+
+    /// @dev UT-FIX-08: with outflow frozen, fundsOut reverts. The
+    ///      whenOutflowNotPaused modifier runs before the body, so a dummy
+    ///      release is enough to exercise the gate.
+    function test_fundsOut_revertsWhenOutflowPaused() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID); // seed the pool
+
+        vm.prank(owner);
+        bridge.emergencyPauseAll();
+
+        vm.expectRevert(BridgeBase.OutflowEnforcedPause.selector);
+        vm.prank(owner);
+        bridge.fundsOut(recipient, AMOUNT, OPERATION_ID, SRC_ADDR);
+    }
+
+    /// @dev The planned inflow-only pause blocks deposits but leaves
+    ///      withdrawals open — the core two-tier distinction (liquidity can be
+    ///      migrated out while new deposits are frozen).
+    function test_fundsOut_worksWhenOnlyInflowPaused() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID); // seed before freezing inflow
+
+        vm.prank(owner);
+        bridge.pauseInflow();
+
+        // Deposits are frozen...
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID);
+
+        // ...but withdrawals still work.
+        vm.prank(owner);
+        bridge.fundsOut(recipient, AMOUNT, OPERATION_ID, SRC_ADDR);
+        assertEq(token.balanceOf(recipient), AMOUNT);
+    }
+
+    /// @dev Emergency pause freezes BOTH paths.
+    function test_emergencyPauseAll_freezesBothPaths() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID); // seed the pool
+
+        vm.prank(owner);
+        bridge.emergencyPauseAll();
+
+        assertTrue(bridge.paused(),        'inflow frozen');
+        assertTrue(bridge.outflowPaused(), 'outflow frozen');
+
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID);
+
+        vm.expectRevert(BridgeBase.OutflowEnforcedPause.selector);
+        vm.prank(owner);
+        bridge.fundsOut(recipient, AMOUNT, OPERATION_ID, SRC_ADDR);
+    }
+
+    /// @dev Emergency unpause lifts BOTH freezes.
+    function test_emergencyUnpauseAll_liftsBoth() public {
+        vm.startPrank(owner);
+        bridge.emergencyPauseAll();
+        bridge.emergencyUnpauseAll();
+        vm.stopPrank();
+
+        assertFalse(bridge.paused(),        'inflow resumed');
+        assertFalse(bridge.outflowPaused(), 'outflow resumed');
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID);
+        assertEq(token.balanceOf(address(bridge)), AMOUNT);
+    }
+
+    /// @dev emergencyPauseAll must be idempotent per flag: it must not revert
+    ///      if inflow is already frozen via the planned path.
+    function test_emergencyPauseAll_idempotentWhenInflowAlreadyPaused() public {
+        vm.startPrank(owner);
+        bridge.pauseInflow();      // inflow already frozen
+        bridge.emergencyPauseAll(); // must not revert on the already-set inflow flag
+        vm.stopPrank();
+
+        assertTrue(bridge.paused(),        'inflow still frozen');
+        assertTrue(bridge.outflowPaused(), 'outflow now frozen');
+    }
+
+    function test_pauseInflow_onlyOwner() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.pauseInflow();
+    }
+
+    function test_emergencyPauseAll_onlyOwner() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.emergencyPauseAll();
+    }
+
+    function test_emergencyUnpauseAll_onlyOwner() public {
+        vm.prank(owner);
+        bridge.emergencyPauseAll();
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.emergencyUnpauseAll();
+    }
+
+    function test_outflowPaused_defaultsFalse() public view {
+        assertFalse(bridge.outflowPaused());
     }
 
     // ========================================================================

--- a/ethereum/test/BaseBridge.t.sol
+++ b/ethereum/test/BaseBridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
 import { BaseBridge } from '../src/BaseBridge.sol';

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -404,7 +404,7 @@ contract BridgeTest is Test {
 
     function test_fundsIn_revertsWhenPaused() public {
         vm.prank(multisig);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
@@ -762,16 +762,16 @@ contract BridgeTest is Test {
     function test_pause_onlyOwner() public {
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.pause();
+        bridge.pauseInflow();
     }
 
     function test_unpause_onlyOwner() public {
         vm.prank(multisig);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.unpause();
+        bridge.unpauseInflow();
     }
 
     function test_renounceOwnership_alwaysReverts() public {

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
 

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
 

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -91,7 +91,8 @@ contract IntegrationTest is Test {
     bytes32 constant COMMITMENT_HASH   = keccak256('integration-btc-block');
     uint256 constant BTC_CONFIRMATIONS = 6;
 
-    uint256 constant TIMELOCK = 1 hours;
+    uint256 constant TIMELOCK     = 1 hours;
+    uint256 constant MIN_TIMELOCK = 1 hours; // floor passed to the proxy constructor in tests
 
     /// @dev New 8-arg fundsOut selector:
     ///        fundsOut(
@@ -189,7 +190,8 @@ contract IntegrationTest is Test {
             enc, 2,
             fed, 2,
             commissionReceiver,
-            TIMELOCK
+            TIMELOCK,
+            MIN_TIMELOCK
         );
 
         cm.transferOwnership(address(proxy));

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -1057,13 +1057,19 @@ contract MultisigProxyTest is Test {
     function test_proposeAdminExecuteAdapter_executesCallOnAdapter() public {
         MockERC20 adapter = new MockERC20('LZ Stub', 'LZS');
         bytes32 idSet = _proposeUpdateLZAdapter(address(adapter));
-        vm.warp(block.timestamp + TIMELOCK + 1);
+        // Read block.timestamp once and derive every warp target from it. Re-reading
+        // block.timestamp after a vm.warp within the same function is unreliable under
+        // via_ir: the optimizer treats TIMESTAMP as tx-invariant and may reuse a
+        // pre-warp read, so a second `block.timestamp + ...` warp can collapse onto a
+        // stale value and leave the timelock unexpired.
+        uint256 firstExec = block.timestamp + TIMELOCK + 1;
+        vm.warp(firstExec);
         proxy.executeProposal(idSet, abi.encode(address(adapter)));
         assertEq(proxy.lzAdapter(), address(adapter));
 
         bytes memory callData = abi.encodeWithSignature('mint(address,uint256)', recipient, 1e18);
         uint256 nonce = proxy.proposalNonce();
-        uint256 deadline = block.timestamp + 1 days;
+        uint256 deadline = firstExec + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeAdminExecuteAdapter(
             domainSep, bytes4(callData), callData, nonce, deadline
@@ -1073,7 +1079,7 @@ contract MultisigProxyTest is Test {
 
         bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
 
-        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.warp(firstExec + TIMELOCK + 1);
         proxy.executeProposal(id, callData);
 
         assertEq(adapter.balanceOf(recipient), 1e18);

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -6,6 +6,8 @@ import { Test } from 'forge-std/Test.sol';
 import { MultisigProxy }  from '../src/MultisigProxy.sol';
 import { IMultisigProxy } from '../src/interfaces/IMultisigProxy.sol';
 import { Bridge }              from '../src/Bridge.sol';
+import { BridgeBase }          from '../src/BridgeBase.sol';
+import { Pausable }            from '@openzeppelin/contracts/utils/Pausable.sol';
 import { CommissionManager }   from '../src/CommissionManager.sol';
 import { RouteRegistry }       from '../src/RouteRegistry.sol';
 import { IRouteRegistry }      from '../src/interfaces/IRouteRegistry.sol';
@@ -355,7 +357,7 @@ contract MultisigProxyTest is Test {
     }
 
     function test_execute_revertsOnDisallowedSelector() public {
-        bytes memory callData = abi.encodeWithSignature('pause()');
+        bytes memory callData = abi.encodeWithSignature('pauseInflow()');
         uint256 nonce = 0;
         uint256 deadline = block.timestamp + 1 hours;
 
@@ -434,7 +436,7 @@ contract MultisigProxyTest is Test {
         bytes[]   memory callDatas = new bytes[](1);
         uint256[] memory values    = new uint256[](1);
         targets[0]   = makeAddr('random-target');
-        callDatas[0] = abi.encodeWithSignature('pause()');
+        callDatas[0] = abi.encodeWithSignature('pauseInflow()');
 
         uint256 nonce    = proxy.batchNonce();
         uint256 deadline = block.timestamp + 1 hours;
@@ -627,6 +629,79 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
+    // R-W-05 — two-tier pause (integration via MultisigProxy)
+    // ========================================================================
+
+    /// @dev After R-W-05, the no-timelock emergency pause freezes the OUTFLOW
+    ///      path too — including the enclave/TEE release, which routes through
+    ///      Bridge.fundsOut. A signed fundsOut executed straight after
+    ///      emergencyPause must revert OutflowEnforcedPause, and inbound deposits
+    ///      must be frozen as well.
+    function test_emergencyPause_freezesEnclaveFundsOut() public {
+        // Federation triggers the emergency freeze (both paths).
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 digest   = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
+        (uint256[] memory fpks, uint256 fbitmap) = _fedSigSet2of3();
+        proxy.emergencyPause(nonce, deadline, fbitmap, MultisigHelper.signAll(vm, digest, fpks));
+
+        assertTrue(bridge.paused(),        'inflow frozen');
+        assertTrue(bridge.outflowPaused(), 'outflow frozen');
+
+        // Inbound deposits are frozen.
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
+
+        // Enclave-signed release is frozen too — the revert propagates from
+        // Bridge.fundsOut through proxy.execute.
+        bytes memory callData = _fundsOutCalldata();
+        uint256 encNonce      = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        bytes32 encDigest     = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, encNonce, deadline);
+        (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
+        bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
+
+        vm.expectRevert(BridgeBase.OutflowEnforcedPause.selector);
+        proxy.execute(callData, encNonce, deadline, ebitmap, esigs);
+    }
+
+    /// @dev The planned inflow-only pause runs through the timelocked
+    ///      propose -> execute path and blocks deposits while leaving the
+    ///      enclave release path open (liquidity migration scenario).
+    function test_proposePauseInflow_blocksFundsInButAllowsFundsOut() public {
+        uint256 t = block.timestamp; // read once; derive all timing from it (via_ir-safe)
+
+        // Propose the inflow-only pause (federation signed).
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = t + 1 days;
+        bytes32 digest   = MultisigHelper.digestProposePauseInflow(domainSep, nonce, deadline);
+        (uint256[] memory fpks, uint256 fbitmap) = _fedSigSet2of3();
+        bytes32 id = proxy.proposePauseInflow(nonce, deadline, fbitmap, MultisigHelper.signAll(vm, digest, fpks));
+
+        // Execute it after the timelock (no payload).
+        vm.warp(t + TIMELOCK + 1);
+        proxy.executeProposal(id, '');
+
+        assertTrue(bridge.paused(),         'inflow frozen');
+        assertFalse(bridge.outflowPaused(), 'outflow stays open');
+
+        // Deposits are frozen...
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
+
+        // ...but the enclave release still executes.
+        bytes memory callData = _fundsOutCalldata();
+        uint256 encNonce      = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        bytes32 encDigest     = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, encNonce, t + 1 days);
+        (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
+        bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
+
+        proxy.execute(callData, encNonce, t + 1 days, ebitmap, esigs);
+        assertEq(token.balanceOf(recipient), AMOUNT, 'withdrawal succeeded while inflow paused');
+    }
+
+    // ========================================================================
     // Propose + Execute — UpdateBridge
     // ========================================================================
 
@@ -763,7 +838,7 @@ contract MultisigProxyTest is Test {
     // ========================================================================
 
     function test_proposeAdminExecute_canCallBridge() public {
-        bytes memory callData = abi.encodeWithSignature('pause()');
+        bytes memory callData = abi.encodeWithSignature('pauseInflow()');
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
 

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
 

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -89,7 +89,8 @@ contract MultisigProxyTest is Test {
     address recipient          = makeAddr('recipient');
     address commissionReceiver = makeAddr('commissionReceiver');
 
-    uint256 constant TIMELOCK = 1 hours;
+    uint256 constant TIMELOCK     = 1 hours;
+    uint256 constant MIN_TIMELOCK = 1 hours; // floor passed to the proxy constructor in tests
 
     bytes32 domainSep;
 
@@ -177,7 +178,8 @@ contract MultisigProxyTest is Test {
             enc, 2,
             fed, 2,
             commissionReceiver,
-            TIMELOCK
+            TIMELOCK,
+            MIN_TIMELOCK
         );
 
         // Production-flow ownership transfer.
@@ -256,56 +258,87 @@ contract MultisigProxyTest is Test {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroBridge.selector);
-        new MultisigProxy(address(0), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(0), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommissionManager() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionManager.selector);
-        new MultisigProxy(address(bridge), address(0), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(0), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnNoEnclaveSigners() public {
         address[] memory enc = new address[](0);
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.NoSigners.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnBadEnclaveThreshold() public {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 3, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 3, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommission() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionRecipient.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, address(0), TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, address(0), TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnTimelockTooLong() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.TimelockTooLong.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 30 days);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 30 days, MIN_TIMELOCK);
+    }
+
+    // ---- R-W-11: MIN_TIMELOCK floor (post-fix) ----
+
+    /// @dev UT-FIX-13: deploying with a timelock below the requested floor reverts.
+    function test_constructor_revertsOnTimelockBelowMinTimelock() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        // timelock (1h) is below the requested floor (2h) -> TimelockTooShort
+        vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 1 hours, 2 hours);
+    }
+
+    /// @dev A zero floor is rejected — it would defeat the purpose of the fix.
+    function test_constructor_revertsOnZeroMinTimelock() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, 0);
+    }
+
+    /// @dev A floor at/above the upper bound leaves no valid range — rejected.
+    function test_constructor_revertsOnMinTimelockTooLong() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, 30 days);
+    }
+
+    function test_minTimelock_returnsConfiguredFloor() public view {
+        assertEq(proxy.MIN_TIMELOCK(), MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnDuplicateSigner() public {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroAddressSigner() public {
         address[] memory enc = new address[](1); enc[0] = address(0);
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     // ========================================================================
@@ -830,6 +863,41 @@ contract MultisigProxyTest is Test {
         emit TimelockDurationUpdated(newDuration);
         proxy.executeProposal(id, abi.encode(newDuration));
 
+        assertEq(proxy.timelockDuration(), newDuration);
+    }
+
+    /// @dev UT-FIX-13: a SetTimelockDuration proposal below the immutable
+    ///      MIN_TIMELOCK floor is rejected at execution; the floor holds.
+    function test_proposeSetTimelockDuration_revertsBelowMinTimelock_afterFix() public {
+        uint256 t           = block.timestamp;
+        uint256 newDuration = MIN_TIMELOCK - 1; // just under the floor
+        uint256 nonce       = proxy.proposalNonce();
+        uint256 deadline    = t + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeSetTimelockDuration(domainSep, newDuration, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes32 id = proxy.proposeSetTimelockDuration(newDuration, nonce, deadline, bitmap, MultisigHelper.signAll(vm, digest, pks));
+
+        vm.warp(t + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
+        proxy.executeProposal(id, abi.encode(newDuration));
+
+        assertEq(proxy.timelockDuration(), TIMELOCK, 'timelock unchanged');
+    }
+
+    /// @dev A value exactly at MIN_TIMELOCK is still accepted (boundary).
+    function test_proposeSetTimelockDuration_acceptsAtMinTimelock_afterFix() public {
+        uint256 t           = block.timestamp;
+        uint256 newDuration = MIN_TIMELOCK; // exactly the floor
+        uint256 nonce       = proxy.proposalNonce();
+        uint256 deadline    = t + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeSetTimelockDuration(domainSep, newDuration, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes32 id = proxy.proposeSetTimelockDuration(newDuration, nonce, deadline, bitmap, MultisigHelper.signAll(vm, digest, pks));
+
+        vm.warp(t + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(newDuration));
         assertEq(proxy.timelockDuration(), newDuration);
     }
 

--- a/ethereum/test/RgbSettlementModule.t.sol
+++ b/ethereum/test/RgbSettlementModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test }                from 'forge-std/Test.sol';
 import { RgbSettlementModule } from '../src/settlement/RgbSettlementModule.sol';

--- a/ethereum/test/RouteRegistry.t.sol
+++ b/ethereum/test/RouteRegistry.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test }    from 'forge-std/Test.sol';
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';

--- a/ethereum/test/mocks/MockAggregatorV3.sol
+++ b/ethereum/test/mocks/MockAggregatorV3.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { AggregatorV3Interface } from '@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol';
 

--- a/ethereum/test/mocks/MockAggregatorV3.sol
+++ b/ethereum/test/mocks/MockAggregatorV3.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.35;
 
-import { AggregatorV3Interface } from '@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol';
+import { AggregatorV3Interface } from '../../src/interfaces/AggregatorV3Interface.sol';
 
 /// @title MockAggregatorV3
 /// @notice Minimal Chainlink-compatible price feed for tests. Lets each test

--- a/ethereum/test/mocks/MockBtcRelay.sol
+++ b/ethereum/test/mocks/MockBtcRelay.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IBtcRelayView } from '../../src/interfaces/IBtcRelayView.sol';
 

--- a/ethereum/test/mocks/MockERC20.sol
+++ b/ethereum/test/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { ERC20 } from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 

--- a/ethereum/test/mocks/MockFinalityVerifier.sol
+++ b/ethereum/test/mocks/MockFinalityVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IFinalityVerifier } from '../../src/interfaces/IFinalityVerifier.sol';
 import { FundsOutContext }   from '../../src/interfaces/RouteTypes.sol';

--- a/ethereum/test/mocks/MockSettlementModule.sol
+++ b/ethereum/test/mocks/MockSettlementModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { ISettlementModule } from '../../src/interfaces/ISettlementModule.sol';
 import { FundsInContext, FundsOutContext } from '../../src/interfaces/RouteTypes.sol';

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Vm } from 'forge-std/Vm.sol';
 

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -26,6 +26,14 @@ library MultisigHelper {
         'EmergencyUnpause(uint256 nonce,uint256 deadline)'
     );
 
+    bytes32 internal constant PROPOSE_PAUSE_INFLOW_TYPEHASH = keccak256(
+        'ProposePauseInflow(uint256 nonce,uint256 deadline)'
+    );
+
+    bytes32 internal constant PROPOSE_UNPAUSE_INFLOW_TYPEHASH = keccak256(
+        'ProposeUnpauseInflow(uint256 nonce,uint256 deadline)'
+    );
+
     bytes32 internal constant PROPOSE_ADMIN_EXECUTE_TYPEHASH = keccak256(
         'ProposeAdminExecute(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
     );
@@ -159,6 +167,14 @@ library MultisigHelper {
 
     function digestEmergencyUnpause(bytes32 domainSep, uint256 nonce, uint256 deadline) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(EMERGENCY_UNPAUSE_TYPEHASH, nonce, deadline)));
+    }
+
+    function digestProposePauseInflow(bytes32 domainSep, uint256 nonce, uint256 deadline) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(PROPOSE_PAUSE_INFLOW_TYPEHASH, nonce, deadline)));
+    }
+
+    function digestProposeUnpauseInflow(bytes32 domainSep, uint256 nonce, uint256 deadline) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(PROPOSE_UNPAUSE_INFLOW_TYPEHASH, nonce, deadline)));
     }
 
     function digestProposeAdminExecute(


### PR DESCRIPTION
**Changes**
- Solidity 0.8.20 → 0.8.35 across all contracts, scripts and tests; pinned via solc_version in foundry.toml for deterministic builds. The two floating pragmas (^0.8.20) are now fixed.
- **forge-std** v1.15.0 → v1.16.1.
- **Dropped the archived** chainlink-brownie-contracts dependency. Only AggregatorV3Interface was used; it's a self-contained interface (verified byte-identical to canonical @chainlink/contracts@1.5.0), now vendored under src/interfaces/. Submodule and remapping removed — this accounts for most of the changed-file count.
- **Fixed one flaky test** (test_proposeAdminExecuteAdapter_executesCallOnAdapter) under via_ir: it re-read block.timestamp after vm.warp in the same function, which the optimizer may treat as tx-invariant and collapse onto a stale value. Test-only — no contract change.