### PR TITLE
fix(R-W-04): reject NATIVE+FUNDS_OUT commission at config time

### DIFF
--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -186,11 +186,13 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (consumedBurnIds[burnId]) revert BurnIdAlreadyConsumed(burnId);
         consumedBurnIds[burnId] = true;
 
-        // Quote commission. NATIVE on fundsOut is disallowed — the caller is
-        // the multisig, there is no user to fund a native payment.
+        // Quote commission. NATIVE on fundsOut is unrepresentable: the
+        // CommissionManager setters reject a (NATIVE, FUNDS_OUT) rule at config,
+        // so `nativeCommission` is always 0 on this path. The
+        // value is ignored here.
         (
             uint256 tokenCommission,
-            uint256 nativeCommission,
+            ,
             uint256 netAmount
         ) = commissionManager.calculateFundsOutCommission(
             sourceChainId,
@@ -198,7 +200,6 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             TOKEN,
             amount
         );
-        if (nativeCommission != 0) revert NativeCommissionNotAllowedOnFundsOut();
 
         // Delegate route-specific finality verification + settlement-state
         // mutation to the configured plugins. The registry runs the verifier

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -292,6 +292,11 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
     ) external onlyOwner {
         if (stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (multiplier == 0) revert MultiplierZero();
+        // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
+        // native fee
+        if (currency == CommissionCurrency.NATIVE && side == CommissionSide.FUNDS_OUT) {
+            revert NativeCommissionNotAllowedOnFundsOut();
+        }
 
         globalStablePercent = stablePercent;
         globalMultiplier = multiplier;
@@ -338,6 +343,11 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
         // Validate config
         if (config.stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (config.multiplier == 0) revert MultiplierZero();
+        // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
+        // native fee
+        if (config.currency == CommissionCurrency.NATIVE && config.side == CommissionSide.FUNDS_OUT) {
+            revert NativeCommissionNotAllowedOnFundsOut();
+        }
 
         // Build route key
         bytes32 key = buildRouteKey(sourceChainId, destChainId, token);

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -13,7 +13,6 @@ interface IBridge {
     error InvalidCommissionManagerAddress();
     error NotLZAdapter();
     error BurnIdAlreadyConsumed(uint256 burnId);
-    error NativeCommissionNotAllowedOnFundsOut();
     error NativeValueMismatch();
 
     // =========================================================================

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -46,6 +46,7 @@ interface ICommissionManager {
     error InvalidRecipient();
     error StablePercentTooHigh();
     error MultiplierZero();
+    error NativeCommissionNotAllowedOnFundsOut();
     error TokenDecimalsUnavailable();
     error BalanceBelowRecordedPool();
     error NothingReceived();

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -718,22 +718,14 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
-    // Commission — fundsOut NATIVE reverts
+    // Commission — NATIVE + FUNDS_OUT rejected at config time (R-W-04)
     // ========================================================================
 
-    function test_fundsOut_nativeCommission_reverts() public {
-        vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
-
-        _setFundsOutNativeRule(100);
-
-        vm.expectRevert(IBridge.NativeCommissionNotAllowedOnFundsOut.selector);
-        vm.prank(multisig);
-        bridge.fundsOut(
-            recipient, AMOUNT, BURN_ID,
-            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
-        );
+    /// @dev Post R-W-04 the invalid (NATIVE, FUNDS_OUT) shape is rejected by the
+    ///      CommissionManager setter, so it can never reach (and brick) fundsOut.
+    function test_setCommissionRule_nativeFundsOut_reverts() public {
+        vm.expectRevert(ICommissionManager.NativeCommissionNotAllowedOnFundsOut.selector);
+        _setFundsOutNativeRule(100); // setCommissionRule(... NATIVE, FUNDS_OUT ...)
     }
 
     // ========================================================================

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -161,25 +161,28 @@ contract CommissionManagerTest is Test {
     }
 
     function test_setGlobalDefaults_updatesAndEmits() public {
+        // FUNDS_IN + NATIVE is a valid shape (the user funds the native fee on
+        // deposit). NATIVE + FUNDS_OUT is rejected by the setter (R-W-04) and is
+        // covered by a dedicated revert test.
         vm.expectEmit(true, true, true, true);
         emit GlobalDefaultsUpdated(
             200,
             100,
-            CommissionSide.FUNDS_OUT,
+            CommissionSide.FUNDS_IN,
             CommissionCurrency.NATIVE
         );
         vm.prank(owner);
         cm.setGlobalDefaults(
             200,
             100,
-            CommissionSide.FUNDS_OUT,
+            CommissionSide.FUNDS_IN,
             CommissionCurrency.NATIVE
         );
         (uint256 sp, uint8 m, CommissionSide side, CommissionCurrency cur) =
             cm.getGlobalDefaults();
         assertEq(sp, 200);
         assertEq(m, 100);
-        assertEq(uint8(side), uint8(CommissionSide.FUNDS_OUT));
+        assertEq(uint8(side), uint8(CommissionSide.FUNDS_IN));
         assertEq(uint8(cur), uint8(CommissionCurrency.NATIVE));
     }
 
@@ -234,6 +237,32 @@ contract CommissionManagerTest is Test {
             CommissionSide.FUNDS_IN,
             CommissionCurrency.TOKEN
         );
+    }
+
+    /// @dev UT-FIX-07: setGlobalDefaults rejects the NATIVE + FUNDS_OUT shape.
+    function test_setGlobalDefaults_revertsNativeFundsOut() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.NativeCommissionNotAllowedOnFundsOut.selector);
+        cm.setGlobalDefaults(
+            100,
+            100,
+            CommissionSide.FUNDS_OUT,
+            CommissionCurrency.NATIVE
+        );
+    }
+
+    /// @dev FUNDS_IN + NATIVE stays valid — the user funds the native fee on deposit.
+    function test_setGlobalDefaults_acceptsNativeFundsIn() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(
+            100,
+            100,
+            CommissionSide.FUNDS_IN,
+            CommissionCurrency.NATIVE
+        );
+        (, , CommissionSide side, CommissionCurrency cur) = cm.getGlobalDefaults();
+        assertEq(uint8(side), uint8(CommissionSide.FUNDS_IN));
+        assertEq(uint8(cur),  uint8(CommissionCurrency.NATIVE));
     }
 
     // --- Commission calculations (globals) ---
@@ -477,6 +506,39 @@ contract CommissionManagerTest is Test {
         vm.prank(owner);
         vm.expectRevert(ICommissionManager.StablePercentTooHigh.selector);
         cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t, cfg);
+    }
+
+    /// @dev UT-FIX-07: setCommissionRule rejects the NATIVE + FUNDS_OUT shape.
+    function test_setCommissionRule_revertsNativeFundsOut() public {
+        address t = address(token);
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 100,
+            multiplier: 100,
+            side: CommissionSide.FUNDS_OUT,
+            currency: CommissionCurrency.NATIVE,
+            isSet: true
+        });
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.NativeCommissionNotAllowedOnFundsOut.selector);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t, cfg);
+    }
+
+    /// @dev FUNDS_OUT + TOKEN stays valid (the fee is deducted from the release).
+    function test_setCommissionRule_acceptsFundsOutToken() public {
+        address t = address(token);
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 100,
+            multiplier: 100,
+            side: CommissionSide.FUNDS_OUT,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+        vm.prank(owner);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t, cfg);
+
+        CommissionConfig memory stored = cm.getCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t);
+        assertEq(uint8(stored.side),     uint8(CommissionSide.FUNDS_OUT));
+        assertEq(uint8(stored.currency), uint8(CommissionCurrency.TOKEN));
     }
 
     // --- Bridge address ---


