### PR TITLE
test(R-W-05): two-tier pause regression

### DIFF
--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -48,6 +48,13 @@ contract MultisigProxy is IMultisigProxy {
     /// @notice Minimum delay (seconds) between proposal creation and execution.
     uint256 public timelockDuration;
 
+    /// @notice Lower bound for `timelockDuration`, fixed at deploy time.
+    /// @dev Immutable so the governance observation/veto window can never be
+    ///      reduced below this floor — not by a `SetTimelockDuration` proposal
+    ///      and not by any later action. Set in the constructor and validated to
+    ///      be in (0, MAX_PROPOSAL_LIFETIME).
+    uint256 public immutable MIN_TIMELOCK;
+
     // =========================================================================
     // Constants
     // =========================================================================
@@ -163,7 +170,8 @@ contract MultisigProxy is IMultisigProxy {
         address[] memory federationSigners_,
         uint256 federationThreshold_,
         address commissionRecipient_,
-        uint256 timelockDuration_
+        uint256 timelockDuration_,
+        uint256 minTimelock_
     ) {
         if (bridge_ == address(0)) revert ZeroBridge();
         if (commissionManager_ == address(0)) revert ZeroCommissionManager();
@@ -172,6 +180,8 @@ contract MultisigProxy is IMultisigProxy {
         if (federationSigners_.length == 0) revert NoSigners();
         if (federationThreshold_ == 0 || federationThreshold_ > federationSigners_.length) revert InvalidThreshold();
         if (commissionRecipient_ == address(0)) revert ZeroCommissionRecipient();
+        if (minTimelock_ == 0 || minTimelock_ >= MAX_PROPOSAL_LIFETIME) revert InvalidMinTimelock();
+        if (timelockDuration_ < minTimelock_) revert TimelockTooShort();
         if (timelockDuration_ >= MAX_PROPOSAL_LIFETIME) revert TimelockTooLong();
 
         _validateSigners(enclaveSigners_);
@@ -185,6 +195,7 @@ contract MultisigProxy is IMultisigProxy {
         federationThreshold = federationThreshold_;
         commissionRecipient = commissionRecipient_;
         timelockDuration = timelockDuration_;
+        MIN_TIMELOCK = minTimelock_;
 
         // Default TEE allowlist: Bridge.fundsOut. Additional (target, selector) pairs
         // (e.g. for the LayerZero adapter's outbound `sendOut`) are added later via
@@ -881,6 +892,7 @@ contract MultisigProxy is IMultisigProxy {
 
         } else if (opType == OperationType.SetTimelockDuration) {
             uint256 newDuration = abi.decode(opData, (uint256));
+            if (newDuration < MIN_TIMELOCK) revert TimelockTooShort();
             if (newDuration >= MAX_PROPOSAL_LIFETIME) revert TimelockTooLong();
             timelockDuration = newDuration;
             emit TimelockDurationUpdated(newDuration);

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -43,6 +43,8 @@ interface IMultisigProxy {
     error InvalidThreshold();
     error ZeroCommissionRecipient();
     error TimelockTooLong();
+    error TimelockTooShort();
+    error InvalidMinTimelock();
     error Expired();
     error CallDataTooShort();
     error CallNotAllowed(address target, bytes4 selector);
@@ -439,5 +441,6 @@ interface IMultisigProxy {
     function DOMAIN_SEPARATOR() external view returns (bytes32);
     function proposalNonce() external view returns (uint256);
     function timelockDuration() external view returns (uint256);
+    function MIN_TIMELOCK() external view returns (uint256);
     function getProposal(bytes32 proposalId) external view returns (Proposal memory);
 }

--- a/ethereum/test/BaseBridge.t.sol
+++ b/ethereum/test/BaseBridge.t.sol
@@ -95,7 +95,7 @@ contract BaseBridgeTest is Test {
 
     function test_fundsIn_revertsWhenPaused() public {
         vm.prank(owner);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
@@ -154,23 +154,23 @@ contract BaseBridgeTest is Test {
     function test_pause_onlyOwner() public {
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.pause();
+        bridge.pauseInflow();
     }
 
     function test_unpause_onlyOwner() public {
         vm.prank(owner);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.unpause();
+        bridge.unpauseInflow();
     }
 
     function test_unpause_ownerCanUnpause() public {
         vm.prank(owner);
-        bridge.pause();
+        bridge.pauseInflow();
         vm.prank(owner);
-        bridge.unpause();
+        bridge.unpauseInflow();
 
         // fundsIn works again
         vm.prank(user);
@@ -182,6 +182,118 @@ contract BaseBridgeTest is Test {
         vm.expectRevert(BridgeBase.RenounceOwnershipBlocked.selector);
         vm.prank(owner);
         bridge.renounceOwnership();
+    }
+
+    // ========================================================================
+    // R-W-05 — two-tier pause (inflow vs outflow / emergency)
+    // ========================================================================
+
+    /// @dev UT-FIX-08: with outflow frozen, fundsOut reverts. The
+    ///      whenOutflowNotPaused modifier runs before the body, so a dummy
+    ///      release is enough to exercise the gate.
+    function test_fundsOut_revertsWhenOutflowPaused() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID); // seed the pool
+
+        vm.prank(owner);
+        bridge.emergencyPauseAll();
+
+        vm.expectRevert(BridgeBase.OutflowEnforcedPause.selector);
+        vm.prank(owner);
+        bridge.fundsOut(recipient, AMOUNT, OPERATION_ID, SRC_ADDR);
+    }
+
+    /// @dev The planned inflow-only pause blocks deposits but leaves
+    ///      withdrawals open — the core two-tier distinction (liquidity can be
+    ///      migrated out while new deposits are frozen).
+    function test_fundsOut_worksWhenOnlyInflowPaused() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID); // seed before freezing inflow
+
+        vm.prank(owner);
+        bridge.pauseInflow();
+
+        // Deposits are frozen...
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID);
+
+        // ...but withdrawals still work.
+        vm.prank(owner);
+        bridge.fundsOut(recipient, AMOUNT, OPERATION_ID, SRC_ADDR);
+        assertEq(token.balanceOf(recipient), AMOUNT);
+    }
+
+    /// @dev Emergency pause freezes BOTH paths.
+    function test_emergencyPauseAll_freezesBothPaths() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID); // seed the pool
+
+        vm.prank(owner);
+        bridge.emergencyPauseAll();
+
+        assertTrue(bridge.paused(),        'inflow frozen');
+        assertTrue(bridge.outflowPaused(), 'outflow frozen');
+
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID);
+
+        vm.expectRevert(BridgeBase.OutflowEnforcedPause.selector);
+        vm.prank(owner);
+        bridge.fundsOut(recipient, AMOUNT, OPERATION_ID, SRC_ADDR);
+    }
+
+    /// @dev Emergency unpause lifts BOTH freezes.
+    function test_emergencyUnpauseAll_liftsBoth() public {
+        vm.startPrank(owner);
+        bridge.emergencyPauseAll();
+        bridge.emergencyUnpauseAll();
+        vm.stopPrank();
+
+        assertFalse(bridge.paused(),        'inflow resumed');
+        assertFalse(bridge.outflowPaused(), 'outflow resumed');
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID);
+        assertEq(token.balanceOf(address(bridge)), AMOUNT);
+    }
+
+    /// @dev emergencyPauseAll must be idempotent per flag: it must not revert
+    ///      if inflow is already frozen via the planned path.
+    function test_emergencyPauseAll_idempotentWhenInflowAlreadyPaused() public {
+        vm.startPrank(owner);
+        bridge.pauseInflow();      // inflow already frozen
+        bridge.emergencyPauseAll(); // must not revert on the already-set inflow flag
+        vm.stopPrank();
+
+        assertTrue(bridge.paused(),        'inflow still frozen');
+        assertTrue(bridge.outflowPaused(), 'outflow now frozen');
+    }
+
+    function test_pauseInflow_onlyOwner() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.pauseInflow();
+    }
+
+    function test_emergencyPauseAll_onlyOwner() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.emergencyPauseAll();
+    }
+
+    function test_emergencyUnpauseAll_onlyOwner() public {
+        vm.prank(owner);
+        bridge.emergencyPauseAll();
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.emergencyUnpauseAll();
+    }
+
+    function test_outflowPaused_defaultsFalse() public view {
+        assertFalse(bridge.outflowPaused());
     }
 
     // ========================================================================

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -404,7 +404,7 @@ contract BridgeTest is Test {
 
     function test_fundsIn_revertsWhenPaused() public {
         vm.prank(multisig);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
@@ -762,16 +762,16 @@ contract BridgeTest is Test {
     function test_pause_onlyOwner() public {
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.pause();
+        bridge.pauseInflow();
     }
 
     function test_unpause_onlyOwner() public {
         vm.prank(multisig);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.unpause();
+        bridge.unpauseInflow();
     }
 
     function test_renounceOwnership_alwaysReverts() public {

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -91,7 +91,8 @@ contract IntegrationTest is Test {
     bytes32 constant COMMITMENT_HASH   = keccak256('integration-btc-block');
     uint256 constant BTC_CONFIRMATIONS = 6;
 
-    uint256 constant TIMELOCK = 1 hours;
+    uint256 constant TIMELOCK     = 1 hours;
+    uint256 constant MIN_TIMELOCK = 1 hours; // floor passed to the proxy constructor in tests
 
     /// @dev New 8-arg fundsOut selector:
     ///        fundsOut(
@@ -189,7 +190,8 @@ contract IntegrationTest is Test {
             enc, 2,
             fed, 2,
             commissionReceiver,
-            TIMELOCK
+            TIMELOCK,
+            MIN_TIMELOCK
         );
 
         cm.transferOwnership(address(proxy));

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -6,6 +6,8 @@ import { Test } from 'forge-std/Test.sol';
 import { MultisigProxy }  from '../src/MultisigProxy.sol';
 import { IMultisigProxy } from '../src/interfaces/IMultisigProxy.sol';
 import { Bridge }              from '../src/Bridge.sol';
+import { BridgeBase }          from '../src/BridgeBase.sol';
+import { Pausable }            from '@openzeppelin/contracts/utils/Pausable.sol';
 import { CommissionManager }   from '../src/CommissionManager.sol';
 import { RouteRegistry }       from '../src/RouteRegistry.sol';
 import { IRouteRegistry }      from '../src/interfaces/IRouteRegistry.sol';
@@ -355,7 +357,7 @@ contract MultisigProxyTest is Test {
     }
 
     function test_execute_revertsOnDisallowedSelector() public {
-        bytes memory callData = abi.encodeWithSignature('pause()');
+        bytes memory callData = abi.encodeWithSignature('pauseInflow()');
         uint256 nonce = 0;
         uint256 deadline = block.timestamp + 1 hours;
 
@@ -434,7 +436,7 @@ contract MultisigProxyTest is Test {
         bytes[]   memory callDatas = new bytes[](1);
         uint256[] memory values    = new uint256[](1);
         targets[0]   = makeAddr('random-target');
-        callDatas[0] = abi.encodeWithSignature('pause()');
+        callDatas[0] = abi.encodeWithSignature('pauseInflow()');
 
         uint256 nonce    = proxy.batchNonce();
         uint256 deadline = block.timestamp + 1 hours;
@@ -627,6 +629,79 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
+    // R-W-05 — two-tier pause (integration via MultisigProxy)
+    // ========================================================================
+
+    /// @dev After R-W-05, the no-timelock emergency pause freezes the OUTFLOW
+    ///      path too — including the enclave/TEE release, which routes through
+    ///      Bridge.fundsOut. A signed fundsOut executed straight after
+    ///      emergencyPause must revert OutflowEnforcedPause, and inbound deposits
+    ///      must be frozen as well.
+    function test_emergencyPause_freezesEnclaveFundsOut() public {
+        // Federation triggers the emergency freeze (both paths).
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 digest   = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
+        (uint256[] memory fpks, uint256 fbitmap) = _fedSigSet2of3();
+        proxy.emergencyPause(nonce, deadline, fbitmap, MultisigHelper.signAll(vm, digest, fpks));
+
+        assertTrue(bridge.paused(),        'inflow frozen');
+        assertTrue(bridge.outflowPaused(), 'outflow frozen');
+
+        // Inbound deposits are frozen.
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
+
+        // Enclave-signed release is frozen too — the revert propagates from
+        // Bridge.fundsOut through proxy.execute.
+        bytes memory callData = _fundsOutCalldata();
+        uint256 encNonce      = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        bytes32 encDigest     = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, encNonce, deadline);
+        (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
+        bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
+
+        vm.expectRevert(BridgeBase.OutflowEnforcedPause.selector);
+        proxy.execute(callData, encNonce, deadline, ebitmap, esigs);
+    }
+
+    /// @dev The planned inflow-only pause runs through the timelocked
+    ///      propose -> execute path and blocks deposits while leaving the
+    ///      enclave release path open (liquidity migration scenario).
+    function test_proposePauseInflow_blocksFundsInButAllowsFundsOut() public {
+        uint256 t = block.timestamp; // read once; derive all timing from it (via_ir-safe)
+
+        // Propose the inflow-only pause (federation signed).
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = t + 1 days;
+        bytes32 digest   = MultisigHelper.digestProposePauseInflow(domainSep, nonce, deadline);
+        (uint256[] memory fpks, uint256 fbitmap) = _fedSigSet2of3();
+        bytes32 id = proxy.proposePauseInflow(nonce, deadline, fbitmap, MultisigHelper.signAll(vm, digest, fpks));
+
+        // Execute it after the timelock (no payload).
+        vm.warp(t + TIMELOCK + 1);
+        proxy.executeProposal(id, '');
+
+        assertTrue(bridge.paused(),         'inflow frozen');
+        assertFalse(bridge.outflowPaused(), 'outflow stays open');
+
+        // Deposits are frozen...
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
+
+        // ...but the enclave release still executes.
+        bytes memory callData = _fundsOutCalldata();
+        uint256 encNonce      = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        bytes32 encDigest     = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, encNonce, t + 1 days);
+        (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
+        bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
+
+        proxy.execute(callData, encNonce, t + 1 days, ebitmap, esigs);
+        assertEq(token.balanceOf(recipient), AMOUNT, 'withdrawal succeeded while inflow paused');
+    }
+
+    // ========================================================================
     // Propose + Execute — UpdateBridge
     // ========================================================================
 
@@ -763,7 +838,7 @@ contract MultisigProxyTest is Test {
     // ========================================================================
 
     function test_proposeAdminExecute_canCallBridge() public {
-        bytes memory callData = abi.encodeWithSignature('pause()');
+        bytes memory callData = abi.encodeWithSignature('pauseInflow()');
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
 

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -89,7 +89,8 @@ contract MultisigProxyTest is Test {
     address recipient          = makeAddr('recipient');
     address commissionReceiver = makeAddr('commissionReceiver');
 
-    uint256 constant TIMELOCK = 1 hours;
+    uint256 constant TIMELOCK     = 1 hours;
+    uint256 constant MIN_TIMELOCK = 1 hours; // floor passed to the proxy constructor in tests
 
     bytes32 domainSep;
 
@@ -177,7 +178,8 @@ contract MultisigProxyTest is Test {
             enc, 2,
             fed, 2,
             commissionReceiver,
-            TIMELOCK
+            TIMELOCK,
+            MIN_TIMELOCK
         );
 
         // Production-flow ownership transfer.
@@ -256,56 +258,87 @@ contract MultisigProxyTest is Test {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroBridge.selector);
-        new MultisigProxy(address(0), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(0), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommissionManager() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionManager.selector);
-        new MultisigProxy(address(bridge), address(0), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(0), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnNoEnclaveSigners() public {
         address[] memory enc = new address[](0);
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.NoSigners.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnBadEnclaveThreshold() public {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 3, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 3, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommission() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionRecipient.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, address(0), TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, address(0), TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnTimelockTooLong() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.TimelockTooLong.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 30 days);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 30 days, MIN_TIMELOCK);
+    }
+
+    // ---- R-W-11: MIN_TIMELOCK floor (post-fix) ----
+
+    /// @dev UT-FIX-13: deploying with a timelock below the requested floor reverts.
+    function test_constructor_revertsOnTimelockBelowMinTimelock() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        // timelock (1h) is below the requested floor (2h) -> TimelockTooShort
+        vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 1 hours, 2 hours);
+    }
+
+    /// @dev A zero floor is rejected — it would defeat the purpose of the fix.
+    function test_constructor_revertsOnZeroMinTimelock() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, 0);
+    }
+
+    /// @dev A floor at/above the upper bound leaves no valid range — rejected.
+    function test_constructor_revertsOnMinTimelockTooLong() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, 30 days);
+    }
+
+    function test_minTimelock_returnsConfiguredFloor() public view {
+        assertEq(proxy.MIN_TIMELOCK(), MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnDuplicateSigner() public {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroAddressSigner() public {
         address[] memory enc = new address[](1); enc[0] = address(0);
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     // ========================================================================
@@ -830,6 +863,41 @@ contract MultisigProxyTest is Test {
         emit TimelockDurationUpdated(newDuration);
         proxy.executeProposal(id, abi.encode(newDuration));
 
+        assertEq(proxy.timelockDuration(), newDuration);
+    }
+
+    /// @dev UT-FIX-13: a SetTimelockDuration proposal below the immutable
+    ///      MIN_TIMELOCK floor is rejected at execution; the floor holds.
+    function test_proposeSetTimelockDuration_revertsBelowMinTimelock_afterFix() public {
+        uint256 t           = block.timestamp;
+        uint256 newDuration = MIN_TIMELOCK - 1; // just under the floor
+        uint256 nonce       = proxy.proposalNonce();
+        uint256 deadline    = t + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeSetTimelockDuration(domainSep, newDuration, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes32 id = proxy.proposeSetTimelockDuration(newDuration, nonce, deadline, bitmap, MultisigHelper.signAll(vm, digest, pks));
+
+        vm.warp(t + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
+        proxy.executeProposal(id, abi.encode(newDuration));
+
+        assertEq(proxy.timelockDuration(), TIMELOCK, 'timelock unchanged');
+    }
+
+    /// @dev A value exactly at MIN_TIMELOCK is still accepted (boundary).
+    function test_proposeSetTimelockDuration_acceptsAtMinTimelock_afterFix() public {
+        uint256 t           = block.timestamp;
+        uint256 newDuration = MIN_TIMELOCK; // exactly the floor
+        uint256 nonce       = proxy.proposalNonce();
+        uint256 deadline    = t + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeSetTimelockDuration(domainSep, newDuration, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes32 id = proxy.proposeSetTimelockDuration(newDuration, nonce, deadline, bitmap, MultisigHelper.signAll(vm, digest, pks));
+
+        vm.warp(t + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(newDuration));
         assertEq(proxy.timelockDuration(), newDuration);
     }
 

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -26,6 +26,14 @@ library MultisigHelper {
         'EmergencyUnpause(uint256 nonce,uint256 deadline)'
     );
 
+    bytes32 internal constant PROPOSE_PAUSE_INFLOW_TYPEHASH = keccak256(
+        'ProposePauseInflow(uint256 nonce,uint256 deadline)'
+    );
+
+    bytes32 internal constant PROPOSE_UNPAUSE_INFLOW_TYPEHASH = keccak256(
+        'ProposeUnpauseInflow(uint256 nonce,uint256 deadline)'
+    );
+
     bytes32 internal constant PROPOSE_ADMIN_EXECUTE_TYPEHASH = keccak256(
         'ProposeAdminExecute(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
     );
@@ -159,6 +167,14 @@ library MultisigHelper {
 
     function digestEmergencyUnpause(bytes32 domainSep, uint256 nonce, uint256 deadline) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(EMERGENCY_UNPAUSE_TYPEHASH, nonce, deadline)));
+    }
+
+    function digestProposePauseInflow(bytes32 domainSep, uint256 nonce, uint256 deadline) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(PROPOSE_PAUSE_INFLOW_TYPEHASH, nonce, deadline)));
+    }
+
+    function digestProposeUnpauseInflow(bytes32 domainSep, uint256 nonce, uint256 deadline) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(PROPOSE_UNPAUSE_INFLOW_TYPEHASH, nonce, deadline)));
     }
 
     function digestProposeAdminExecute(


### PR DESCRIPTION
## test(R-W-05): two-tier pause regression tests

Companion test PR for the **R-W-05 / EXT-W-05** fix (branch `fundsIn-pause-fix`). Stacked on the fix branch.

### Added — behavioral / regression
**`BaseBridge.t.sol`** (unit):
- `test_fundsOut_revertsWhenOutflowPaused` — **UT-FIX-08**: `fundsOut` reverts when the outflow path is frozen.
- `test_fundsOut_worksWhenOnlyInflowPaused` — planned inflow-only pause blocks deposits but leaves withdrawals open.
- `test_emergencyPauseAll_freezesBothPaths` / `test_emergencyUnpauseAll_liftsBoth`.
- `test_emergencyPauseAll_idempotentWhenInflowAlreadyPaused`.
- `onlyOwner` gating on `pauseInflow` / `emergencyPauseAll` / `emergencyUnpauseAll`; default `outflowPaused()`.

**`MultisigProxy.t.sol`** (integration):
- `test_emergencyPause_freezesEnclaveFundsOut` — emergency pause freezes the enclave/TEE-signed `fundsOut` path and inbound deposits.
- `test_proposePauseInflow_blocksFundsInButAllowsFundsOut` — the timelocked `PauseInflow` proposal blocks `fundsIn` while the enclave release still executes.