### PR DESCRIPTION
## fix(R-W-04): reject NATIVE + FUNDS_OUT commission at config time

Audit finding **R-W-04 / EXT-W-04** — `CommissionManager` accepted a `(NATIVE, FUNDS_OUT)` rule that later bricked `Bridge.fundsOut`.

### Problem
`setGlobalDefaults` / `setCommissionRule` validated only `stablePercent` and `multiplier`, never the `(side, currency)` pair. A `(side = FUNDS_OUT, currency = NATIVE)` rule was stored silently; at release time `Bridge.fundsOut` quoted a non-zero `nativeCommission` and hard-reverted `NativeCommissionNotAllowedOnFundsOut()`, freezing every redemption on the route (or all routes, if set as the global default) until reconfigured through the timelock.

### Fix
- Reject `currency == NATIVE && side == FUNDS_OUT` at config time in **both** setters (`NativeCommissionNotAllowedOnFundsOut`), making the bad shape unrepresentable — fail-fast off the critical money path.
- Moved the `NativeCommissionNotAllowedOnFundsOut` error from `IBridge` to `ICommissionManager`.
- Removed the now-dead runtime guard in `Bridge.fundsOut`: with the config-time check, `calculateFundsOutCommission` can never return a non-zero native fee on the release path (it does so only for a `NATIVE` + `FUNDS_OUT` effective config, including the global fallback), so the check is unreachable.