### PR TITLE
Multisig timelock duration tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "ethereum/lib/openzeppelin-contracts"]
 	path = ethereum/lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-[submodule "ethereum/lib/chainlink-brownie-contracts"]
-	path = ethereum/lib/chainlink-brownie-contracts
-	url = https://github.com/smartcontractkit/chainlink-brownie-contracts

--- a/README.md
+++ b/README.md
@@ -76,3 +76,12 @@ Each transfer deducts a service commission, configured per-route: source side (`
 ### Replay protection
 
 Each network enforces replay protection at the smart-contract level. On EVM the `Bridge` records consumed `burnId`s on-chain (each `FundsOut` carries the `burnId` extracted from the source-side burn consignment and is rejected if already seen) and `MultisigProxy` enforces per-selector sequential nonces on `execute` plus a sequential `batchNonce` on `executeBatch`. Route-specific bookkeeping — e.g. matching `FundsOut` against the exact source-side deposits being settled — lives in the per-route `SettlementModule` (for the RGB route, `RgbSettlementModule` tracks net deposit balances and consumes them atomically with the release).
+
+## Third-party code
+
+The Bitcoin SPV light client consulted on the RGB route lives under `ethereum/src/btc_relay/`. This code is vendored from the upstream Atomiq project:
+
+- **Source:** [atomiqlabs/atomiq-contracts-evm](https://github.com/atomiqlabs/atomiq-contracts-evm)
+- **License:** Apache License 2.0 — preserved in the SPDX headers of the vendored files.
+
+`RGBVerifier` does not import the vendored `BtcRelay` directly — it talks to a deployed relay through the minimal local `IBtcRelayView` interface (`ethereum/src/interfaces/IBtcRelayView.sol`), which mirrors only the read methods the verifier relies on.

--- a/ethereum/.env.deploy.example
+++ b/ethereum/.env.deploy.example
@@ -89,3 +89,8 @@ COMMISSION_RECIPIENT=
 
 # Timelock between propose and execute for federation proposals (seconds).
 TIMELOCK_DURATION=3600
+
+# Immutable lower bound for the timelock (seconds), fixed at deploy time.
+# Must be in (0, MAX_PROPOSAL_LIFETIME=30 days) and <= TIMELOCK_DURATION.
+# The timelock can never be lowered below this floor afterwards (R-W-11).
+MIN_TIMELOCK=3600

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -2,6 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+solc_version = "0.8.35"
 optimizer = true
 optimizer_runs = 200
 via_ir = true

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -10,5 +10,4 @@ via_ir = true
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 remappings = [
     "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
-    "@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/",
 ]

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -37,7 +37,8 @@ import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.so
 ///   PRIVATE_KEY, USDT0_ADDRESS, BTC_RELAY_ADDRESS,
 ///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD,
 ///   FEDERATION_SIGNERS, FEDERATION_THRESHOLD,
-///   COMMISSION_RECIPIENT, TIMELOCK_DURATION, MIN_TIMELOCK
+///   COMMISSION_RECIPIENT, TIMELOCK_DURATION, MIN_TIMELOCK,
+///   MIN_FUNDS_IN_AMOUNT
 ///
 /// Env (optional):
 ///   ETH_USD_FEED      — Chainlink ETH/USD aggregator (wired in before CM
@@ -74,6 +75,7 @@ contract DeployAll is Script {
         uint256 minTimelock    = vm.envUint('MIN_TIMELOCK');
         address ethUsdFeed     = vm.envOr('ETH_USD_FEED', address(0));
         uint256 ethUsdHb       = vm.envOr('ETH_USD_HEARTBEAT', uint256(0));
+        uint256 minFundsIn     = vm.envUint('MIN_FUNDS_IN_AMOUNT');
 
         address deployer    = vm.addr(pk);
         uint64  startNonce  = vm.getNonce(deployer);
@@ -96,7 +98,8 @@ contract DeployAll is Script {
             usdt0,
             address(routeRegistry),
             payable(address(cm)),
-            address(0)
+            address(0),
+            minFundsIn
         );
 
         // ---- 5. Route plugins (nonce n+3, n+4) ---------------------------

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -37,7 +37,7 @@ import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.so
 ///   PRIVATE_KEY, USDT0_ADDRESS, BTC_RELAY_ADDRESS,
 ///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD,
 ///   FEDERATION_SIGNERS, FEDERATION_THRESHOLD,
-///   COMMISSION_RECIPIENT, TIMELOCK_DURATION
+///   COMMISSION_RECIPIENT, TIMELOCK_DURATION, MIN_TIMELOCK
 ///
 /// Env (optional):
 ///   ETH_USD_FEED      — Chainlink ETH/USD aggregator (wired in before CM
@@ -71,6 +71,7 @@ contract DeployAll is Script {
         uint256 fedThr         = vm.envUint('FEDERATION_THRESHOLD');
         address commission     = vm.envAddress('COMMISSION_RECIPIENT');
         uint256 timelock       = vm.envUint('TIMELOCK_DURATION');
+        uint256 minTimelock    = vm.envUint('MIN_TIMELOCK');
         address ethUsdFeed     = vm.envOr('ETH_USD_FEED', address(0));
         uint256 ethUsdHb       = vm.envOr('ETH_USD_HEARTBEAT', uint256(0));
 
@@ -109,7 +110,8 @@ contract DeployAll is Script {
             enc, encThr,
             fed, fedThr,
             commission,
-            timelock
+            timelock,
+            minTimelock
         );
 
         // ---- 7. Wire optional ETH/USD feed before CM ownership transfer --

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 

--- a/ethereum/script/deploy/DeployBaseBridge.s.sol
+++ b/ethereum/script/deploy/DeployBaseBridge.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { BaseBridge } from '../../src/BaseBridge.sol';

--- a/ethereum/script/deploy/DeployBridge.s.sol
+++ b/ethereum/script/deploy/DeployBridge.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { Bridge } from '../../src/Bridge.sol';

--- a/ethereum/script/deploy/DeployBridge.s.sol
+++ b/ethereum/script/deploy/DeployBridge.s.sol
@@ -29,6 +29,12 @@ import { Bridge } from '../../src/Bridge.sol';
 ///                               `Bridge.setLZAdapter(adapter)`. The Bridge
 ///                               accepts adapter-only `fundsInFromAdapter`
 ///                               calls *only* from the configured adapter.
+///   MIN_FUNDS_IN_AMOUNT       — Minimum accepted `fundsIn` deposit in token
+///                               smallest units (USDT0 has 6 decimals, so e.g.
+///                               10000 = 0.01 USDT0). Required and must be
+///                               non-zero; retune later via federation
+///                               governance with
+///                               `Bridge.setMinFundsInAmount(newMinimum)`.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployBridge.s.sol \
@@ -40,9 +46,10 @@ contract DeployBridge is Script {
         address routeRegistry     = vm.envAddress('ROUTE_REGISTRY_ADDRESS');
         address commissionManager = vm.envAddress('COMMISSION_MANAGER');
         address lzAdapter         = vm.envOr('LZ_ADAPTER', address(0));
+        uint256 minFundsInAmount  = vm.envUint('MIN_FUNDS_IN_AMOUNT');
 
         vm.startBroadcast(pk);
-        bridge = new Bridge(usdt0, routeRegistry, payable(commissionManager), lzAdapter);
+        bridge = new Bridge(usdt0, routeRegistry, payable(commissionManager), lzAdapter, minFundsInAmount);
         vm.stopBroadcast();
 
         console2.log('Bridge deployed at:  ', address(bridge));
@@ -51,5 +58,6 @@ contract DeployBridge is Script {
         console2.log('RouteRegistry:       ', address(bridge.routeRegistry()));
         console2.log('CommissionManager:   ', address(bridge.commissionManager()));
         console2.log('LZ adapter:          ', bridge.lzAdapter());
+        console2.log('Min fundsIn amount:  ', bridge.minFundsInAmount());
     }
 }

--- a/ethereum/script/deploy/DeployCommissionManager.s.sol
+++ b/ethereum/script/deploy/DeployCommissionManager.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { CommissionManager } from '../../src/CommissionManager.sol';

--- a/ethereum/script/deploy/DeployMultisigProxy.s.sol
+++ b/ethereum/script/deploy/DeployMultisigProxy.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { MultisigProxy } from '../../src/MultisigProxy.sol';

--- a/ethereum/script/deploy/DeployMultisigProxy.s.sol
+++ b/ethereum/script/deploy/DeployMultisigProxy.s.sol
@@ -34,6 +34,7 @@ contract DeployMultisigProxy is Script {
         uint256 fedThr             = vm.envUint('FEDERATION_THRESHOLD');
         address commission         = vm.envAddress('COMMISSION_RECIPIENT');
         uint256 timelock           = vm.envUint('TIMELOCK_DURATION');
+        uint256 minTimelock        = vm.envUint('MIN_TIMELOCK');
 
         vm.startBroadcast(pk);
         proxy = new MultisigProxy(
@@ -42,7 +43,8 @@ contract DeployMultisigProxy is Script {
             enc, encThr,
             fed, fedThr,
             commission,
-            timelock
+            timelock,
+            minTimelock
         );
         vm.stopBroadcast();
 

--- a/ethereum/script/deploy/DeployRGBVerifier.s.sol
+++ b/ethereum/script/deploy/DeployRGBVerifier.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { RGBVerifier } from '../../src/verifiers/RGBVerifier.sol';

--- a/ethereum/script/deploy/DeployRgbSettlementModule.s.sol
+++ b/ethereum/script/deploy/DeployRgbSettlementModule.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.sol';

--- a/ethereum/script/deploy/DeployRouteRegistry.s.sol
+++ b/ethereum/script/deploy/DeployRouteRegistry.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { RouteRegistry } from '../../src/RouteRegistry.sol';

--- a/ethereum/script/interact/BridgeFundsIn.s.sol
+++ b/ethereum/script/interact/BridgeFundsIn.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';

--- a/ethereum/script/interact/EmergencyPause.s.sol
+++ b/ethereum/script/interact/EmergencyPause.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { MultisigProxy } from '../../src/MultisigProxy.sol';

--- a/ethereum/script/interact/EmergencyUnpause.s.sol
+++ b/ethereum/script/interact/EmergencyUnpause.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { MultisigProxy } from '../../src/MultisigProxy.sol';

--- a/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
+++ b/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { MultisigProxy } from '../../src/MultisigProxy.sol';

--- a/ethereum/script/interact/MultisigProposeSetRoute.s.sol
+++ b/ethereum/script/interact/MultisigProposeSetRoute.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Script, console2 } from 'forge-std/Script.sol';
 import { MultisigProxy } from '../../src/MultisigProxy.sol';

--- a/ethereum/src/BaseBridge.sol
+++ b/ethereum/src/BaseBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { SafeERC20 } from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';

--- a/ethereum/src/BaseBridge.sol
+++ b/ethereum/src/BaseBridge.sol
@@ -68,7 +68,7 @@ contract BaseBridge is BridgeBase {
         uint256 amount,
         uint256 operationId,
         string  calldata sourceAddress
-    ) external onlyOwner {
+    ) external onlyOwner whenOutflowNotPaused {
         if (recipient == address(0)) revert InvalidRecipientAddress();
         if (amount > IERC20(TOKEN).balanceOf(address(this))) revert AmountExceedBridgePool();
 

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -186,11 +186,13 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (consumedBurnIds[burnId]) revert BurnIdAlreadyConsumed(burnId);
         consumedBurnIds[burnId] = true;
 
-        // Quote commission. NATIVE on fundsOut is disallowed — the caller is
-        // the multisig, there is no user to fund a native payment.
+        // Quote commission. NATIVE on fundsOut is unrepresentable: the
+        // CommissionManager setters reject a (NATIVE, FUNDS_OUT) rule at config,
+        // so `nativeCommission` is always 0 on this path. The
+        // value is ignored here.
         (
             uint256 tokenCommission,
-            uint256 nativeCommission,
+            ,
             uint256 netAmount
         ) = commissionManager.calculateFundsOutCommission(
             sourceChainId,
@@ -198,7 +200,6 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             TOKEN,
             amount
         );
-        if (nativeCommission != 0) revert NativeCommissionNotAllowedOnFundsOut();
 
         // Delegate route-specific finality verification + settlement-state
         // mutation to the configured plugins. The registry runs the verifier

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IERC20 }            from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { SafeERC20 }         from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -40,6 +40,21 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     // State
     // =========================================================================
 
+    /// @notice Upper bound on the `destinationAddress` (fundsIn) and
+    ///         `sourceAddress` (fundsOut) byte length. These strings are echoed
+    ///         into event logs, so an unbounded value would let a caller inflate
+    ///         log-storage and indexer cost. 512 bytes covers every supported
+    ///         destination representation (RGB invoices and other chains) with
+    ///         ample headroom.
+    uint256 public constant MAX_ADDRESS_LENGTH = 512;
+
+    /// @notice Upper bound on the `fundsOut` `proof` byte length. `proof` is
+    ///         forwarded to the route verifier, so an unbounded blob would let a
+    ///         release inflate calldata + verifier gas. 1024 bytes comfortably
+    ///         fits the verifier formats (RGB is 64 bytes today; a future SPV
+    ///         inclusion proof stays well under this).
+    uint256 public constant MAX_PROOF_LENGTH = 1024;
+
     /// @notice CommissionManager that receives and custodies protocol fees.
     ICommissionManager public immutable commissionManager;
 
@@ -55,6 +70,12 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     /// @notice Set of burn identifiers already consumed by a successful
     ///         `fundsOut`.
     mapping(uint256 burnId => bool consumed) public consumedBurnIds;
+
+    /// @inheritdoc IBridge
+    /// @dev Always non-zero (validated at the constructor and setter). Mutable
+    ///      so federation can retune the dust floor via the `MultisigProxy`
+    ///      propose -> timelock -> execute flow without redeploying the Bridge.
+    uint256 public override minFundsInAmount;
 
     // =========================================================================
     // Modifiers
@@ -80,18 +101,24 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     ///                           `address(0)` if it has not been deployed yet
     ///                           (federation can wire it up later via
     ///                           `setLZAdapter`).
+    /// @param minFundsInAmount_  Initial minimum accepted `fundsIn` deposit in
+    ///                           token smallest units. Must be non-zero; it can
+    ///                           be retuned later via `setMinFundsInAmount`.
     constructor(
         address          usdt0_,
         address          routeRegistry_,
         address payable  commissionManager_,
-        address          lzAdapter_
+        address          lzAdapter_,
+        uint256          minFundsInAmount_
     ) BridgeBase(usdt0_) {
         if (routeRegistry_     == address(0)) revert InvalidRouteRegistryAddress();
         if (commissionManager_ == address(0)) revert InvalidCommissionManagerAddress();
+        if (minFundsInAmount_  == 0)          revert InvalidMinFundsInAmount();
 
         routeRegistry     = routeRegistry_;
         commissionManager = ICommissionManager(commissionManager_);
         lzAdapter         = lzAdapter_;
+        minFundsInAmount  = minFundsInAmount_;
     }
 
     // =========================================================================
@@ -115,6 +142,18 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         address old = routeRegistry;
         routeRegistry = newRouteRegistry;
         emit RouteRegistryUpdated(old, newRouteRegistry);
+    }
+
+    /// @inheritdoc IBridge
+    /// @dev Owner is `MultisigProxy`; federation gates this on its M-of-N
+    ///      timelock flow (generic `proposeAdminExecute` -> execute). Must be
+    ///      non-zero: a non-zero floor is what rejects zero-amount and dust
+    ///      deposits on the inbound path.
+    function setMinFundsInAmount(uint256 newMinimum) external override onlyOwner {
+        if (newMinimum == 0) revert InvalidMinFundsInAmount();
+        uint256 old = minFundsInAmount;
+        minFundsInAmount = newMinimum;
+        emit MinFundsInAmountUpdated(old, newMinimum);
     }
 
     // =========================================================================
@@ -175,9 +214,14 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         bytes   calldata proof,
         bytes   calldata settlementData
     ) external override onlyOwner nonReentrant whenOutflowNotPaused {
+        if (amount             == 0)                         revert ZeroAmount();
         if (recipient          == address(0))                revert InvalidRecipientAddress();
         if (sourceChainId      == 0)                         revert InvalidSourceChainId();
         if (destinationChainId == 0)                         revert InvalidDestinationChainId();
+        if (bytes(sourceAddress).length > MAX_ADDRESS_LENGTH) {
+            revert AddressTooLong(bytes(sourceAddress).length, MAX_ADDRESS_LENGTH);
+        }
+        if (proof.length > MAX_PROOF_LENGTH) revert ProofTooLong(proof.length, MAX_PROOF_LENGTH);
         if (amount > IERC20(TOKEN).balanceOf(address(this))) revert AmountExceedBridgePool();
 
         // Common replay guard. Set the flag before any external interaction
@@ -263,7 +307,11 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         uint256          operationId,
         bytes   calldata settlementData
     ) private {
+        if (amount < minFundsInAmount)             revert AmountBelowMinimum(amount, minFundsInAmount);
         if (bytes(destinationAddress).length == 0) revert InvalidDestinationAddress();
+        if (bytes(destinationAddress).length > MAX_ADDRESS_LENGTH) {
+            revert AddressTooLong(bytes(destinationAddress).length, MAX_ADDRESS_LENGTH);
+        }
         if (sourceChainId      == 0)               revert InvalidSourceChainId();
         if (destinationChainId == 0)               revert InvalidDestinationChainId();
 

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -174,7 +174,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         string  calldata sourceAddress,
         bytes   calldata proof,
         bytes   calldata settlementData
-    ) external override onlyOwner nonReentrant {
+    ) external override onlyOwner nonReentrant whenOutflowNotPaused {
         if (recipient          == address(0))                revert InvalidRecipientAddress();
         if (sourceChainId      == 0)                         revert InvalidSourceChainId();
         if (destinationChainId == 0)                         revert InvalidDestinationChainId();

--- a/ethereum/src/BridgeBase.sol
+++ b/ethereum/src/BridgeBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
 import { SafeERC20, IERC20 } from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';

--- a/ethereum/src/BridgeBase.sol
+++ b/ethereum/src/BridgeBase.sol
@@ -23,6 +23,15 @@ abstract contract BridgeBase is Ownable, Pausable {
     /// @notice The only accepted ERC-20 token. Immutable after deploy.
     address public immutable TOKEN;
 
+    /// @notice Outflow (withdrawal) freeze flag, independent of the inflow
+    ///         freeze. Inflow reuses OpenZeppelin `Pausable._paused` (gated by
+    ///         `whenNotPaused` on `fundsIn`); this second flag gates `fundsOut`
+    ///         via `whenOutflowNotPaused`. Two independent flags are required so
+    ///         that a planned inflow-only pause (deposits frozen, withdrawals
+    ///         still open for liquidity migration) and an emergency pause (both
+    ///         frozen) can be expressed separately.
+    bool private _outflowPaused;
+
     // =========================================================================
     // Events
     // =========================================================================
@@ -37,6 +46,14 @@ abstract contract BridgeBase is Ownable, Pausable {
         uint256 amount
     );
 
+    /// @notice Emitted when the outflow (withdrawal) path is frozen.
+    /// @dev The inflow path reuses OpenZeppelin `Pausable`, which emits its own
+    ///      `Paused` / `Unpaused` events.
+    event OutflowPaused(address account);
+
+    /// @notice Emitted when the outflow (withdrawal) path is unfrozen.
+    event OutflowUnpaused(address account);
+
     // =========================================================================
     // Errors
     // =========================================================================
@@ -45,6 +62,22 @@ abstract contract BridgeBase is Ownable, Pausable {
     error InvalidRecipientAddress();
     error AmountExceedBridgePool();
     error RenounceOwnershipBlocked();
+
+    /// @notice Thrown by `whenOutflowNotPaused` when the outflow path is frozen.
+    error OutflowEnforcedPause();
+
+    // =========================================================================
+    // Modifiers
+    // =========================================================================
+
+    /// @dev Reverts when the outflow path is frozen. Mirrors OpenZeppelin's
+    ///      `whenNotPaused` (which gates inflow) but for the independent
+    ///      `_outflowPaused` flag, so `fundsOut` can be frozen without freezing
+    ///      `fundsIn` and vice versa.
+    modifier whenOutflowNotPaused() {
+        if (_outflowPaused) revert OutflowEnforcedPause();
+        _;
+    }
 
     // =========================================================================
     // Constructor
@@ -59,11 +92,41 @@ abstract contract BridgeBase is Ownable, Pausable {
     // Owner-only
     // =========================================================================
 
-    /// @notice Pause all user-facing operations.
-    function pause() external onlyOwner { _pause(); }
+    /// @notice Freeze the inflow (deposit) path only; withdrawals stay open.
+    /// @dev Intended for planned operations such as a bridge upgrade or
+    ///      liquidity migration. On the production `Bridge` this is reached
+    ///      through the timelocked `MultisigProxy` propose -> execute path
+    ///      (`PauseInflow` operation), giving the federation an observation
+    ///      window before it takes effect.
+    function pauseInflow() external onlyOwner { _pause(); }
 
-    /// @notice Resume all user-facing operations.
-    function unpause() external onlyOwner { _unpause(); }
+    /// @notice Resume the inflow (deposit) path.
+    function unpauseInflow() external onlyOwner { _unpause(); }
+
+    /// @notice Emergency freeze of BOTH inflow and outflow, set atomically.
+    /// @dev No-timelock control for incident response. On the production
+    ///      `Bridge` it is reached through the federation-signed
+    ///      `MultisigProxy.emergencyPause` (multisig only, no propose step).
+    ///      Each flag is set idempotently, so the call does not revert if one
+    ///      side is already frozen (e.g. inflow already paused via the planned
+    ///      path). Freezing `fundsOut` also freezes the enclave/TEE release
+    ///      path, which routes through `fundsOut`.
+    function emergencyPauseAll() external onlyOwner {
+        if (!paused()) _pause(); // inflow (OpenZeppelin flag), guarded against double-pause
+        if (!_outflowPaused) {
+            _outflowPaused = true;
+            emit OutflowPaused(_msgSender());
+        }
+    }
+
+    /// @notice Lift the emergency freeze on BOTH inflow and outflow. Idempotent.
+    function emergencyUnpauseAll() external onlyOwner {
+        if (paused()) _unpause();
+        if (_outflowPaused) {
+            _outflowPaused = false;
+            emit OutflowUnpaused(_msgSender());
+        }
+    }
 
     /// @notice Permanently blocks renouncing ownership.
     function renounceOwnership() public view virtual override onlyOwner {
@@ -77,6 +140,12 @@ abstract contract BridgeBase is Ownable, Pausable {
     /// @notice Returns the token balance held by the contract (bridgeable liquidity).
     function getContractBalance() external view returns (uint256) {
         return IERC20(TOKEN).balanceOf(address(this));
+    }
+
+    /// @notice Whether the outflow (withdrawal) path is currently frozen.
+    /// @dev The inflow freeze is exposed by OpenZeppelin's `paused()`.
+    function outflowPaused() external view returns (bool) {
+        return _outflowPaused;
     }
 
     /// @notice Returns the current chain ID.

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -7,7 +7,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+import {AggregatorV3Interface} from "./interfaces/AggregatorV3Interface.sol";
 
 import {
     CommissionConfig,

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -292,6 +292,15 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
     ) external onlyOwner {
         if (stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (multiplier == 0) revert MultiplierZero();
+        // Joint invariant: the fee fraction is `stablePercent / multiplier^2`.
+        // When `stablePercent > multiplier^2` the quoted fee exceeds the
+        // bridged amount, so `netAmount = amount - fee` underflows and bricks
+        // every subsequent funds flow on the affected route. Widen to uint256
+        // before squaring — `multiplier` is uint8 and the common `100 * 100`
+        // would itself overflow uint8.
+        if (stablePercent > uint256(multiplier) * uint256(multiplier)) {
+            revert InvalidFeeShape(stablePercent, multiplier);
+        }
         // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
         // native fee
         if (currency == CommissionCurrency.NATIVE && side == CommissionSide.FUNDS_OUT) {
@@ -343,6 +352,15 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
         // Validate config
         if (config.stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (config.multiplier == 0) revert MultiplierZero();
+        // Joint invariant: the fee fraction is `stablePercent / multiplier^2`.
+        // When `stablePercent > multiplier^2` the quoted fee exceeds the
+        // bridged amount, so `netAmount = amount - fee` underflows and bricks
+        // every subsequent funds flow on the affected route. Widen to uint256
+        // before squaring — `multiplier` is uint8 and the common `100 * 100`
+        // would itself overflow uint8.
+        if (config.stablePercent > uint256(config.multiplier) * uint256(config.multiplier)) {
+            revert InvalidFeeShape(config.stablePercent, config.multiplier);
+        }
         // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
         // native fee
         if (config.currency == CommissionCurrency.NATIVE && config.side == CommissionSide.FUNDS_OUT) {

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -292,6 +292,11 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
     ) external onlyOwner {
         if (stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (multiplier == 0) revert MultiplierZero();
+        // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
+        // native fee
+        if (currency == CommissionCurrency.NATIVE && side == CommissionSide.FUNDS_OUT) {
+            revert NativeCommissionNotAllowedOnFundsOut();
+        }
 
         globalStablePercent = stablePercent;
         globalMultiplier = multiplier;
@@ -338,6 +343,11 @@ contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
         // Validate config
         if (config.stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (config.multiplier == 0) revert MultiplierZero();
+        // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
+        // native fee
+        if (config.currency == CommissionCurrency.NATIVE && config.side == CommissionSide.FUNDS_OUT) {
+            revert NativeCommissionNotAllowedOnFundsOut();
+        }
 
         // Build route key
         bytes32 key = buildRouteKey(sourceChainId, destChainId, token);

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -62,8 +62,21 @@ contract MultisigProxy is IMultisigProxy {
     /// @notice Maximum allowed time between proposal creation and its deadline.
     uint256 public constant MAX_PROPOSAL_LIFETIME = 30 days;
 
+    /// @notice Maximum allowed lifetime of a TEE-signed `execute` / `executeBatch`
+    ///         deadline. Tighter than `MAX_PROPOSAL_LIFETIME` because enclave
+    ///         operations (e.g. `fundsOut`) are meant to be executed promptly
+    ///         after signing; a short ceiling limits how long a leaked or
+    ///         pre-signed payload stays executable while its nonce is unconsumed.
+    uint256 public constant MAX_TEE_DEADLINE = 1 days;
+
     /// @notice Hard upper bound on `executeBatch` size to keep gas use bounded.
     uint256 public constant MAX_BATCH_SIZE = 3;
+
+    /// @notice Hard upper bound on the size of either signer set. Bounds the
+    ///         O(N^2) duplicate/disjointness checks and stays far within the
+    ///         `uint256` signature-bitmap width (so no signer index is ever
+    ///         unreachable). 20 is ample for an enclave/federation committee.
+    uint256 public constant MAX_SIGNERS = 20;
 
     /// @notice Length of a Solidity function selector (`bytes4`) in bytes. Used
     ///         to guard `callData` against payloads too short to even carry a
@@ -176,9 +189,9 @@ contract MultisigProxy is IMultisigProxy {
         if (bridge_ == address(0)) revert ZeroBridge();
         if (commissionManager_ == address(0)) revert ZeroCommissionManager();
         if (enclaveSigners_.length == 0) revert NoSigners();
-        if (enclaveThreshold_ == 0 || enclaveThreshold_ > enclaveSigners_.length) revert InvalidThreshold();
+        _requireValidThreshold(enclaveThreshold_, enclaveSigners_.length);
         if (federationSigners_.length == 0) revert NoSigners();
-        if (federationThreshold_ == 0 || federationThreshold_ > federationSigners_.length) revert InvalidThreshold();
+        _requireValidThreshold(federationThreshold_, federationSigners_.length);
         if (commissionRecipient_ == address(0)) revert ZeroCommissionRecipient();
         if (minTimelock_ == 0 || minTimelock_ >= MAX_PROPOSAL_LIFETIME) revert InvalidMinTimelock();
         if (timelockDuration_ < minTimelock_) revert TimelockTooShort();
@@ -186,6 +199,9 @@ contract MultisigProxy is IMultisigProxy {
 
         _validateSigners(enclaveSigners_);
         _validateSigners(federationSigners_);
+        // The enclave and federation are distinct trust domains; an address in
+        // both would count toward quorum in each, collapsing that separation.
+        _requireDisjoint(enclaveSigners_, federationSigners_);
 
         bridge = bridge_;
         commissionManager = commissionManager_;
@@ -228,6 +244,10 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata enclaveSigs
     ) external {
         if (block.timestamp > deadline) revert Expired();
+        // Bound how far in the future a signed deadline may sit, so a leaked or
+        // pre-signed payload cannot stay executable indefinitely while its
+        // nonce is unconsumed.
+        if (deadline > block.timestamp + MAX_TEE_DEADLINE) revert DeadlineTooFar();
         if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
 
         bytes4 selector;
@@ -258,6 +278,8 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata enclaveSigs
     ) external payable {
         if (block.timestamp > deadline) revert Expired();
+        // Bound the signed deadline's distance into the future;
+        if (deadline > block.timestamp + MAX_TEE_DEADLINE) revert DeadlineTooFar();
         uint256 n = targets.length;
         if (n == 0) revert BatchEmpty();
         if (n > MAX_BATCH_SIZE) revert BatchTooLarge();
@@ -818,6 +840,7 @@ contract MultisigProxy is IMultisigProxy {
     ) private returns (bytes32 proposalId) {
         if (block.timestamp > deadline) revert Expired();
         if (deadline > block.timestamp + MAX_PROPOSAL_LIFETIME) revert DeadlineTooFar();
+        if (deadline < block.timestamp + timelockDuration) revert DeadlineBeforeTimelock();
         if (nonce != proposalNonce) revert InvalidNonce();
 
         bytes32 digest = _hashTypedData(structHash);
@@ -855,8 +878,9 @@ contract MultisigProxy is IMultisigProxy {
         } else if (opType == OperationType.UpdateEnclaveSigners) {
             (address[] memory newSigners, uint256 newThreshold) = abi.decode(opData, (address[], uint256));
             if (newSigners.length == 0) revert NoSigners();
-            if (newThreshold == 0 || newThreshold > newSigners.length) revert InvalidThreshold();
+            _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
+            _requireDisjoint(newSigners, _federationSigners);
             _enclaveSigners = newSigners;
             enclaveThreshold = newThreshold;
             emit EnclaveSignersUpdated(newSigners, newThreshold);
@@ -864,8 +888,9 @@ contract MultisigProxy is IMultisigProxy {
         } else if (opType == OperationType.UpdateFederationSigners) {
             (address[] memory newSigners, uint256 newThreshold) = abi.decode(opData, (address[], uint256));
             if (newSigners.length == 0) revert NoSigners();
-            if (newThreshold == 0 || newThreshold > newSigners.length) revert InvalidThreshold();
+            _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
+            _requireDisjoint(newSigners, _enclaveSigners);
             _federationSigners = newSigners;
             federationThreshold = newThreshold;
             emit FederationSignersUpdated(newSigners, newThreshold);
@@ -1064,7 +1089,37 @@ contract MultisigProxy is IMultisigProxy {
     // =========================================================================
 
     /// @dev Validates no zero addresses and no duplicates. O(n^2), fine for <20 signers.
+    /// @dev Enforces the quorum policy shared by both signer sets (enclave and
+    ///      federation), in the constructor and the signer-update handlers:
+    ///        - at least 2 signers (no single-key set);
+    ///        - threshold of at least 2 (no single signer can authorise alone);
+    ///        - threshold a strict majority (`2 * threshold > n`), which rejects
+    ///          1-of-N and any sub-majority quorum;
+    ///        - threshold not exceeding the signer count.
+    ///      The smallest valid sets are 2-of-2 and 2-of-3. This upholds the
+    ///      spec invariant "one signer MUST NOT authorise fundsOut alone".
+    function _requireValidThreshold(uint256 threshold, uint256 n) private pure {
+        if (n < 2 || threshold < 2 || threshold > n || 2 * threshold <= n) {
+            revert InvalidThreshold();
+        }
+    }
+
+    /// @dev Reverts if any address in `candidate` also appears in `counterpart`.
+    ///      Used to keep the enclave and federation signer sets disjoint so the
+    ///      two trust domains stay independent (R-W-14). O(n*m), bounded by the
+    ///      signer-set sizes.
+    function _requireDisjoint(address[] memory candidate, address[] memory counterpart) private pure {
+        for (uint256 i = 0; i < candidate.length; i++) {
+            for (uint256 j = 0; j < counterpart.length; j++) {
+                if (candidate[i] == counterpart[j]) revert SignerSetsOverlap(candidate[i]);
+            }
+        }
+    }
+
     function _validateSigners(address[] memory signers) private pure {
+        // Bound the set before the O(N^2) duplicate scan below, and keep every
+        // signer index within the uint256 signature bitmap (R-I-06).
+        if (signers.length > MAX_SIGNERS) revert TooManySigners(signers.length, MAX_SIGNERS);
         for (uint256 i = 0; i < signers.length; i++) {
             if (signers[i] == address(0)) revert ZeroAddressSigner();
             for (uint256 j = i + 1; j < signers.length; j++) {

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -48,6 +48,13 @@ contract MultisigProxy is IMultisigProxy {
     /// @notice Minimum delay (seconds) between proposal creation and execution.
     uint256 public timelockDuration;
 
+    /// @notice Lower bound for `timelockDuration`, fixed at deploy time.
+    /// @dev Immutable so the governance observation/veto window can never be
+    ///      reduced below this floor — not by a `SetTimelockDuration` proposal
+    ///      and not by any later action. Set in the constructor and validated to
+    ///      be in (0, MAX_PROPOSAL_LIFETIME).
+    uint256 public immutable MIN_TIMELOCK;
+
     // =========================================================================
     // Constants
     // =========================================================================
@@ -163,7 +170,8 @@ contract MultisigProxy is IMultisigProxy {
         address[] memory federationSigners_,
         uint256 federationThreshold_,
         address commissionRecipient_,
-        uint256 timelockDuration_
+        uint256 timelockDuration_,
+        uint256 minTimelock_
     ) {
         if (bridge_ == address(0)) revert ZeroBridge();
         if (commissionManager_ == address(0)) revert ZeroCommissionManager();
@@ -172,6 +180,8 @@ contract MultisigProxy is IMultisigProxy {
         if (federationSigners_.length == 0) revert NoSigners();
         if (federationThreshold_ == 0 || federationThreshold_ > federationSigners_.length) revert InvalidThreshold();
         if (commissionRecipient_ == address(0)) revert ZeroCommissionRecipient();
+        if (minTimelock_ == 0 || minTimelock_ >= MAX_PROPOSAL_LIFETIME) revert InvalidMinTimelock();
+        if (timelockDuration_ < minTimelock_) revert TimelockTooShort();
         if (timelockDuration_ >= MAX_PROPOSAL_LIFETIME) revert TimelockTooLong();
 
         _validateSigners(enclaveSigners_);
@@ -185,6 +195,7 @@ contract MultisigProxy is IMultisigProxy {
         federationThreshold = federationThreshold_;
         commissionRecipient = commissionRecipient_;
         timelockDuration = timelockDuration_;
+        MIN_TIMELOCK = minTimelock_;
 
         // Default TEE allowlist: Bridge.fundsOut. Additional (target, selector) pairs
         // (e.g. for the LayerZero adapter's outbound `sendOut`) are added later via
@@ -881,6 +892,7 @@ contract MultisigProxy is IMultisigProxy {
 
         } else if (opType == OperationType.SetTimelockDuration) {
             uint256 newDuration = abi.decode(opData, (uint256));
+            if (newDuration < MIN_TIMELOCK) revert TimelockTooShort();
             if (newDuration >= MAX_PROPOSAL_LIFETIME) revert TimelockTooLong();
             timelockDuration = newDuration;
             emit TimelockDurationUpdated(newDuration);

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -143,6 +143,14 @@ contract MultisigProxy is IMultisigProxy {
         'EmergencyUnpause(uint256 nonce,uint256 deadline)'
     );
 
+    // Federation propose — planned inflow-only pause (timelocked)
+    bytes32 private constant _PROPOSE_PAUSE_INFLOW_TYPEHASH = keccak256(
+        'ProposePauseInflow(uint256 nonce,uint256 deadline)'
+    );
+    bytes32 private constant _PROPOSE_UNPAUSE_INFLOW_TYPEHASH = keccak256(
+        'ProposeUnpauseInflow(uint256 nonce,uint256 deadline)'
+    );
+
     // =========================================================================
     // Constructor
     // =========================================================================
@@ -298,7 +306,10 @@ contract MultisigProxy is IMultisigProxy {
 
         proposalNonce++;
 
-        (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('pause()'));
+        // Emergency freeze of BOTH inflow and outflow — no timelock, federation
+        // signatures only. Also halts the enclave/TEE release path (it routes
+        // through Bridge.fundsOut, now gated by whenOutflowNotPaused).
+        (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('emergencyPauseAll()'));
         _propagateRevert(ok, ret);
 
         emit EmergencyPaused(nonce, fedBitmap);
@@ -321,7 +332,8 @@ contract MultisigProxy is IMultisigProxy {
 
         proposalNonce++;
 
-        (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('unpause()'));
+        // Lift the emergency freeze on BOTH inflow and outflow.
+        (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('emergencyUnpauseAll()'));
         _propagateRevert(ok, ret);
 
         emit EmergencyUnpaused(nonce, fedBitmap);
@@ -654,6 +666,48 @@ contract MultisigProxy is IMultisigProxy {
         );
     }
 
+    /// @inheritdoc IMultisigProxy
+    /// @dev Planned inflow-only pause: freezes deposits while leaving
+    ///      withdrawals open (e.g. to migrate liquidity during an upgrade).
+    ///      Runs through the timelocked propose -> execute path, so the
+    ///      federation has an observation window. The emergency, no-timelock
+    ///      freeze of BOTH paths is `emergencyPause` instead. Carries no payload.
+    function proposePauseInflow(
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_PAUSE_INFLOW_TYPEHASH, nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.PauseInflow,
+            '',
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
+    /// @inheritdoc IMultisigProxy
+    /// @dev Resumes the inflow path, reversing `proposePauseInflow`. Timelocked.
+    function proposeUnpauseInflow(
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_UNPAUSE_INFLOW_TYPEHASH, nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.UnpauseInflow,
+            '',
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
     // =========================================================================
     // Cancel
     // =========================================================================
@@ -904,6 +958,15 @@ contract MultisigProxy is IMultisigProxy {
             // `NotBridge` and the route plane goes dark.
             address newRegistry = abi.decode(opData, (address));
             IBridge(bridge).setRouteRegistry(newRegistry);
+
+        } else if (opType == OperationType.PauseInflow) {
+            // Planned inflow-only freeze (no payload). Withdrawals stay open.
+            (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('pauseInflow()'));
+            _propagateRevert(ok, ret);
+
+        } else if (opType == OperationType.UnpauseInflow) {
+            (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('unpauseInflow()'));
+            _propagateRevert(ok, ret);
 
         } else {
             revert UnknownOperationType();

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity 0.8.35;
 
 import { ECDSA } from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import { IMultisigProxy } from './interfaces/IMultisigProxy.sol';

--- a/ethereum/src/RouteRegistry.sol
+++ b/ethereum/src/RouteRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
 

--- a/ethereum/src/btc_relay/BtcRelay.sol
+++ b/ethereum/src/btc_relay/BtcRelay.sol
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+import {ForkImpl, Fork} from "./state/Fork.sol";
+import {StoredBlockHeaderImpl, StoredBlockHeader, StoredBlockHeaderByteLength} from "./structs/StoredBlockHeader.sol";
+import {CompactBlockHeaderByteLength} from "./structs/CompactBlockHeader.sol";
+import {BtcRelayState, BtcRelayStateImpl} from "./state/BtcRelayState.sol";
+import {Events} from "./Events.sol";
+
+interface IBtcRelay {
+    function submitMainBlockheaders(bytes calldata data) external;
+    function submitShortForkBlockheaders(bytes calldata data) external;
+    function submitForkBlockheaders(uint256 forkId, bytes calldata data) external;
+}
+
+interface IBtcRelayView {
+    function getChainwork() external view returns (uint224);
+    function getBlockheight() external view returns (uint32);
+    function verifyBlockheader(StoredBlockHeader memory storedHeader) external view returns (uint256 confirmations);
+    function verifyBlockheaderHash(uint256 height, bytes32 commitmentHash) external view returns (uint256 confirmations);
+    function getCommitHash(uint256 height) external view returns (bytes32);
+    function getTipCommitHash() external view returns (bytes32);
+}
+
+contract BtcRelay is IBtcRelay, IBtcRelayView {
+
+    using StoredBlockHeaderImpl for StoredBlockHeader;
+    using ForkImpl for Fork;
+    using BtcRelayStateImpl for BtcRelayState;
+
+    BtcRelayState _relayState;
+
+    //Mapping of the blockHeight => main chain blockheader commitment
+    mapping(uint256 => bytes32) _mainChain;
+    //Mapping of the submitter address => fork id => Fork struct
+    mapping(address => mapping(uint256 => Fork)) _forks;
+
+    //Whether to clamp block target (enforce the maximum PoW block target of 0x00000000FFFF0000000000000000000000000000000000000000000000000000),
+    // only used during testing
+    bool immutable _clampBlockTarget;
+
+    //Initialize the btc relay with the provided stored_header
+    constructor(StoredBlockHeader memory storedHeader, bool clampBlockTarget) {
+        _clampBlockTarget = clampBlockTarget;
+
+        //Save the initial stored header
+        bytes32 commitHash = storedHeader.hash();
+        uint32 blockHeight = storedHeader.blockHeight();
+        _mainChain[blockHeight] = commitHash;
+        _relayState.write(blockHeight, uint224(storedHeader.chainWork() & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+
+        //Emit event
+        emit Events.StoreHeader(commitHash, storedHeader.header_blockhash());
+    }
+
+    //Internal functions
+    function _verifyBlockheaderHash(uint256 height, bytes32 commitmentHash) internal view returns (uint256 confirmations) {
+        uint256 mainBlockheight = _relayState.blockHeight;
+        //Check that the block height isn't past the tip, this can happen if there is a reorg, where a shorter
+        // chain becomes the cannonical one, this can happen due to the heaviest work rule (and not lonest chain rule)
+        require(height <= mainBlockheight, 'verify: future block');
+
+        require(
+            _mainChain[height] == commitmentHash,
+            'verify: block commitment'
+        );
+
+        confirmations = mainBlockheight - height + 1;
+    }
+
+    //Mutating functions
+    function submitMainBlockheaders(bytes calldata data) external {
+        require(data.length >= StoredBlockHeaderByteLength + CompactBlockHeaderByteLength, "submitMain: no headers");
+
+        StoredBlockHeader memory storedHeader = StoredBlockHeaderImpl.fromCalldata(data, 0); //160-byte previous blockheader
+        
+        //Verify stored header is latest committed
+        uint32 blockHeight = _relayState.blockHeight;
+        require(blockHeight == storedHeader.blockHeight(), "submitMain: block height");
+        require(_mainChain[blockHeight] == storedHeader.hash(), "submitMain: block commitment");
+
+        //Proccess new block headers, start at offset 160 and read 48-byte blockheaders
+        for(uint256 i = StoredBlockHeaderByteLength; i < data.length; i += CompactBlockHeaderByteLength) {
+            //Process the blockheader
+            bytes32 blockHash = storedHeader.updateChain(data, i, block.timestamp, _clampBlockTarget);
+            blockHeight = storedHeader.blockHeight();
+
+            //Write header commitment
+            bytes32 commitHash = storedHeader.hash();
+            _mainChain[blockHeight] = commitHash;
+
+            //Emit event
+            emit Events.StoreHeader(commitHash, blockHash);
+        }
+
+        //Update globals
+        _relayState.write(blockHeight, uint224(storedHeader.chainWork() & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+    }
+
+    
+    function submitShortForkBlockheaders(bytes calldata data) external {
+        require(data.length >= StoredBlockHeaderByteLength + CompactBlockHeaderByteLength, "submitMain: no headers");
+
+        StoredBlockHeader memory storedHeader = StoredBlockHeaderImpl.fromCalldata(data, 0);
+
+        //Verify stored header is committed
+        (uint32 tipBlockHeight, uint256 chainWork) = _relayState.read();
+        uint32 blockHeight = storedHeader.blockHeight();
+        require(blockHeight <= tipBlockHeight, "shortFork: future block");
+        require(_mainChain[blockHeight] == storedHeader.hash(), "shortFork: block commitment");
+
+        uint256 startHeight = uint256(blockHeight) + 1;
+
+        //Proccess new block headers
+        bytes32 commitHash;
+        bytes32 blockHash;
+        for(uint256 i = StoredBlockHeaderByteLength; i < data.length; i += CompactBlockHeaderByteLength) {
+            //Process the blockheader
+            blockHash = storedHeader.updateChain(data, i, block.timestamp, _clampBlockTarget);
+            blockHeight = storedHeader.blockHeight();
+
+            //Write header commitment
+            commitHash = storedHeader.hash();
+            _mainChain[blockHeight] = commitHash;
+
+            //Emit event - here we can already emit main chain submission events
+            emit Events.StoreHeader(commitHash, blockHash);
+        }
+
+        //Check if this fork's chainwork is higher than main chainwork
+        uint256 newChainWork = storedHeader.chainWork();
+        require(newChainWork > chainWork, 'shortFork: not enough work');
+
+        //Emit chain re-org event
+        emit Events.ChainReorg(commitHash, blockHash, 0, msg.sender, startHeight);
+
+        //Update globals
+        _relayState.write(blockHeight, uint224(newChainWork & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+    }
+
+    function submitForkBlockheaders(uint256 forkId, bytes calldata data) external {
+        require(data.length >= StoredBlockHeaderByteLength + CompactBlockHeaderByteLength, "fork: no headers");
+        require(forkId != 0, "fork: forkId 0 reserved");
+        Fork storage fork = _forks[msg.sender][forkId];
+
+        StoredBlockHeader memory storedHeader = StoredBlockHeaderImpl.fromCalldata(data, 0);
+
+        (uint32 tipBlockHeight, uint256 chainWork) = _relayState.read();
+        bytes32 commitHash = storedHeader.hash();
+        uint256 forkStartBlockheight = fork.startHeight;
+        if(forkStartBlockheight==0) {
+            //Verify stored header is committed in the main chain
+            uint256 storedHeaderBlockHeight = storedHeader.blockHeight();
+            require(storedHeaderBlockHeight <= tipBlockHeight, "fork: future block");
+            require(_mainChain[storedHeaderBlockHeight] == commitHash, "fork: block commitment");
+            forkStartBlockheight = storedHeaderBlockHeight + 1;
+            //Save the block start height and also the commitment of the fork root block (latest
+            // block that is still committed in the main chain)
+            fork.startHeight = uint32(forkStartBlockheight);
+            fork.chain[storedHeaderBlockHeight] = commitHash;
+        } else {
+            //Verify stored header is the tip of the fork chain
+            uint256 forkTipHeight = fork.tipHeight;
+            require(fork.chain[forkTipHeight] == commitHash, "fork: fork block commitment");
+        }
+
+        //Proccess new block headers
+        bytes32 blockHash;
+        uint32 forkTipBlockHeight;
+        mapping(uint256 => bytes32) storage forkChain = fork.chain;
+        for(uint256 i = StoredBlockHeaderByteLength; i < data.length; i += CompactBlockHeaderByteLength) {
+            //Process the blockheader
+            blockHash = storedHeader.updateChain(data, i, block.timestamp, _clampBlockTarget);
+            forkTipBlockHeight = storedHeader.blockHeight();
+
+            //Write header commitment
+            commitHash = storedHeader.hash();
+            forkChain[forkTipBlockHeight] = commitHash;
+
+            //Emit event - here we can already emit main chain submission events
+            emit Events.StoreForkHeader(commitHash, blockHash, forkId);
+        }
+
+        //Update tip height of the fork
+        fork.tipHeight = forkTipBlockHeight;
+        
+        //Check if this fork's chainwork is higher than main chainwork
+        uint256 newChainWork = storedHeader.chainWork();
+        if(chainWork < newChainWork) {
+            //This fork has just overtaken the main chain in chainwork
+            //Make this fork main chain
+            uint256 blockHeight = forkStartBlockheight-1;
+            
+            //Make sure that the fork's root block is still committed
+            require(_mainChain[blockHeight] == forkChain[blockHeight], "fork: reorg block commitment");
+            delete forkChain[blockHeight];
+
+            blockHeight++;
+
+            for(; blockHeight <= forkTipBlockHeight; blockHeight++) {
+                _mainChain[blockHeight] = forkChain[blockHeight];
+                delete forkChain[blockHeight];
+            }
+            fork.remove();
+            
+            //Emit chain re-org event
+            emit Events.ChainReorg(commitHash, blockHash, forkId, msg.sender, forkStartBlockheight);
+
+            //Update globals
+            _relayState.write(forkTipBlockHeight, uint224(newChainWork & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+        }
+    }
+
+    //Read-only functions
+    function getChainwork() external view returns (uint224 chainWork) {
+        return _relayState.chainWork;
+    }
+
+    function getBlockheight() external view returns (uint32 blockheight) {
+        return _relayState.blockHeight;
+    }
+    
+    function verifyBlockheader(StoredBlockHeader memory storedHeader) external view returns (uint256 confirmations) {
+        return _verifyBlockheaderHash(storedHeader.blockHeight(), storedHeader.hash());
+    }
+
+    function verifyBlockheaderHash(uint256 height, bytes32 commitmentHash) external view returns (uint256 confirmations) {
+        return _verifyBlockheaderHash(height, commitmentHash);
+    }
+
+    function getCommitHash(uint256 height) external view returns (bytes32) {
+        return _mainChain[height];
+    }
+
+    function getTipCommitHash() external view returns (bytes32) {
+        return _mainChain[_relayState.blockHeight];
+    }
+
+}

--- a/ethereum/src/btc_relay/BtcRelay.sol
+++ b/ethereum/src/btc_relay/BtcRelay.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {ForkImpl, Fork} from "./state/Fork.sol";
 import {StoredBlockHeaderImpl, StoredBlockHeader, StoredBlockHeaderByteLength} from "./structs/StoredBlockHeader.sol";

--- a/ethereum/src/btc_relay/BtcRelayTestnet.sol
+++ b/ethereum/src/btc_relay/BtcRelayTestnet.sol
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+import {ForkImpl, Fork} from "./state/Fork.sol";
+import {StoredBlockHeaderImpl, StoredBlockHeader, StoredBlockHeaderByteLength} from "./structs/StoredBlockHeaderTestnet.sol";
+import {CompactBlockHeaderByteLength} from "./structs/CompactBlockHeader.sol";
+import {BtcRelayState, BtcRelayStateImpl} from "./state/BtcRelayState.sol";
+import {Events} from "./Events.sol";
+
+interface IBtcRelay {
+    function submitMainBlockheaders(bytes calldata data) external;
+    function submitShortForkBlockheaders(bytes calldata data) external;
+    function submitForkBlockheaders(uint256 forkId, bytes calldata data) external;
+}
+
+interface IBtcRelayView {
+    function getChainwork() external view returns (uint224);
+    function getBlockheight() external view returns (uint32);
+    function verifyBlockheader(StoredBlockHeader memory storedHeader) external view returns (uint256 confirmations);
+    function verifyBlockheaderHash(uint256 height, bytes32 commitmentHash) external view returns (uint256 confirmations);
+    function getCommitHash(uint256 height) external view returns (bytes32);
+    function getTipCommitHash() external view returns (bytes32);
+}
+
+contract BtcRelayTestnet is IBtcRelay, IBtcRelayView {
+
+    using StoredBlockHeaderImpl for StoredBlockHeader;
+    using ForkImpl for Fork;
+    using BtcRelayStateImpl for BtcRelayState;
+
+    BtcRelayState _relayState;
+
+    //Mapping of the blockHeight => main chain blockheader commitment
+    mapping(uint256 => bytes32) _mainChain;
+    //Mapping of the submitter address => fork id => Fork struct
+    mapping(address => mapping(uint256 => Fork)) _forks;
+
+    //Whether to clamp block target (enforce the maximum PoW block target of 0x00000000FFFF0000000000000000000000000000000000000000000000000000),
+    // only used during testing
+    bool immutable _clampBlockTarget;
+
+    //Initialize the btc relay with the provided stored_header
+    constructor(StoredBlockHeader memory storedHeader, bool clampBlockTarget) {
+        _clampBlockTarget = clampBlockTarget;
+
+        //Save the initial stored header
+        bytes32 commitHash = storedHeader.hash();
+        uint32 blockHeight = storedHeader.blockHeight();
+        _mainChain[blockHeight] = commitHash;
+        _relayState.write(blockHeight, uint224(storedHeader.chainWork() & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+
+        //Emit event
+        emit Events.StoreHeader(commitHash, storedHeader.header_blockhash());
+    }
+
+    //Internal functions
+    function _verifyBlockheaderHash(uint256 height, bytes32 commitmentHash) internal view returns (uint256 confirmations) {
+        uint256 mainBlockheight = _relayState.blockHeight;
+        //Check that the block height isn't past the tip, this can happen if there is a reorg, where a shorter
+        // chain becomes the cannonical one, this can happen due to the heaviest work rule (and not lonest chain rule)
+        require(height <= mainBlockheight, 'verify: future block');
+
+        require(
+            _mainChain[height] == commitmentHash,
+            'verify: block commitment'
+        );
+
+        confirmations = mainBlockheight - height + 1;
+    }
+
+    //Mutating functions
+    function submitMainBlockheaders(bytes calldata data) external {
+        require(data.length >= StoredBlockHeaderByteLength + CompactBlockHeaderByteLength, "submitMain: no headers");
+
+        StoredBlockHeader memory storedHeader = StoredBlockHeaderImpl.fromCalldata(data, 0); //160-byte previous blockheader
+        
+        //Verify stored header is latest committed
+        uint32 blockHeight = _relayState.blockHeight;
+        require(blockHeight == storedHeader.blockHeight(), "submitMain: block height");
+        require(_mainChain[blockHeight] == storedHeader.hash(), "submitMain: block commitment");
+
+        //Proccess new block headers, start at offset 160 and read 48-byte blockheaders
+        for(uint256 i = StoredBlockHeaderByteLength; i < data.length; i += CompactBlockHeaderByteLength) {
+            //Process the blockheader
+            bytes32 blockHash = storedHeader.updateChain(data, i, block.timestamp);
+            blockHeight = storedHeader.blockHeight();
+
+            //Write header commitment
+            bytes32 commitHash = storedHeader.hash();
+            _mainChain[blockHeight] = commitHash;
+
+            //Emit event
+            emit Events.StoreHeader(commitHash, blockHash);
+        }
+
+        //Update globals
+        _relayState.write(blockHeight, uint224(storedHeader.chainWork() & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+    }
+
+    
+    function submitShortForkBlockheaders(bytes calldata data) external {
+        require(data.length >= StoredBlockHeaderByteLength + CompactBlockHeaderByteLength, "submitMain: no headers");
+
+        StoredBlockHeader memory storedHeader = StoredBlockHeaderImpl.fromCalldata(data, 0);
+
+        //Verify stored header is committed
+        (uint32 tipBlockHeight, uint256 chainWork) = _relayState.read();
+        uint32 blockHeight = storedHeader.blockHeight();
+        require(blockHeight <= tipBlockHeight, "shortFork: future block");
+        require(_mainChain[blockHeight] == storedHeader.hash(), "shortFork: block commitment");
+
+        uint256 startHeight = uint256(blockHeight) + 1;
+
+        //Proccess new block headers
+        bytes32 commitHash;
+        bytes32 blockHash;
+        for(uint256 i = StoredBlockHeaderByteLength; i < data.length; i += CompactBlockHeaderByteLength) {
+            //Process the blockheader
+            blockHash = storedHeader.updateChain(data, i, block.timestamp);
+            blockHeight = storedHeader.blockHeight();
+
+            //Write header commitment
+            commitHash = storedHeader.hash();
+            _mainChain[blockHeight] = commitHash;
+
+            //Emit event - here we can already emit main chain submission events
+            emit Events.StoreHeader(commitHash, blockHash);
+        }
+
+        //Check if this fork's chainwork is higher than main chainwork
+        uint256 newChainWork = storedHeader.chainWork();
+        require(newChainWork > chainWork, 'shortFork: not enough work');
+
+        //Emit chain re-org event
+        emit Events.ChainReorg(commitHash, blockHash, 0, msg.sender, startHeight);
+
+        //Update globals
+        _relayState.write(blockHeight, uint224(newChainWork & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+    }
+
+    function submitForkBlockheaders(uint256 forkId, bytes calldata data) external {
+        require(data.length >= StoredBlockHeaderByteLength + CompactBlockHeaderByteLength, "fork: no headers");
+        require(forkId != 0, "fork: forkId 0 reserved");
+        Fork storage fork = _forks[msg.sender][forkId];
+
+        StoredBlockHeader memory storedHeader = StoredBlockHeaderImpl.fromCalldata(data, 0);
+
+        (uint32 tipBlockHeight, uint256 chainWork) = _relayState.read();
+        bytes32 commitHash = storedHeader.hash();
+        uint256 forkStartBlockheight = fork.startHeight;
+        if(forkStartBlockheight==0) {
+            //Verify stored header is committed in the main chain
+            uint256 storedHeaderBlockHeight = storedHeader.blockHeight();
+            require(storedHeaderBlockHeight <= tipBlockHeight, "fork: future block");
+            require(_mainChain[storedHeaderBlockHeight] == commitHash, "fork: block commitment");
+            forkStartBlockheight = storedHeaderBlockHeight + 1;
+            //Save the block start height and also the commitment of the fork root block (latest
+            // block that is still committed in the main chain)
+            fork.startHeight = uint32(forkStartBlockheight);
+            fork.chain[storedHeaderBlockHeight] = commitHash;
+        } else {
+            //Verify stored header is the tip of the fork chain
+            uint256 forkTipHeight = fork.tipHeight;
+            require(fork.chain[forkTipHeight] == commitHash, "fork: fork block commitment");
+        }
+
+        //Proccess new block headers
+        bytes32 blockHash;
+        uint32 forkTipBlockHeight;
+        mapping(uint256 => bytes32) storage forkChain = fork.chain;
+        for(uint256 i = StoredBlockHeaderByteLength; i < data.length; i += CompactBlockHeaderByteLength) {
+            //Process the blockheader
+            blockHash = storedHeader.updateChain(data, i, block.timestamp);
+            forkTipBlockHeight = storedHeader.blockHeight();
+
+            //Write header commitment
+            commitHash = storedHeader.hash();
+            forkChain[forkTipBlockHeight] = commitHash;
+
+            //Emit event - here we can already emit main chain submission events
+            emit Events.StoreForkHeader(commitHash, blockHash, forkId);
+        }
+
+        //Update tip height of the fork
+        fork.tipHeight = forkTipBlockHeight;
+        
+        //Check if this fork's chainwork is higher than main chainwork
+        uint256 newChainWork = storedHeader.chainWork();
+        if(chainWork < newChainWork) {
+            //This fork has just overtaken the main chain in chainwork
+            //Make this fork main chain
+            uint256 blockHeight = forkStartBlockheight-1;
+            
+            //Make sure that the fork's root block is still committed
+            require(_mainChain[blockHeight] == forkChain[blockHeight], "fork: reorg block commitment");
+            delete forkChain[blockHeight];
+
+            blockHeight++;
+
+            for(; blockHeight <= forkTipBlockHeight; blockHeight++) {
+                _mainChain[blockHeight] = forkChain[blockHeight];
+                delete forkChain[blockHeight];
+            }
+            fork.remove();
+            
+            //Emit chain re-org event
+            emit Events.ChainReorg(commitHash, blockHash, forkId, msg.sender, forkStartBlockheight);
+
+            //Update globals
+            _relayState.write(forkTipBlockHeight, uint224(newChainWork & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+        }
+    }
+
+    //Read-only functions
+    function getChainwork() external view returns (uint224 chainWork) {
+        return _relayState.chainWork;
+    }
+
+    function getBlockheight() external view returns (uint32 blockheight) {
+        return _relayState.blockHeight;
+    }
+    
+    function verifyBlockheader(StoredBlockHeader memory storedHeader) external view returns (uint256 confirmations) {
+        return _verifyBlockheaderHash(storedHeader.blockHeight(), storedHeader.hash());
+    }
+
+    function verifyBlockheaderHash(uint256 height, bytes32 commitmentHash) external view returns (uint256 confirmations) {
+        return _verifyBlockheaderHash(height, commitmentHash);
+    }
+
+    function getCommitHash(uint256 height) external view returns (bytes32) {
+        return _mainChain[height];
+    }
+
+    function getTipCommitHash() external view returns (bytes32) {
+        return _mainChain[_relayState.blockHeight];
+    }
+
+}

--- a/ethereum/src/btc_relay/BtcRelayTestnet.sol
+++ b/ethereum/src/btc_relay/BtcRelayTestnet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {ForkImpl, Fork} from "./state/Fork.sol";
 import {StoredBlockHeaderImpl, StoredBlockHeader, StoredBlockHeaderByteLength} from "./structs/StoredBlockHeaderTestnet.sol";

--- a/ethereum/src/btc_relay/Constants.sol
+++ b/ethereum/src/btc_relay/Constants.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+//Interval (in blocks) of the difficulty adjustment
+uint256 constant DIFFICULTY_ADJUSTMENT_INTERVAL = 2016;
+
+//Maximum positive difference between bitcoin block's timestamp and EVM chain's on-chain clock
+//Nodes in bitcoin network generally reject any block with timestamp more than 2 hours in the future
+//As we are dealing with another blockchain here,
+// with the possibility of the EVM chain's on-chain clock being skewed, we chose double the value -> 4 hours
+uint256 constant MAX_FUTURE_BLOCKTIME = 4 * 60 * 60;
+
+//Lowest possible mining difficulty - highest possible target
+uint256 constant UNROUNDED_MAX_TARGET = 0x00000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+uint256 constant ROUNDED_MAX_TARGET = 0x00000000FFFF0000000000000000000000000000000000000000000000000000;
+uint32 constant ROUNDED_MAX_TARGET_NBITS = 0xFFFF001D;
+
+//Bitcoin epoch timespan
+uint256 constant TARGET_TIMESPAN = 14 * 24 * 60 * 60; //2 weeks
+uint256 constant TARGET_TIMESPAN_DIV_4 = TARGET_TIMESPAN / 4;
+uint256 constant TARGET_TIMESPAN_MUL_4 = TARGET_TIMESPAN * 4;

--- a/ethereum/src/btc_relay/Constants.sol
+++ b/ethereum/src/btc_relay/Constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 //Interval (in blocks) of the difficulty adjustment
 uint256 constant DIFFICULTY_ADJUSTMENT_INTERVAL = 2016;

--- a/ethereum/src/btc_relay/Events.sol
+++ b/ethereum/src/btc_relay/Events.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+library Events {
+    event StoreHeader(bytes32 indexed commitHash, bytes32 indexed blockHash);
+    event StoreForkHeader(bytes32 indexed commitHash, bytes32 indexed blockHash, uint256 indexed forkId);
+    event ChainReorg(bytes32 indexed commitHash, bytes32 indexed blockHash, uint256 indexed forkId, address submitter, uint256 startHeight);
+}

--- a/ethereum/src/btc_relay/Events.sol
+++ b/ethereum/src/btc_relay/Events.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 library Events {
     event StoreHeader(bytes32 indexed commitHash, bytes32 indexed blockHash);

--- a/ethereum/src/btc_relay/btc_utils/Endianness.sol
+++ b/ethereum/src/btc_relay/btc_utils/Endianness.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+library Endianness {
+    function reverseUint32(uint32 input) internal pure returns (uint32) {
+        assembly {
+            input := or(shr(8, and(input, 0xFF00FF00)), shl(8, and(input, 0x00FF00FF)))
+            input := or(shr(16, and(input, 0xFFFF0000)), shl(16, and(input, 0x0000FFFF)))
+        }
+        return input;
+    }
+
+    function reverseUint64(uint64 input) internal pure returns (uint64) {
+        assembly {
+            input := or(shr(8, and(input, 0xFF00FF00FF00FF00)), shl(8, and(input, 0x00FF00FF00FF00FF)))
+            input := or(shr(16, and(input, 0xFFFF0000FFFF0000)), shl(16, and(input, 0x0000FFFF0000FFFF)))
+            input := or(shr(32, and(input, 0xFFFFFFFF00000000)), shl(32, and(input, 0x00000000FFFFFFFF)))
+        }
+        return input;
+    }
+    
+    function reverseBytes32(bytes32 input) internal pure returns (bytes32) {
+        assembly {
+            // swap bytes
+            input := or(shr(8, and(input, 0xFF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00)), shl(8, and(input, 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF)))
+            input := or(shr(16, and(input, 0xFFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000)), shl(16, and(input, 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF)))
+            input := or(shr(32, and(input, 0xFFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000)), shl(32, and(input, 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF)))
+            input := or(shr(64, and(input, 0xFFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF0000000000000000)), shl(64, and(input, 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF)))
+            input := or(shr(128, input), shl(128, input))
+        }
+        return input;
+    }
+}

--- a/ethereum/src/btc_relay/btc_utils/Endianness.sol
+++ b/ethereum/src/btc_relay/btc_utils/Endianness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 library Endianness {
     function reverseUint32(uint32 input) internal pure returns (uint32) {

--- a/ethereum/src/btc_relay/state/BtcRelayState.sol
+++ b/ethereum/src/btc_relay/state/BtcRelayState.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+struct BtcRelayState {
+    uint32 blockHeight;
+    uint224 chainWork;
+}
+
+library BtcRelayStateImpl {
+
+    //Optimized read function, that reads all the values at once
+    function read(BtcRelayState storage self) view internal returns (uint32 blockHeight, uint224 chainWork) {
+        //The following assembly is equivalent to:
+        // blockHeight = self.blockHeight;
+        // chainWork = self.chainWork;
+        assembly {
+            let value := sload(self.slot) //All the data is stored at slot 0
+            blockHeight := and(value, 0xffffffff)
+            chainWork := shr(32, value)
+        }
+    }
+
+    //Optimized write function that writes all the values at once
+    function write(BtcRelayState storage self, uint32 blockHeight, uint224 chainWork) internal {
+        //The following assembly is equivalent to:
+        // self.blockHeight = blockHeight;
+        // self.chainWork = chainWork;
+        assembly {
+            let value := or(
+                blockHeight,
+                shl(32, chainWork)
+            )
+            sstore(self.slot, value)
+        }
+    }
+
+}

--- a/ethereum/src/btc_relay/state/BtcRelayState.sol
+++ b/ethereum/src/btc_relay/state/BtcRelayState.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 struct BtcRelayState {
     uint32 blockHeight;

--- a/ethereum/src/btc_relay/state/Fork.sol
+++ b/ethereum/src/btc_relay/state/Fork.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+struct Fork {
+    //Slot 0
+    mapping(uint256 => bytes32) chain;
+    
+    //Slot 1
+    uint32 startHeight;
+    uint32 tipHeight;
+}
+
+library ForkImpl {
+
+    //Deletes startHeight and tipHeight saved in the fork storage slot
+    function remove(Fork storage self) internal {
+        assembly {
+            sstore(add(self.slot, 1), 0)
+        }
+    }
+
+}

--- a/ethereum/src/btc_relay/state/Fork.sol
+++ b/ethereum/src/btc_relay/state/Fork.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 struct Fork {
     //Slot 0

--- a/ethereum/src/btc_relay/structs/CompactBlockHeader.sol
+++ b/ethereum/src/btc_relay/structs/CompactBlockHeader.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+import {Endianness} from "../btc_utils/Endianness.sol";
+
+uint256 constant CompactBlockHeaderByteLength = 48;
+
+/**
+ * Bitcoin blockheader decoding from bytes (previous block hash is not included and is instead
+ *  fetched from latest stored blockheader)
+ * Structure (total 48 bytes):
+ * - uint32 versionLE
+ * - bytes32 merkleRoot
+ * - uint32 timestampLE
+ * - uint32 nBitsLE
+ * - uint32 nonce
+ */
+library CompactBlockHeaderImpl {
+
+    function verifyOutOfBounds(bytes calldata self, uint256 offset) pure internal {
+        require(self.length >= offset + CompactBlockHeaderByteLength, "BlockHeader: out of bounds");
+    }
+
+    //Getters
+
+    //Gets the timestamp of the blockheader, NOTE: This doesn't check whether the offset is out of bounds!
+    function timestamp(bytes calldata self, uint256 offset) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, calldataload(add(add(self.offset, offset), 36)))
+        }
+        result = Endianness.reverseUint32(result);
+    }
+
+    //Gets the nBits of the blockheader in little-endian format, NOTE: This doesn't check whether the offset is out of bounds!
+    function nBitsLE(bytes calldata self, uint256 offset) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, calldataload(add(add(self.offset, offset), 40)))
+        }
+    }
+    
+}

--- a/ethereum/src/btc_relay/structs/CompactBlockHeader.sol
+++ b/ethereum/src/btc_relay/structs/CompactBlockHeader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {Endianness} from "../btc_utils/Endianness.sol";
 

--- a/ethereum/src/btc_relay/structs/StoredBlockHeader.sol
+++ b/ethereum/src/btc_relay/structs/StoredBlockHeader.sol
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+import {CompactBlockHeaderImpl} from "./CompactBlockHeader.sol";
+import {Nbits} from "../utils/Nbits.sol";
+import {Difficulty} from "../utils/Difficulty.sol";
+import {Endianness} from "../btc_utils/Endianness.sol";
+import {DIFFICULTY_ADJUSTMENT_INTERVAL, MAX_FUTURE_BLOCKTIME} from "../Constants.sol";
+
+/**
+ * Bitcoin stored blockheader defined as a fixed-length bytes32 array
+ * Structure (total 160 bytes):
+ * - bytes blockheader (80 bytes)
+ * - uint256 chainWork
+ * - uint32 blockHeight
+ * - uint32 lastDiffAdjustment
+ * - uint32[10] prevBlockTimestamps
+ */
+struct StoredBlockHeader {
+    bytes32[5] data;
+}
+uint256 constant StoredBlockHeaderByteLength = 160;
+uint256 constant BitcoinBlockHeaderByteLength = 80;
+
+library StoredBlockHeaderImpl {
+
+    using CompactBlockHeaderImpl for bytes;
+
+    function fromCalldata(bytes calldata data, uint256 offset) pure internal returns (StoredBlockHeader memory storedHeader) {
+        require(data.length >= StoredBlockHeaderByteLength+offset, "StoredBlockHeader: out of bounds");
+        assembly ("memory-safe") {
+            calldatacopy(mload(storedHeader), add(data.offset, offset), StoredBlockHeaderByteLength) //Store stored header data
+        }
+    }
+
+    //Getters
+    function header_version(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(mload(self)))
+        }
+        result = Endianness.reverseUint32(result);
+    }
+
+    function header_previousBlockhash(StoredBlockHeader memory self) pure internal returns (bytes32 result) {
+        assembly ("memory-safe") {
+            result := mload(add(mload(self), 4))
+        }
+    }
+
+    function header_merkleRoot(StoredBlockHeader memory self) pure internal returns (bytes32 result) {
+        assembly ("memory-safe") {
+            result := mload(add(mload(self), 36))
+        }
+    }
+
+    function header_timestamp(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(add(mload(self), 68)))
+        }
+        result = Endianness.reverseUint32(result);
+    }
+
+    function header_nBitsLE(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(add(mload(self), 72)))
+        }
+    }
+
+    function header_nonce(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(add(mload(self), 76)))
+        }
+        result = Endianness.reverseUint32(result);
+    }
+
+    function chainWork(StoredBlockHeader memory self) pure internal returns (uint256 result) {
+        assembly ("memory-safe") {
+            result := mload(add(mload(self), 80))
+        }
+    }
+
+    function blockHeight(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(add(mload(self), 112)))
+        }
+    }
+
+    function lastDiffAdjustment(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(add(mload(self), 116)))
+        }
+    }
+
+    function previousBlockTimestamps(StoredBlockHeader memory self) pure internal returns (uint32[10] memory result) {
+        assembly ("memory-safe") {
+            let ptr := mload(self)
+            let prevBlockTimestampsArray1 := mload(add(ptr, 120)) //offset(120) Stores first 8 last block timestamps
+            let prevBlockTimestampsArray2 := mload(add(ptr, 128)) //offset(120 + 8) Stores last 2 last block timestamps in least significant bits
+            mstore(result, shr(224, prevBlockTimestampsArray1))
+            mstore(add(result, 32), and(shr(192, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 64), and(shr(160, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 96), and(shr(128, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 128), and(shr(96, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 160), and(shr(64, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 192), and(shr(32, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 224), and(prevBlockTimestampsArray1, 0xffffffff))
+            mstore(add(result, 256), and(shr(32, prevBlockTimestampsArray2), 0xffffffff))
+            mstore(add(result, 288), and(prevBlockTimestampsArray2, 0xffffffff))
+        }
+    }
+
+    //Functions
+    function header_blockhash(StoredBlockHeader memory self) view internal returns (bytes32 result) {
+        assembly ("memory-safe") {
+            //Invoke first sha256 hash on the memory region now storing the current blockheader, destination is scratch space at 0x00
+            pop(staticcall(gas(), 0x02, mload(self), BitcoinBlockHeaderByteLength, 0x00, 32))
+            //Invoke second sha256 on the scratch space at 0x00
+            pop(staticcall(gas(), 0x02, 0x00, 32, 0x00, 32))
+
+            //Load and return the result
+            result := mload(0x00)
+        }
+    }
+
+    function hash(StoredBlockHeader memory self) pure internal returns (bytes32 result) {
+        assembly ("memory-safe") {
+            result := keccak256(mload(self), StoredBlockHeaderByteLength)
+        }
+    }
+
+    //Writes new blockheader to the stored header memory and computes the double sha256 hash of this new blockheader
+    function writeHeaderAndGetDblSha256Hash(StoredBlockHeader memory self, bytes calldata headers, uint256 offset) private view returns (bytes32 result) {
+        assembly ("memory-safe") {
+            let ptr := mload(self)
+
+            //Invoke first sha256 hash on the memory region storing the previous blockheader, destination is scratch space at 0x00
+            pop(staticcall(gas(), 0x02, ptr, BitcoinBlockHeaderByteLength, 0x00, 32))
+            //Invoke second sha256 on the scratch space at 0x00, copy directly to where the previous blockhash should be stored for next stored blockheader
+            pop(staticcall(gas(), 0x02, 0x00, 32, add(ptr, 4), 32))
+
+            //Copy other data to the stored blockheader from calldata
+            calldatacopy(ptr, add(headers.offset, offset), 4)
+            calldatacopy(add(ptr, 36), add(headers.offset, add(offset, 4)), 44)
+
+            //Invoke first sha256 hash on the memory region now storing the current blockheader, destination is scratch space at 0x00
+            pop(staticcall(gas(), 0x02, ptr, BitcoinBlockHeaderByteLength, 0x00, 32))
+            //Invoke second sha256 on the scratch space at 0x00
+            pop(staticcall(gas(), 0x02, 0x00, 32, 0x00, 32))
+
+            //Load and return the result
+            result := mload(0x00)
+        }
+    }
+
+    function updateChain(
+        StoredBlockHeader memory self, bytes calldata headers, uint256 offset, uint256 timestamp, bool clampTarget
+    ) internal view returns (bytes32 blockHash) {
+        //We don't check whether pevious header matches since submitted headers are submitted
+        // without previousBlockHash fields, which is instead taken automatically from the
+        // current StoredBlockHeader, this allows us to save at least 512 gas on calldata
+
+        uint32 prevBlockTimestamp = header_timestamp(self);
+        uint32 currBlockTimestamp = headers.timestamp(offset);
+
+        //Check correct nbits
+        uint256 currBlockHeight = blockHeight(self) + 1;
+        uint32 _lastDiffAdjustment = lastDiffAdjustment(self);
+        uint32 newNbits = headers.nBitsLE(offset);
+        uint256 newTarget;
+        if(currBlockHeight % DIFFICULTY_ADJUSTMENT_INTERVAL == 0) {
+            //Compute new nbits, bitcoin uses the timestamp of the last block in the epoch to re-target PoW difficulty
+            // https://github.com/bitcoin/bitcoin/blob/78dae8caccd82cfbfd76557f1fb7d7557c7b5edb/src/pow.cpp#L49
+            uint256 computedNbits;
+            (newTarget, computedNbits) = Difficulty.computeNewTarget(
+                prevBlockTimestamp,
+                _lastDiffAdjustment,
+                header_nBitsLE(self),
+                clampTarget
+            );
+            require(newNbits == computedNbits, "updateChain: new nbits");
+            //Even though timestamp of the last block in epoch is used to re-target PoW difficulty, the first
+            // block in a new epoch is used as last_diff_adjustment, the time it takes to mine the first block
+            // in every epoch is therefore not taken into consideration when retargetting PoW - one of many
+            // bitcoin's quirks
+            _lastDiffAdjustment = currBlockTimestamp;
+        } else {
+            //nbits must be same as last block
+            require(newNbits == header_nBitsLE(self), "updateChain: nbits");
+            newTarget = Nbits.toTarget(newNbits);
+        }
+
+        //Check PoW
+        blockHash = writeHeaderAndGetDblSha256Hash(self, headers, offset);
+        require(uint256(Endianness.reverseBytes32(blockHash)) < Nbits.toTarget(newNbits), "updateChain: invalid PoW");
+
+        //Verify timestamp is larger than median of last 11 block timestamps
+        uint256 count = 0;
+        uint256 prevBlockTimestampsArray1;
+        uint256 prevBlockTimestampsArray2;
+        assembly ("memory-safe") {
+            let ptr := mload(self)
+            prevBlockTimestampsArray1 := mload(add(ptr, 120)) //offset(120) Stores first 8 last block timestamps
+            prevBlockTimestampsArray2 := mload(add(ptr, 128)) //offset(120 + 8) Stores last 2 last block timestamps in least significant bits
+            count := gt(currBlockTimestamp, prevBlockTimestamp)
+            count := add(count, gt(currBlockTimestamp, shr(224, prevBlockTimestampsArray1)))
+            count := add(count, gt(currBlockTimestamp, and(shr(192, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(160, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(128, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(96, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(64, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(32, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(prevBlockTimestampsArray1, 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(32, prevBlockTimestampsArray2), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(prevBlockTimestampsArray2, 0xffffffff)))
+        }
+        require(count > 5, "updateChain: timestamp median");
+        require(currBlockTimestamp < timestamp + MAX_FUTURE_BLOCKTIME, 'updateChain: timestamp future');
+
+        //Update prev block timestamps
+        assembly {
+            prevBlockTimestampsArray1 := shl(32, prevBlockTimestampsArray1) //Shift to the left, to remove oldest timestamp
+            prevBlockTimestampsArray1 := or(prevBlockTimestampsArray1, and(shr(32, prevBlockTimestampsArray2), 0xffffffff)) //Push timestamp from arr2 to arr1
+            prevBlockTimestampsArray2 := shl(32, prevBlockTimestampsArray2) //Shift to the left
+            prevBlockTimestampsArray2 := or(prevBlockTimestampsArray2, prevBlockTimestamp) //Add previous block timestamp
+        }
+
+        uint256 _chainWork = chainWork(self) + Difficulty.getChainWork(newTarget);
+
+        //Save the stored blockheader to memory
+        assembly ("memory-safe") {
+            //Blockheader is already written to memory with prior writeHeaderAndGetDblSha256Hash() call
+            let ptr := mload(self)
+
+            //Write chainwork at offset 80..112
+            mstore(add(ptr, 80), _chainWork)
+            mstore(add(ptr, 112), 
+                or(
+                    or(
+                        shl(224, currBlockHeight), //Current block height at offset 112..116
+                        shl(192, and(_lastDiffAdjustment, 0xffffffff)) //Last difficulty adjustment at offset 116..120
+                    ),
+                    shr(64, prevBlockTimestampsArray1) //First 6 values of previous block timestamps at offset 120..144
+                )
+            )
+            //Ensure we don't write outside the region of the stored blockheader byte array, so we
+            // have a little bit of an overlap here
+            mstore(add(ptr, 128), 
+                or(
+                    shl(64, prevBlockTimestampsArray1),
+                    and(prevBlockTimestampsArray2, 0xffffffffffffffff)
+                )
+            )
+        }
+    }
+
+}

--- a/ethereum/src/btc_relay/structs/StoredBlockHeader.sol
+++ b/ethereum/src/btc_relay/structs/StoredBlockHeader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {CompactBlockHeaderImpl} from "./CompactBlockHeader.sol";
 import {Nbits} from "../utils/Nbits.sol";

--- a/ethereum/src/btc_relay/structs/StoredBlockHeaderTestnet.sol
+++ b/ethereum/src/btc_relay/structs/StoredBlockHeaderTestnet.sol
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+import {CompactBlockHeaderImpl} from "./CompactBlockHeader.sol";
+import {Nbits} from "../utils/Nbits.sol";
+import {Difficulty} from "../utils/Difficulty.sol";
+import {Endianness} from "../btc_utils/Endianness.sol";
+import {DIFFICULTY_ADJUSTMENT_INTERVAL, MAX_FUTURE_BLOCKTIME} from "../Constants.sol";
+
+/**
+ * Bitcoin stored blockheader defined as a fixed-length bytes32 array
+ * Structure (total 160 bytes):
+ * - bytes blockheader (80 bytes)
+ * - uint256 chainWork
+ * - uint32 blockHeight
+ * - uint32 lastDiffAdjustment
+ * - uint32[10] prevBlockTimestamps
+ */
+struct StoredBlockHeader {
+    bytes32[5] data;
+}
+uint256 constant StoredBlockHeaderByteLength = 160;
+uint256 constant BitcoinBlockHeaderByteLength = 80;
+
+library StoredBlockHeaderImpl {
+
+    using CompactBlockHeaderImpl for bytes;
+
+    function fromCalldata(bytes calldata data, uint256 offset) pure internal returns (StoredBlockHeader memory storedHeader) {
+        require(data.length >= StoredBlockHeaderByteLength+offset, "StoredBlockHeader: out of bounds");
+        assembly ("memory-safe") {
+            calldatacopy(mload(storedHeader), add(data.offset, offset), StoredBlockHeaderByteLength) //Store stored header data
+        }
+    }
+
+    //Getters
+    function header_version(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(mload(self)))
+        }
+        result = Endianness.reverseUint32(result);
+    }
+
+    function header_previousBlockhash(StoredBlockHeader memory self) pure internal returns (bytes32 result) {
+        assembly ("memory-safe") {
+            result := mload(add(mload(self), 4))
+        }
+    }
+
+    function header_merkleRoot(StoredBlockHeader memory self) pure internal returns (bytes32 result) {
+        assembly ("memory-safe") {
+            result := mload(add(mload(self), 36))
+        }
+    }
+
+    function header_timestamp(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(add(mload(self), 68)))
+        }
+        result = Endianness.reverseUint32(result);
+    }
+
+    function header_nBitsLE(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(add(mload(self), 72)))
+        }
+    }
+
+    function header_nonce(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(add(mload(self), 76)))
+        }
+        result = Endianness.reverseUint32(result);
+    }
+
+    function chainWork(StoredBlockHeader memory self) pure internal returns (uint256 result) {
+        assembly ("memory-safe") {
+            result := mload(add(mload(self), 80))
+        }
+    }
+
+    function blockHeight(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(add(mload(self), 112)))
+        }
+    }
+
+    function lastDiffAdjustment(StoredBlockHeader memory self) pure internal returns (uint32 result) {
+        assembly ("memory-safe") {
+            result := shr(224, mload(add(mload(self), 116)))
+        }
+    }
+
+    function previousBlockTimestamps(StoredBlockHeader memory self) pure internal returns (uint32[10] memory result) {
+        assembly ("memory-safe") {
+            let ptr := mload(self)
+            let prevBlockTimestampsArray1 := mload(add(ptr, 120)) //offset(120) Stores first 8 last block timestamps
+            let prevBlockTimestampsArray2 := mload(add(ptr, 128)) //offset(120 + 8) Stores last 2 last block timestamps in least significant bits
+            mstore(result, shr(224, prevBlockTimestampsArray1))
+            mstore(add(result, 32), and(shr(192, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 64), and(shr(160, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 96), and(shr(128, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 128), and(shr(96, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 160), and(shr(64, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 192), and(shr(32, prevBlockTimestampsArray1), 0xffffffff))
+            mstore(add(result, 224), and(prevBlockTimestampsArray1, 0xffffffff))
+            mstore(add(result, 256), and(shr(32, prevBlockTimestampsArray2), 0xffffffff))
+            mstore(add(result, 288), and(prevBlockTimestampsArray2, 0xffffffff))
+        }
+    }
+
+    //Functions
+    function header_blockhash(StoredBlockHeader memory self) view internal returns (bytes32 result) {
+        assembly ("memory-safe") {
+            //Invoke first sha256 hash on the memory region now storing the current blockheader, destination is scratch space at 0x00
+            pop(staticcall(gas(), 0x02, mload(self), BitcoinBlockHeaderByteLength, 0x00, 32))
+            //Invoke second sha256 on the scratch space at 0x00
+            pop(staticcall(gas(), 0x02, 0x00, 32, 0x00, 32))
+
+            //Load and return the result
+            result := mload(0x00)
+        }
+    }
+
+    function hash(StoredBlockHeader memory self) pure internal returns (bytes32 result) {
+        assembly ("memory-safe") {
+            result := keccak256(mload(self), StoredBlockHeaderByteLength)
+        }
+    }
+
+    //Writes new blockheader to the stored header memory and computes the double sha256 hash of this new blockheader
+    function writeHeaderAndGetDblSha256Hash(StoredBlockHeader memory self, bytes calldata headers, uint256 offset) private view returns (bytes32 result) {
+        assembly ("memory-safe") {
+            let ptr := mload(self)
+
+            //Invoke first sha256 hash on the memory region storing the previous blockheader, destination is scratch space at 0x00
+            pop(staticcall(gas(), 0x02, ptr, BitcoinBlockHeaderByteLength, 0x00, 32))
+            //Invoke second sha256 on the scratch space at 0x00, copy directly to where the previous blockhash should be stored for next stored blockheader
+            pop(staticcall(gas(), 0x02, 0x00, 32, add(ptr, 4), 32))
+
+            //Copy other data to the stored blockheader from calldata
+            calldatacopy(ptr, add(headers.offset, offset), 4)
+            calldatacopy(add(ptr, 36), add(headers.offset, add(offset, 4)), 44)
+
+            //Invoke first sha256 hash on the memory region now storing the current blockheader, destination is scratch space at 0x00
+            pop(staticcall(gas(), 0x02, ptr, BitcoinBlockHeaderByteLength, 0x00, 32))
+            //Invoke second sha256 on the scratch space at 0x00
+            pop(staticcall(gas(), 0x02, 0x00, 32, 0x00, 32))
+
+            //Load and return the result
+            result := mload(0x00)
+        }
+    }
+
+    function updateChain(
+        StoredBlockHeader memory self, bytes calldata headers, uint256 offset, uint256 timestamp
+    ) internal view returns (bytes32 blockHash) {
+        //We don't check whether pevious header matches since submitted headers are submitted
+        // without previousBlockHash fields, which is instead taken automatically from the
+        // current StoredBlockHeader, this allows us to save at least 512 gas on calldata
+
+        uint32 prevBlockTimestamp = header_timestamp(self);
+        uint32 currBlockTimestamp = headers.timestamp(offset);
+
+        //Check correct nbits
+        uint256 currBlockHeight = blockHeight(self) + 1;
+        uint32 _lastDiffAdjustment = lastDiffAdjustment(self);
+        uint32 newNbits = headers.nBitsLE(offset);
+        uint256 newTarget = Nbits.toTarget(newNbits);
+
+        //Skip difficulty adjustment enforcement on testnet!
+        if(currBlockHeight % DIFFICULTY_ADJUSTMENT_INTERVAL == 0) {
+        //     //Compute new nbits, bitcoin uses the timestamp of the last block in the epoch to re-target PoW difficulty
+        //     // https://github.com/bitcoin/bitcoin/blob/78dae8caccd82cfbfd76557f1fb7d7557c7b5edb/src/pow.cpp#L49
+        //     uint256 computedNbits;
+        //     (newTarget, computedNbits) = Difficulty.computeNewTarget(
+        //         prevBlockTimestamp,
+        //         _lastDiffAdjustment,
+        //         header_nBitsLE(self),
+        //         clampTarget
+        //     );
+        //     require(newNbits == computedNbits, "updateChain: new nbits");
+        //     //Even though timestamp of the last block in epoch is used to re-target PoW difficulty, the first
+        //     // block in a new epoch is used as last_diff_adjustment, the time it takes to mine the first block
+        //     // in every epoch is therefore not taken into consideration when retargetting PoW - one of many
+        //     // bitcoin's quirks
+            _lastDiffAdjustment = currBlockTimestamp;
+        }
+        // } else {
+        //     //nbits must be same as last block
+        //     require(newNbits == header_nBitsLE(self), "updateChain: nbits");
+        //     newTarget = Nbits.toTarget(newNbits);
+        // }
+
+        //Check PoW
+        blockHash = writeHeaderAndGetDblSha256Hash(self, headers, offset);
+        require(uint256(Endianness.reverseBytes32(blockHash)) < Nbits.toTarget(newNbits), "updateChain: invalid PoW");
+
+        //Verify timestamp is larger than median of last 11 block timestamps
+        uint256 count = 0;
+        uint256 prevBlockTimestampsArray1;
+        uint256 prevBlockTimestampsArray2;
+        assembly ("memory-safe") {
+            let ptr := mload(self)
+            prevBlockTimestampsArray1 := mload(add(ptr, 120)) //offset(120) Stores first 8 last block timestamps
+            prevBlockTimestampsArray2 := mload(add(ptr, 128)) //offset(120 + 8) Stores last 2 last block timestamps in least significant bits
+            count := gt(currBlockTimestamp, prevBlockTimestamp)
+            count := add(count, gt(currBlockTimestamp, shr(224, prevBlockTimestampsArray1)))
+            count := add(count, gt(currBlockTimestamp, and(shr(192, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(160, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(128, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(96, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(64, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(32, prevBlockTimestampsArray1), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(prevBlockTimestampsArray1, 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(shr(32, prevBlockTimestampsArray2), 0xffffffff)))
+            count := add(count, gt(currBlockTimestamp, and(prevBlockTimestampsArray2, 0xffffffff)))
+        }
+        require(count > 5, "updateChain: timestamp median");
+        require(currBlockTimestamp < timestamp + MAX_FUTURE_BLOCKTIME, 'updateChain: timestamp future');
+
+        //Update prev block timestamps
+        assembly {
+            prevBlockTimestampsArray1 := shl(32, prevBlockTimestampsArray1) //Shift to the left, to remove oldest timestamp
+            prevBlockTimestampsArray1 := or(prevBlockTimestampsArray1, and(shr(32, prevBlockTimestampsArray2), 0xffffffff)) //Push timestamp from arr2 to arr1
+            prevBlockTimestampsArray2 := shl(32, prevBlockTimestampsArray2) //Shift to the left
+            prevBlockTimestampsArray2 := or(prevBlockTimestampsArray2, prevBlockTimestamp) //Add previous block timestamp
+        }
+
+        uint256 _chainWork = chainWork(self) + Difficulty.getChainWork(newTarget);
+
+        //Save the stored blockheader to memory
+        assembly ("memory-safe") {
+            //Blockheader is already written to memory with prior writeHeaderAndGetDblSha256Hash() call
+            let ptr := mload(self)
+
+            //Write chainwork at offset 80..112
+            mstore(add(ptr, 80), _chainWork)
+            mstore(add(ptr, 112), 
+                or(
+                    or(
+                        shl(224, currBlockHeight), //Current block height at offset 112..116
+                        shl(192, and(_lastDiffAdjustment, 0xffffffff)) //Last difficulty adjustment at offset 116..120
+                    ),
+                    shr(64, prevBlockTimestampsArray1) //First 6 values of previous block timestamps at offset 120..144
+                )
+            )
+            //Ensure we don't write outside the region of the stored blockheader byte array, so we
+            // have a little bit of an overlap here
+            mstore(add(ptr, 128), 
+                or(
+                    shl(64, prevBlockTimestampsArray1),
+                    and(prevBlockTimestampsArray2, 0xffffffffffffffff)
+                )
+            )
+        }
+    }
+
+}

--- a/ethereum/src/btc_relay/structs/StoredBlockHeaderTestnet.sol
+++ b/ethereum/src/btc_relay/structs/StoredBlockHeaderTestnet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {CompactBlockHeaderImpl} from "./CompactBlockHeader.sol";
 import {Nbits} from "../utils/Nbits.sol";

--- a/ethereum/src/btc_relay/utils/Difficulty.sol
+++ b/ethereum/src/btc_relay/utils/Difficulty.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+import {Nbits} from "./Nbits.sol";
+import {
+    TARGET_TIMESPAN, TARGET_TIMESPAN_DIV_4, TARGET_TIMESPAN_MUL_4,
+    ROUNDED_MAX_TARGET, ROUNDED_MAX_TARGET_NBITS
+} from "../Constants.sol";
+
+library Difficulty {
+
+    //Old version of the target computation, operates on targets and uses uint256 arithmetics
+    // function _computeNewTarget(uint32 prevTimestamp, uint32 startTimestamp, uint256 prevTarget) pure internal returns (uint256 newTarget) {
+    //     uint256 timespan = uint256(prevTimestamp) - uint256(startTimestamp);
+        
+    //     //Difficulty increase/decrease multiples are clamped between 0.25 (-75%) and 4 (+300%)
+    //     if(timespan < TARGET_TIMESPAN_DIV_4) timespan = TARGET_TIMESPAN_DIV_4;
+    //     if(timespan > TARGET_TIMESPAN_MUL_4) timespan = TARGET_TIMESPAN_MUL_4;
+
+    //     newTarget = prevTarget * timespan / TARGET_TIMESPAN;
+    //     if(newTarget > UNROUNDED_MAX_TARGET) newTarget = UNROUNDED_MAX_TARGET;
+    // }
+
+    //New version of the target computation, works directly with nBits
+    function computeNewTarget(uint32 prevTimestamp, uint32 startTimestamp, uint32 prevNbitsLE, bool clampTarget) pure internal returns (uint256 newTarget, uint32 newNbitsLE) {
+        uint256 timespan = uint256(prevTimestamp) - uint256(startTimestamp);
+        //Difficulty increase/decrease multiples are clamped between 0.25 (-75%) and 4 (+300%)
+        if(timespan < TARGET_TIMESPAN_DIV_4) timespan = TARGET_TIMESPAN_DIV_4;
+        if(timespan > TARGET_TIMESPAN_MUL_4) timespan = TARGET_TIMESPAN_MUL_4;
+
+        uint256 targetTimespan = TARGET_TIMESPAN;
+        assembly {
+            let nSize := and(prevNbitsLE, 0xFF)
+            let nWord := or(
+                or(
+                    and(shl(16, prevNbitsLE), 0x7f000000),
+                    and(prevNbitsLE, 0xff0000)
+                ),
+                and(shr(16, prevNbitsLE), 0xff00)
+            ) //Shift it 1 more byte to the left, so we have enough precision when we do multiplication and division
+            //The maximum value of the nWord is 0x7fffff00 (due to the extra shift to the left)
+            //The range of values for the newNWord is from nWord/4 to nWord*4
+            let newNWord := div(mul(nWord, timespan), targetTimespan) //Adjust the nWord based on timestamp
+
+            if gt(and(newNWord, 0xff00000000), 0) {
+                //The result requires increasing the nSize
+                nSize := add(nSize, 1)
+                newNWord := shr(8, newNWord)
+            }
+            if iszero(and(newNWord, 0xff000000)) {
+                //The result requires decreasing the nSize
+                nSize := sub(nSize, 1)
+                newNWord := shl(8, newNWord)
+            }
+            //Any other possibility cannot happen, because of the bounded div 4 and mul 4 adjustments
+            
+            //Check that nbits are not encoding negative number, in case yes, shift
+            // the result one byte to the right and adjust nSize accordingly
+            if eq(and(newNWord, 0x80000000), 0x80000000) {
+                newNWord := shr(8, newNWord)
+                nSize := add(nSize, 1)
+            }
+
+            newNbitsLE := or(
+                or(
+                    and(shl(16, newNWord), 0xff000000),
+                    and(newNWord, 0xff0000)
+                ),
+                or(
+                    and(shr(16, newNWord), 0xff00),
+                    nSize
+                )
+            )
+        }
+
+        newTarget = Nbits.toTarget(newNbitsLE);
+
+        if(clampTarget) {
+            if(newTarget > ROUNDED_MAX_TARGET) {
+                newNbitsLE = ROUNDED_MAX_TARGET_NBITS;
+                newTarget = ROUNDED_MAX_TARGET;
+            }
+        }
+    }
+
+    //Compute chainwork according to bitcoin core implementation
+    // https://github.com/bitcoin/bitcoin/blob/master/src/chain.cpp#L131
+    function getChainWork(uint256 target) pure internal returns (uint256 chainwork) {
+        assembly {
+            chainwork := add(div(not(target), add(target, 1)), 1)
+        }
+    }
+}

--- a/ethereum/src/btc_relay/utils/Difficulty.sol
+++ b/ethereum/src/btc_relay/utils/Difficulty.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import {Nbits} from "./Nbits.sol";
 import {

--- a/ethereum/src/btc_relay/utils/Nbits.sol
+++ b/ethereum/src/btc_relay/utils/Nbits.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.20;
+
+library Nbits {
+
+    //Calculates difficulty target from nBits
+    //Description: https://btcinformation.org/en/developer-reference#target-nbits
+    //This implementation panics on negative targets, accepts oveflown targets
+    function toTarget(uint32 nBitsLE) pure internal returns (uint256 target) {
+        uint256 nSize;
+        assembly {
+            nSize := and(nBitsLE, 0xFF)
+            let nWord := or(
+                or(
+                    and(shl(8, nBitsLE), 0x7f0000),
+                    and(shr(8, nBitsLE), 0xff00)
+                ),
+                and(shr(24, nBitsLE), 0xff)
+            )
+
+            switch lt(nSize, 3)
+            case 1 {
+                target := shr(shl(3, sub(3, nSize)), nWord) //shl(3, sub(3, nSize)) == mul(sub(3, nSize), 8)
+            }
+            default {
+                target := shl(shl(3, sub(nSize, 3)), nWord) //shl(3, sub(nSize, 3)) == mul(sub(nSize, 3), 8)
+            }
+        }
+        require(target == 0 || nBitsLE & 0x8000 == 0, "Nbits: negative");
+    }
+
+    //Compresses difficulty target to nBits
+    //Description: https://btcinformation.org/en/developer-reference#target-nbits
+    function toReversedNbits(uint256 target) pure internal returns (uint32 nBitsLE) {
+        assembly {
+            switch target
+            case 0 {
+                nBitsLE := 0x00000000
+            }
+            default {
+                //Find first non-zero byte
+                let start := 0
+                for
+                    { }
+                    iszero(byte(start, target))
+                    { start := add(start, 1) }
+                {}
+                let nSize := sub(32, start)
+
+                let result
+                switch lt(nSize, 3) case 1 {
+                    result := shl(shl(3, sub(3, nSize)), target) //shl(3, sub(3, nSize)) == mul(sub(3, nSize), 8)
+                }
+                default {
+                    result := shr(shl(3, sub(nSize, 3)), target) //shl(3, sub(nSize, 3)) == mul(sub(nSize, 3), 8)
+                }
+
+                //Check that nbits are not encoding negative number, in case yes, shift
+                // the result one byte to the right and adjust nSize accordingly
+                if eq(and(result, 0x00800000), 0x00800000) {
+                    result := shr(8, result)
+                    nSize := add(nSize, 1)
+                }
+
+                nBitsLE := or(
+                    or(
+                        and(shl(24, result), 0xff000000),
+                        and(shl(8, result), 0xff0000)
+                    ),
+                    or(
+                        and(shr(8, result), 0xff00),
+                        nSize
+                    )
+                )
+            }
+        }
+    }
+
+}

--- a/ethereum/src/btc_relay/utils/Nbits.sol
+++ b/ethereum/src/btc_relay/utils/Nbits.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 library Nbits {
 

--- a/ethereum/src/interfaces/AggregatorV3Interface.sol
+++ b/ethereum/src/interfaces/AggregatorV3Interface.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+// Vendored from @chainlink/contracts (chainlink-brownie-contracts v1.3.0),
+// src/v0.8/shared/interfaces/AggregatorV3Interface.sol. Inlined here to drop the
+// dependency on the deprecated/archived chainlink-brownie-contracts repository.
+// The interface is self-contained (no imports) and matches Chainlink upstream.
+
+// solhint-disable-next-line interface-starts-with-i
+interface AggregatorV3Interface {
+  function decimals() external view returns (uint8);
+
+  function description() external view returns (string memory);
+
+  function version() external view returns (uint256);
+
+  function getRoundData(
+    uint80 _roundId
+  ) external view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+
+  function latestRoundData()
+    external
+    view
+    returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -9,6 +9,11 @@ interface IBridge {
     error InvalidDestinationAddress();
     error InvalidDestinationChainId();
     error InvalidSourceChainId();
+    error ZeroAmount();
+    error AmountBelowMinimum(uint256 amount, uint256 minimum);
+    error InvalidMinFundsInAmount();
+    error AddressTooLong(uint256 length, uint256 maxLength);
+    error ProofTooLong(uint256 length, uint256 maxLength);
     error InvalidRouteRegistryAddress();
     error InvalidCommissionManagerAddress();
     error NotLZAdapter();
@@ -29,6 +34,11 @@ interface IBridge {
     ///                    before the first rotation).
     /// @param newRegistry New registry (non-zero by `setRouteRegistry` guard).
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+
+    /// @notice Emitted on every successful `setMinFundsInAmount`.
+    /// @param oldMinimum Previous minimum (constructor value before first update).
+    /// @param newMinimum New minimum (in token smallest units; always non-zero).
+    event MinFundsInAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
 
     /// @param sender             Address that deposited the tokens (the EOA on the
     ///                           public overload, or the LZ adapter on the
@@ -147,6 +157,16 @@ interface IBridge {
     /// @notice Updates the `RouteRegistry` reference Bridge dispatches
     ///         `onFundsIn` / `beforeFundsOut` through. Owner-only.
     function setRouteRegistry(address newRouteRegistry) external;
+
+    /// @notice Updates the minimum accepted `fundsIn` deposit (token smallest
+    ///         units). Owner-only (MultisigProxy via the federation
+    ///         propose -> timelock -> execute flow). Must be non-zero; reverts
+    ///         `InvalidMinFundsInAmount` otherwise.
+    function setMinFundsInAmount(uint256 newMinimum) external;
+
+    /// @notice Current minimum accepted `fundsIn` deposit in token smallest
+    ///         units. Always non-zero.
+    function minFundsInAmount() external view returns (uint256);
 
     /// @notice Current trusted adapter; `address(0)` means the adapter
     ///         overload is closed.

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 interface IBridge {
     // =========================================================================

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -13,7 +13,6 @@ interface IBridge {
     error InvalidCommissionManagerAddress();
     error NotLZAdapter();
     error BurnIdAlreadyConsumed(uint256 burnId);
-    error NativeCommissionNotAllowedOnFundsOut();
     error NativeValueMismatch();
 
     // =========================================================================

--- a/ethereum/src/interfaces/IBtcRelayView.sol
+++ b/ethereum/src/interfaces/IBtcRelayView.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 /// @title IBtcRelayView
 /// @notice Read-only interface for the Atomiq BtcRelay contract.

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 /**
  * @title ICommissionManager types & interface

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -46,6 +46,7 @@ interface ICommissionManager {
     error InvalidRecipient();
     error StablePercentTooHigh();
     error MultiplierZero();
+    error InvalidFeeShape(uint256 stablePercent, uint8 multiplier);
     error NativeCommissionNotAllowedOnFundsOut();
     error TokenDecimalsUnavailable();
     error BalanceBelowRecordedPool();

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -46,6 +46,7 @@ interface ICommissionManager {
     error InvalidRecipient();
     error StablePercentTooHigh();
     error MultiplierZero();
+    error NativeCommissionNotAllowedOnFundsOut();
     error TokenDecimalsUnavailable();
     error BalanceBelowRecordedPool();
     error NothingReceived();

--- a/ethereum/src/interfaces/IFinalityVerifier.sol
+++ b/ethereum/src/interfaces/IFinalityVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { FundsOutContext } from './RouteTypes.sol';
 

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -43,6 +43,8 @@ interface IMultisigProxy {
     error InvalidThreshold();
     error ZeroCommissionRecipient();
     error TimelockTooLong();
+    error TimelockTooShort();
+    error InvalidMinTimelock();
     error Expired();
     error CallDataTooShort();
     error CallNotAllowed(address target, bytes4 selector);
@@ -439,5 +441,6 @@ interface IMultisigProxy {
     function DOMAIN_SEPARATOR() external view returns (bytes32);
     function proposalNonce() external view returns (uint256);
     function timelockDuration() external view returns (uint256);
+    function MIN_TIMELOCK() external view returns (uint256);
     function getProposal(bytes32 proposalId) external view returns (Proposal memory);
 }

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -54,6 +54,7 @@ interface IMultisigProxy {
     error ProposalExpired();
     error DataMismatch();
     error DeadlineTooFar();
+    error DeadlineBeforeTimelock();
     error ProposalExists();
     error IndexOutOfRange();
     error BitmapOutOfRange();
@@ -62,6 +63,8 @@ interface IMultisigProxy {
     error InvalidSignature();
     error ZeroAddressSigner();
     error DuplicateSigner();
+    error SignerSetsOverlap(address signer);
+    error TooManySigners(uint256 count, uint256 max);
     error CallFailed();
     error UnknownOperationType();
     error ZeroRecipient();

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity 0.8.35;
 
 /// @title IMultisigProxy
 /// @notice Two-level ECDSA multisig proxy that owns the Bridge and the CommissionManager.

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -88,7 +88,9 @@ interface IMultisigProxy {
         AdminExecuteAdapter,             // 11 — generic call into LZAdapter (setTrustedEntrypoint, refundStuckFunds, …)
         UpdateLZAdapter,                 // 12 — rotate the routing target for AdminExecuteAdapter
         SetRoute,                        // 13 — RouteRegistry.setRoute(src, dst, enabled, verifier, module)
-        UpdateRouteRegistry              // 14 — Bridge.setRouteRegistry(newRouteRegistry)
+        UpdateRouteRegistry,             // 14 — Bridge.setRouteRegistry(newRouteRegistry)
+        PauseInflow,                     // 15 — Bridge.pauseInflow()  (planned inflow-only freeze, timelocked)
+        UnpauseInflow                    // 16 — Bridge.unpauseInflow()
     }
 
     enum ProposalStatus { None, Pending, Executed, Cancelled }
@@ -367,6 +369,27 @@ interface IMultisigProxy {
     ///      simultaneously breaks.
     function proposeUpdateRouteRegistry(
         address newRouteRegistry,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
+    /// @notice Propose a planned inflow-only pause on Bridge (`pauseInflow`).
+    /// @dev Freezes deposits while leaving withdrawals open — intended for a
+    ///      bridge upgrade / liquidity migration. Runs through the timelocked
+    ///      propose -> execute path. For an immediate freeze of BOTH paths use
+    ///      `emergencyPause`. Carries no payload (opData is empty).
+    function proposePauseInflow(
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
+    /// @notice Propose resuming the inflow path on Bridge (`unpauseInflow`).
+    /// @dev Reverses `proposePauseInflow`. Timelocked. Carries no payload.
+    function proposeUnpauseInflow(
         uint256 nonce,
         uint256 deadline,
         uint256 fedBitmap,

--- a/ethereum/src/interfaces/IRouteRegistry.sol
+++ b/ethereum/src/interfaces/IRouteRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { FundsInContext, FundsOutContext, RouteConfig } from './RouteTypes.sol';
 

--- a/ethereum/src/interfaces/ISettlementModule.sol
+++ b/ethereum/src/interfaces/ISettlementModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { FundsInContext, FundsOutContext } from './RouteTypes.sol';
 

--- a/ethereum/src/interfaces/RouteTypes.sol
+++ b/ethereum/src/interfaces/RouteTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 /// @title RouteTypes
 /// @notice Shared data shapes used by `IRouteRegistry`, `ISettlementModule`

--- a/ethereum/src/settlement/NullSettlementModule.sol
+++ b/ethereum/src/settlement/NullSettlementModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { ISettlementModule } from '../interfaces/ISettlementModule.sol';
 import { FundsInContext, FundsOutContext } from '../interfaces/RouteTypes.sol';

--- a/ethereum/src/settlement/RgbSettlementModule.sol
+++ b/ethereum/src/settlement/RgbSettlementModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { ISettlementModule } from '../interfaces/ISettlementModule.sol';
 import { FundsInContext, FundsOutContext } from '../interfaces/RouteTypes.sol';

--- a/ethereum/src/verifiers/NullVerifier.sol
+++ b/ethereum/src/verifiers/NullVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IFinalityVerifier }  from '../interfaces/IFinalityVerifier.sol';
 import { FundsOutContext }    from '../interfaces/RouteTypes.sol';

--- a/ethereum/src/verifiers/RGBVerifier.sol
+++ b/ethereum/src/verifiers/RGBVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IFinalityVerifier } from '../interfaces/IFinalityVerifier.sol';
 import { FundsOutContext }   from '../interfaces/RouteTypes.sol';

--- a/ethereum/test/BaseBridge.t.sol
+++ b/ethereum/test/BaseBridge.t.sol
@@ -95,7 +95,7 @@ contract BaseBridgeTest is Test {
 
     function test_fundsIn_revertsWhenPaused() public {
         vm.prank(owner);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
@@ -154,23 +154,23 @@ contract BaseBridgeTest is Test {
     function test_pause_onlyOwner() public {
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.pause();
+        bridge.pauseInflow();
     }
 
     function test_unpause_onlyOwner() public {
         vm.prank(owner);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.unpause();
+        bridge.unpauseInflow();
     }
 
     function test_unpause_ownerCanUnpause() public {
         vm.prank(owner);
-        bridge.pause();
+        bridge.pauseInflow();
         vm.prank(owner);
-        bridge.unpause();
+        bridge.unpauseInflow();
 
         // fundsIn works again
         vm.prank(user);
@@ -182,6 +182,118 @@ contract BaseBridgeTest is Test {
         vm.expectRevert(BridgeBase.RenounceOwnershipBlocked.selector);
         vm.prank(owner);
         bridge.renounceOwnership();
+    }
+
+    // ========================================================================
+    // R-W-05 — two-tier pause (inflow vs outflow / emergency)
+    // ========================================================================
+
+    /// @dev UT-FIX-08: with outflow frozen, fundsOut reverts. The
+    ///      whenOutflowNotPaused modifier runs before the body, so a dummy
+    ///      release is enough to exercise the gate.
+    function test_fundsOut_revertsWhenOutflowPaused() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID); // seed the pool
+
+        vm.prank(owner);
+        bridge.emergencyPauseAll();
+
+        vm.expectRevert(BridgeBase.OutflowEnforcedPause.selector);
+        vm.prank(owner);
+        bridge.fundsOut(recipient, AMOUNT, OPERATION_ID, SRC_ADDR);
+    }
+
+    /// @dev The planned inflow-only pause blocks deposits but leaves
+    ///      withdrawals open — the core two-tier distinction (liquidity can be
+    ///      migrated out while new deposits are frozen).
+    function test_fundsOut_worksWhenOnlyInflowPaused() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID); // seed before freezing inflow
+
+        vm.prank(owner);
+        bridge.pauseInflow();
+
+        // Deposits are frozen...
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID);
+
+        // ...but withdrawals still work.
+        vm.prank(owner);
+        bridge.fundsOut(recipient, AMOUNT, OPERATION_ID, SRC_ADDR);
+        assertEq(token.balanceOf(recipient), AMOUNT);
+    }
+
+    /// @dev Emergency pause freezes BOTH paths.
+    function test_emergencyPauseAll_freezesBothPaths() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID); // seed the pool
+
+        vm.prank(owner);
+        bridge.emergencyPauseAll();
+
+        assertTrue(bridge.paused(),        'inflow frozen');
+        assertTrue(bridge.outflowPaused(), 'outflow frozen');
+
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID);
+
+        vm.expectRevert(BridgeBase.OutflowEnforcedPause.selector);
+        vm.prank(owner);
+        bridge.fundsOut(recipient, AMOUNT, OPERATION_ID, SRC_ADDR);
+    }
+
+    /// @dev Emergency unpause lifts BOTH freezes.
+    function test_emergencyUnpauseAll_liftsBoth() public {
+        vm.startPrank(owner);
+        bridge.emergencyPauseAll();
+        bridge.emergencyUnpauseAll();
+        vm.stopPrank();
+
+        assertFalse(bridge.paused(),        'inflow resumed');
+        assertFalse(bridge.outflowPaused(), 'outflow resumed');
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, OPERATION_ID);
+        assertEq(token.balanceOf(address(bridge)), AMOUNT);
+    }
+
+    /// @dev emergencyPauseAll must be idempotent per flag: it must not revert
+    ///      if inflow is already frozen via the planned path.
+    function test_emergencyPauseAll_idempotentWhenInflowAlreadyPaused() public {
+        vm.startPrank(owner);
+        bridge.pauseInflow();      // inflow already frozen
+        bridge.emergencyPauseAll(); // must not revert on the already-set inflow flag
+        vm.stopPrank();
+
+        assertTrue(bridge.paused(),        'inflow still frozen');
+        assertTrue(bridge.outflowPaused(), 'outflow now frozen');
+    }
+
+    function test_pauseInflow_onlyOwner() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.pauseInflow();
+    }
+
+    function test_emergencyPauseAll_onlyOwner() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.emergencyPauseAll();
+    }
+
+    function test_emergencyUnpauseAll_onlyOwner() public {
+        vm.prank(owner);
+        bridge.emergencyPauseAll();
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        bridge.emergencyUnpauseAll();
+    }
+
+    function test_outflowPaused_defaultsFalse() public view {
+        assertFalse(bridge.outflowPaused());
     }
 
     // ========================================================================

--- a/ethereum/test/BaseBridge.t.sol
+++ b/ethereum/test/BaseBridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
 import { BaseBridge } from '../src/BaseBridge.sol';

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -404,7 +404,7 @@ contract BridgeTest is Test {
 
     function test_fundsIn_revertsWhenPaused() public {
         vm.prank(multisig);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
@@ -762,16 +762,16 @@ contract BridgeTest is Test {
     function test_pause_onlyOwner() public {
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.pause();
+        bridge.pauseInflow();
     }
 
     function test_unpause_onlyOwner() public {
         vm.prank(multisig);
-        bridge.pause();
+        bridge.pauseInflow();
 
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.unpause();
+        bridge.unpauseInflow();
     }
 
     function test_renounceOwnership_alwaysReverts() public {

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -718,22 +718,14 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
-    // Commission — fundsOut NATIVE reverts
+    // Commission — NATIVE + FUNDS_OUT rejected at config time (R-W-04)
     // ========================================================================
 
-    function test_fundsOut_nativeCommission_reverts() public {
-        vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
-
-        _setFundsOutNativeRule(100);
-
-        vm.expectRevert(IBridge.NativeCommissionNotAllowedOnFundsOut.selector);
-        vm.prank(multisig);
-        bridge.fundsOut(
-            recipient, AMOUNT, BURN_ID,
-            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
-        );
+    /// @dev Post R-W-04 the invalid (NATIVE, FUNDS_OUT) shape is rejected by the
+    ///      CommissionManager setter, so it can never reach (and brick) fundsOut.
+    function test_setCommissionRule_nativeFundsOut_reverts() public {
+        vm.expectRevert(ICommissionManager.NativeCommissionNotAllowedOnFundsOut.selector);
+        _setFundsOutNativeRule(100); // setCommissionRule(... NATIVE, FUNDS_OUT ...)
     }
 
     // ========================================================================

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -50,6 +50,7 @@ contract BridgeTest is Test {
     );
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+    event MinFundsInAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
 
     Bridge              bridge;
     MockERC20           usdt0;
@@ -101,7 +102,8 @@ contract BridgeTest is Test {
             address(usdt0),
             address(routeRegistry),
             payable(address(cm)),
-            address(0)
+            address(0),
+            1 // minFundsInAmount: smallest non-zero floor; cases that need a higher floor deploy their own Bridge
         );
 
         rgbVerifier = new RGBVerifier(address(btcRelay));
@@ -150,6 +152,15 @@ contract BridgeTest is Test {
 
     function _settlement(uint256[] memory ids) internal pure returns (bytes memory) {
         return abi.encode(ids);
+    }
+
+    /// @dev Build an ASCII string of exactly `len` bytes (for address-length caps).
+    function _str(uint256 len) internal pure returns (string memory) {
+        bytes memory b = new bytes(len);
+        for (uint256 i = 0; i < len; i++) {
+            b[i] = 'a';
+        }
+        return string(b);
     }
 
     function _setFundsInTokenRule(uint256 percent) internal {
@@ -221,24 +232,24 @@ contract BridgeTest is Test {
 
     function test_constructor_revertsOnZeroToken() public {
         vm.expectRevert(BridgeBase.InvalidTokenAddress.selector);
-        new Bridge(address(0), address(routeRegistry), payable(address(cm)), address(0));
+        new Bridge(address(0), address(routeRegistry), payable(address(cm)), address(0), 1);
     }
 
     function test_constructor_revertsOnZeroRouteRegistry() public {
         vm.expectRevert(IBridge.InvalidRouteRegistryAddress.selector);
-        new Bridge(address(usdt0), address(0), payable(address(cm)), address(0));
+        new Bridge(address(usdt0), address(0), payable(address(cm)), address(0), 1);
     }
 
     function test_constructor_revertsOnZeroCommissionManager() public {
         vm.expectRevert(IBridge.InvalidCommissionManagerAddress.selector);
-        new Bridge(address(usdt0), address(routeRegistry), payable(address(0)), address(0));
+        new Bridge(address(usdt0), address(routeRegistry), payable(address(0)), address(0), 1);
     }
 
     function test_constructor_storesInitialLZAdapter() public {
         address initialAdapter = makeAddr('initial-adapter');
         vm.prank(deployer);
         Bridge b = new Bridge(
-            address(usdt0), address(routeRegistry), payable(address(cm)), initialAdapter
+            address(usdt0), address(routeRegistry), payable(address(cm)), initialAdapter, 1
         );
         assertEq(b.lzAdapter(), initialAdapter, 'lzAdapter set in constructor');
     }
@@ -299,6 +310,263 @@ contract BridgeTest is Test {
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         bridge.setRouteRegistry(makeAddr('newReg'));
+    }
+
+    // ========================================================================
+    // Minimum fundsIn amount + zero-amount guards
+    //
+    // `minFundsInAmount` is a non-zero floor enforced on the inbound path: it
+    // rejects zero-amount deposits (R-I-07) and dust whose commission would
+    // round to zero (R-I-08). `fundsOut` is an authorized release and only
+    // rejects amount == 0. The harness deploys with the smallest floor (1), so
+    // tests that need a higher floor raise it via `setMinFundsInAmount`.
+    // ========================================================================
+
+    function test_constructor_storesMinFundsInAmount() public {
+        vm.prank(deployer);
+        Bridge b = new Bridge(
+            address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 1234
+        );
+        assertEq(b.minFundsInAmount(), 1234, 'minFundsInAmount stored from constructor');
+    }
+
+    function test_constructor_revertsOnZeroMinFundsInAmount() public {
+        vm.expectRevert(IBridge.InvalidMinFundsInAmount.selector);
+        new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 0);
+    }
+
+    function test_setMinFundsInAmount_updatesAndEmits() public {
+        vm.expectEmit(false, false, false, true, address(bridge));
+        emit MinFundsInAmountUpdated(1, 1000);
+
+        vm.prank(multisig);
+        bridge.setMinFundsInAmount(1000);
+        assertEq(bridge.minFundsInAmount(), 1000);
+    }
+
+    function test_setMinFundsInAmount_revertsOnZero() public {
+        vm.prank(multisig);
+        vm.expectRevert(IBridge.InvalidMinFundsInAmount.selector);
+        bridge.setMinFundsInAmount(0);
+    }
+
+    function test_setMinFundsInAmount_revertsIfNotOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.setMinFundsInAmount(1000);
+    }
+
+    // --- R-I-07: zero amount ---
+
+    function test_fundsIn_revertsOnZeroAmount() public {
+        // Floor is 1 (setUp), so a zero deposit is below the minimum.
+        vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, uint256(0), uint256(1)));
+        vm.prank(user);
+        bridge.fundsIn(0, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+    }
+
+    function test_fundsOut_revertsOnZeroAmount() public {
+        // fundsOut has no minimum — only the zero-amount no-op guard, which
+        // fires before the burn-id and balance checks.
+        vm.expectRevert(IBridge.ZeroAmount.selector);
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, 0, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+    }
+
+    // --- R-I-08: dust / below-minimum on the inbound path ---
+
+    function test_fundsIn_revertsBelowMinimum() public {
+        vm.prank(multisig);
+        bridge.setMinFundsInAmount(1000);
+
+        vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, uint256(999), uint256(1000)));
+        vm.prank(user);
+        bridge.fundsIn(999, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+    }
+
+    function test_fundsIn_acceptsExactlyAtMinimum() public {
+        vm.prank(multisig);
+        bridge.setMinFundsInAmount(1000);
+
+        vm.prank(user);
+        bridge.fundsIn(1000, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        assertEq(rgbModule.fundsInRecords(TX_ID), 1000, 'deposit at the floor is accepted');
+    }
+
+    function test_fundsIn_acceptsAboveMinimum() public {
+        vm.prank(multisig);
+        bridge.setMinFundsInAmount(1000);
+
+        vm.prank(user);
+        bridge.fundsIn(1001, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        assertEq(rgbModule.fundsInRecords(TX_ID), 1001, 'deposit above the floor is accepted');
+    }
+
+    function test_fundsIn_dustThatRoundsCommissionToZeroIsRejected() public {
+        // 4% token commission. Below 25 units the fee floors to zero
+        // (24 * 400 / 100 / 100 == 0) — the exact dust case R-I-08 describes.
+        // A floor of 25 keeps such dust off the inbound path; at 25 the fee is
+        // a non-zero 1 unit.
+        _setFundsInTokenRule(400);
+        vm.prank(multisig);
+        bridge.setMinFundsInAmount(25);
+
+        assertEq(cm.calculateStableFee(24, 400, 100), 0, 'sanity: 24 pays zero commission');
+
+        vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, uint256(24), uint256(25)));
+        vm.prank(user);
+        bridge.fundsIn(24, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        // At the floor the deposit is accepted and pays a non-zero commission.
+        vm.prank(user);
+        bridge.fundsIn(25, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        assertEq(rgbModule.fundsInRecords(TX_ID), 24, 'net = 25 - 1 commission');
+    }
+
+    function test_fundsInFromAdapter_revertsBelowMinimum() public {
+        // The adapter overload shares `_fundsIn`, so the floor applies there too.
+        address mockAdapter = makeAddr('mock-adapter');
+        vm.prank(multisig);
+        bridge.setLZAdapter(mockAdapter);
+        vm.prank(multisig);
+        bridge.setMinFundsInAmount(1000);
+
+        usdt0.mint(mockAdapter, 999);
+        vm.prank(mockAdapter);
+        usdt0.approve(address(bridge), 999);
+
+        vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, uint256(999), uint256(1000)));
+        vm.prank(mockAdapter);
+        bridge.fundsIn(999, SOURCE_CHAIN_ID, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+    }
+
+    function test_fundsIn_revertsOnDestinationAddressTooLong() public {
+        uint256 max = bridge.MAX_ADDRESS_LENGTH();
+        string memory tooLong = _str(max + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(IBridge.AddressTooLong.selector, max + 1, max));
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, tooLong, TX_ID, '');
+    }
+
+    function test_fundsIn_acceptsDestinationAddressAtMaxLength() public {
+        uint256 max = bridge.MAX_ADDRESS_LENGTH();
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, _str(max), TX_ID, '');
+        assertEq(rgbModule.fundsInRecords(TX_ID), AMOUNT, 'deposit at the address-length cap is accepted');
+    }
+
+    function test_fundsOut_revertsOnSourceAddressTooLong() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        uint256 max = bridge.MAX_ADDRESS_LENGTH();
+        string memory tooLong = _str(max + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(IBridge.AddressTooLong.selector, max + 1, max));
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, tooLong,
+            _proof(), _settlement(_singleFundsInId())
+        );
+    }
+
+    function test_fundsOut_acceptsSourceAddressAtMaxLength() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        uint256 max = bridge.MAX_ADDRESS_LENGTH();
+
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, _str(max),
+            _proof(), _settlement(_singleFundsInId())
+        );
+        assertEq(usdt0.balanceOf(recipient), AMOUNT, 'release with sourceAddress at the cap succeeds');
+    }
+
+    // ========================================================================
+    // Proof length cap (R-I-12)
+    //
+    // fundsOut forwards `proof` to the route verifier, so it is capped at
+    // MAX_PROOF_LENGTH to bound calldata + verifier gas. The exact cap is
+    // accepted; one byte over reverts ProofTooLong. The real RGB proof
+    // (abi.encode(uint256, bytes32) = 64 bytes) is far under the cap.
+    // ========================================================================
+
+    /// @dev Build a `bytes` blob of exactly `len` bytes.
+    function _bytesOfLength(uint256 len) internal pure returns (bytes memory b) {
+        b = new bytes(len);
+        for (uint256 i = 0; i < len; i++) {
+            b[i] = 0x61;
+        }
+    }
+
+    function test_fundsOut_revertsOnProofTooLong() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        uint256 max = bridge.MAX_PROOF_LENGTH();
+        bytes memory tooLong = _bytesOfLength(max + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(IBridge.ProofTooLong.selector, max + 1, max));
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            tooLong, _settlement(_singleFundsInId())
+        );
+    }
+
+    function test_fundsOut_acceptsProofAtMaxLength() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        // A proof at the exact cap passes the length guard. It then reverts in
+        // the verifier (the blob is not a valid (height, commitment) pair), so
+        // the cap check is isolated by asserting it is NOT ProofTooLong: the
+        // call reaches the verifier instead.
+        uint256 max = bridge.MAX_PROOF_LENGTH();
+        bytes memory atMax = _bytesOfLength(max);
+
+        vm.prank(multisig);
+        try bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            atMax, _settlement(_singleFundsInId())
+        ) {
+            // a decodable proof would succeed; this blob won't, so we don't
+            // expect to land here — but if a future verifier accepts it, the
+            // length guard still passed, which is what this test asserts.
+        } catch (bytes memory reason) {
+            // Must NOT be the length guard — proving max-length passes it.
+            bytes4 sel = bytes4(reason);
+            assertTrue(sel != IBridge.ProofTooLong.selector, 'max-length proof must clear the length guard');
+        }
+    }
+
+    function test_fundsOut_acceptsRealProofUnderCap() public {
+        // The production-shaped 64-byte RGB proof is well under the cap and the
+        // happy path still succeeds.
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertLt(_proof().length, bridge.MAX_PROOF_LENGTH(), 'sanity: real proof under cap');
+
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+        assertEq(usdt0.balanceOf(recipient), AMOUNT, 'release with a normal proof succeeds');
     }
 
     // ========================================================================

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
 

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -161,25 +161,28 @@ contract CommissionManagerTest is Test {
     }
 
     function test_setGlobalDefaults_updatesAndEmits() public {
+        // FUNDS_IN + NATIVE is a valid shape (the user funds the native fee on
+        // deposit). NATIVE + FUNDS_OUT is rejected by the setter (R-W-04) and is
+        // covered by a dedicated revert test.
         vm.expectEmit(true, true, true, true);
         emit GlobalDefaultsUpdated(
             200,
             100,
-            CommissionSide.FUNDS_OUT,
+            CommissionSide.FUNDS_IN,
             CommissionCurrency.NATIVE
         );
         vm.prank(owner);
         cm.setGlobalDefaults(
             200,
             100,
-            CommissionSide.FUNDS_OUT,
+            CommissionSide.FUNDS_IN,
             CommissionCurrency.NATIVE
         );
         (uint256 sp, uint8 m, CommissionSide side, CommissionCurrency cur) =
             cm.getGlobalDefaults();
         assertEq(sp, 200);
         assertEq(m, 100);
-        assertEq(uint8(side), uint8(CommissionSide.FUNDS_OUT));
+        assertEq(uint8(side), uint8(CommissionSide.FUNDS_IN));
         assertEq(uint8(cur), uint8(CommissionCurrency.NATIVE));
     }
 
@@ -234,6 +237,32 @@ contract CommissionManagerTest is Test {
             CommissionSide.FUNDS_IN,
             CommissionCurrency.TOKEN
         );
+    }
+
+    /// @dev UT-FIX-07: setGlobalDefaults rejects the NATIVE + FUNDS_OUT shape.
+    function test_setGlobalDefaults_revertsNativeFundsOut() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.NativeCommissionNotAllowedOnFundsOut.selector);
+        cm.setGlobalDefaults(
+            100,
+            100,
+            CommissionSide.FUNDS_OUT,
+            CommissionCurrency.NATIVE
+        );
+    }
+
+    /// @dev FUNDS_IN + NATIVE stays valid — the user funds the native fee on deposit.
+    function test_setGlobalDefaults_acceptsNativeFundsIn() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(
+            100,
+            100,
+            CommissionSide.FUNDS_IN,
+            CommissionCurrency.NATIVE
+        );
+        (, , CommissionSide side, CommissionCurrency cur) = cm.getGlobalDefaults();
+        assertEq(uint8(side), uint8(CommissionSide.FUNDS_IN));
+        assertEq(uint8(cur),  uint8(CommissionCurrency.NATIVE));
     }
 
     // --- Commission calculations (globals) ---
@@ -477,6 +506,39 @@ contract CommissionManagerTest is Test {
         vm.prank(owner);
         vm.expectRevert(ICommissionManager.StablePercentTooHigh.selector);
         cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t, cfg);
+    }
+
+    /// @dev UT-FIX-07: setCommissionRule rejects the NATIVE + FUNDS_OUT shape.
+    function test_setCommissionRule_revertsNativeFundsOut() public {
+        address t = address(token);
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 100,
+            multiplier: 100,
+            side: CommissionSide.FUNDS_OUT,
+            currency: CommissionCurrency.NATIVE,
+            isSet: true
+        });
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.NativeCommissionNotAllowedOnFundsOut.selector);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t, cfg);
+    }
+
+    /// @dev FUNDS_OUT + TOKEN stays valid (the fee is deducted from the release).
+    function test_setCommissionRule_acceptsFundsOutToken() public {
+        address t = address(token);
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 100,
+            multiplier: 100,
+            side: CommissionSide.FUNDS_OUT,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+        vm.prank(owner);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t, cfg);
+
+        CommissionConfig memory stored = cm.getCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t);
+        assertEq(uint8(stored.side),     uint8(CommissionSide.FUNDS_OUT));
+        assertEq(uint8(stored.currency), uint8(CommissionCurrency.TOKEN));
     }
 
     // --- Bridge address ---

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -541,6 +541,120 @@ contract CommissionManagerTest is Test {
         assertEq(uint8(stored.currency), uint8(CommissionCurrency.TOKEN));
     }
 
+    // --- Fee-shape invariant (R-W-03 / UT-FIX-06) -----------------------------
+    //
+    // The stable-fee formula is `amount * stablePercent / multiplier / multiplier`,
+    // i.e. a fee fraction of `stablePercent / multiplier^2`. If `stablePercent`
+    // exceeds `multiplier^2` the quoted fee exceeds the bridged amount and the
+    // later `netAmount = amount - fee` underflows (Panic 0x11), bricking the
+    // route until the federation reconfigures. The setters must therefore reject
+    // any `(stablePercent, multiplier)` pair where `stablePercent > multiplier^2`.
+    function test_setGlobalDefaults_revertsWhenStablePercentExceedsMultiplierSquared() public {
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(9000), uint8(1))
+        );
+        cm.setGlobalDefaults(9000, 1, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    /// @dev Boundary just above the invariant: `multiplier = 10` → `multiplier^2 = 100`,
+    ///      so `stablePercent = 101` is the smallest rejected value for that multiplier.
+    function test_setGlobalDefaults_revertsJustAboveFeeShapeBoundary() public {
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(101), uint8(10))
+        );
+        cm.setGlobalDefaults(101, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    /// @dev Exact boundary `stablePercent == multiplier^2` is accepted: it is a 100%
+    ///      fee (`netAmount = 0`) which is degenerate but does not underflow, so the
+    ///      invariant rejects only the strictly-greater case.
+    function test_setGlobalDefaults_acceptsFeeShapeAtExactBoundary() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(100, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        (uint256 sp, uint8 m,,) = cm.getGlobalDefaults();
+        assertEq(sp, 100);
+        assertEq(m, 10);
+    }
+
+    /// @dev Regression for the uint8 widening in the fix. With the default
+    ///      `multiplier = 100`, `multiplier^2 = 10000`, so `stablePercent = 9000`
+    ///      is a valid 90% fee and must be accepted. The audit's literal snippet
+    ///      `multiplier * multiplier` evaluates in uint8 and overflows at
+    ///      `100 * 100 = 10000 > 255`, which would wrongly revert this valid config;
+    ///      the fix widens to uint256 before squaring.
+    function test_setGlobalDefaults_acceptsHighPercentWithDefaultMultiplier() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(9000, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        (uint256 sp, uint8 m,,) = cm.getGlobalDefaults();
+        assertEq(sp, 9000);
+        assertEq(m, 100);
+    }
+
+    /// @dev Same invariant on the per-route setter: `(9000, 1)` must revert.
+    function test_setCommissionRule_revertsWhenStablePercentExceedsMultiplierSquared() public {
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 9000,
+            multiplier: 1,
+            side: CommissionSide.FUNDS_IN,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(9000), uint8(1))
+        );
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), cfg);
+    }
+
+    /// @dev Exact boundary `stablePercent == multiplier^2` accepted on the route setter.
+    function test_setCommissionRule_acceptsFeeShapeAtExactBoundary() public {
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 100,
+            multiplier: 10,
+            side: CommissionSide.FUNDS_IN,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+        vm.prank(owner);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), cfg);
+        CommissionConfig memory stored = cm.getCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token));
+        assertEq(stored.stablePercent, 100);
+        assertEq(stored.multiplier, 10);
+    }
+
+    /// @dev uint8-widening regression on the per-route setter: `(9000, 100)` is valid.
+    function test_setCommissionRule_acceptsHighPercentWithDefaultMultiplier() public {
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 9000,
+            multiplier: 100,
+            side: CommissionSide.FUNDS_IN,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+        vm.prank(owner);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), cfg);
+        CommissionConfig memory stored = cm.getCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token));
+        assertEq(stored.stablePercent, 9000);
+        assertEq(stored.multiplier, 100);
+    }
+
+    /// @dev End state of the invariant: a config accepted at the exact boundary
+    ///      yields `fee == amount` and `netAmount == 0` without underflowing. This
+    ///      is what the setter guard guarantees for every storable rule — the
+    ///      `amount - fee` subtraction in the calculators can never go negative.
+    function test_calculateFundsInCommission_acceptedBoundaryDoesNotUnderflow() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(100, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        uint256 amount = 50_000;
+        (uint256 tok, uint256 nat, uint256 net) =
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), amount);
+        assertEq(tok, amount); // 100% fee at the boundary
+        assertEq(nat, 0);
+        assertEq(net, 0);      // no underflow
+    }
+
     // --- Bridge address ---
 
     function test_setBridgeAddress_updates() public {

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -161,7 +161,8 @@ contract IntegrationTest is Test {
             address(token),
             address(routeRegistry),
             payable(address(cm)),
-            address(0)
+            address(0),
+            1 // minFundsInAmount: smallest non-zero floor for tests
         );
 
         rgbVerifier = new RGBVerifier(address(btcRelay));

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
 

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -91,7 +91,8 @@ contract IntegrationTest is Test {
     bytes32 constant COMMITMENT_HASH   = keccak256('integration-btc-block');
     uint256 constant BTC_CONFIRMATIONS = 6;
 
-    uint256 constant TIMELOCK = 1 hours;
+    uint256 constant TIMELOCK     = 1 hours;
+    uint256 constant MIN_TIMELOCK = 1 hours; // floor passed to the proxy constructor in tests
 
     /// @dev New 8-arg fundsOut selector:
     ///        fundsOut(
@@ -189,7 +190,8 @@ contract IntegrationTest is Test {
             enc, 2,
             fed, 2,
             commissionReceiver,
-            TIMELOCK
+            TIMELOCK,
+            MIN_TIMELOCK
         );
 
         cm.transferOwnership(address(proxy));

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -1057,13 +1057,19 @@ contract MultisigProxyTest is Test {
     function test_proposeAdminExecuteAdapter_executesCallOnAdapter() public {
         MockERC20 adapter = new MockERC20('LZ Stub', 'LZS');
         bytes32 idSet = _proposeUpdateLZAdapter(address(adapter));
-        vm.warp(block.timestamp + TIMELOCK + 1);
+        // Read block.timestamp once and derive every warp target from it. Re-reading
+        // block.timestamp after a vm.warp within the same function is unreliable under
+        // via_ir: the optimizer treats TIMESTAMP as tx-invariant and may reuse a
+        // pre-warp read, so a second `block.timestamp + ...` warp can collapse onto a
+        // stale value and leave the timelock unexpired.
+        uint256 firstExec = block.timestamp + TIMELOCK + 1;
+        vm.warp(firstExec);
         proxy.executeProposal(idSet, abi.encode(address(adapter)));
         assertEq(proxy.lzAdapter(), address(adapter));
 
         bytes memory callData = abi.encodeWithSignature('mint(address,uint256)', recipient, 1e18);
         uint256 nonce = proxy.proposalNonce();
-        uint256 deadline = block.timestamp + 1 days;
+        uint256 deadline = firstExec + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeAdminExecuteAdapter(
             domainSep, bytes4(callData), callData, nonce, deadline
@@ -1073,7 +1079,7 @@ contract MultisigProxyTest is Test {
 
         bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
 
-        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.warp(firstExec + TIMELOCK + 1);
         proxy.executeProposal(id, callData);
 
         assertEq(adapter.balanceOf(recipient), 1e18);

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -6,6 +6,8 @@ import { Test } from 'forge-std/Test.sol';
 import { MultisigProxy }  from '../src/MultisigProxy.sol';
 import { IMultisigProxy } from '../src/interfaces/IMultisigProxy.sol';
 import { Bridge }              from '../src/Bridge.sol';
+import { BridgeBase }          from '../src/BridgeBase.sol';
+import { Pausable }            from '@openzeppelin/contracts/utils/Pausable.sol';
 import { CommissionManager }   from '../src/CommissionManager.sol';
 import { RouteRegistry }       from '../src/RouteRegistry.sol';
 import { IRouteRegistry }      from '../src/interfaces/IRouteRegistry.sol';
@@ -355,7 +357,7 @@ contract MultisigProxyTest is Test {
     }
 
     function test_execute_revertsOnDisallowedSelector() public {
-        bytes memory callData = abi.encodeWithSignature('pause()');
+        bytes memory callData = abi.encodeWithSignature('pauseInflow()');
         uint256 nonce = 0;
         uint256 deadline = block.timestamp + 1 hours;
 
@@ -434,7 +436,7 @@ contract MultisigProxyTest is Test {
         bytes[]   memory callDatas = new bytes[](1);
         uint256[] memory values    = new uint256[](1);
         targets[0]   = makeAddr('random-target');
-        callDatas[0] = abi.encodeWithSignature('pause()');
+        callDatas[0] = abi.encodeWithSignature('pauseInflow()');
 
         uint256 nonce    = proxy.batchNonce();
         uint256 deadline = block.timestamp + 1 hours;
@@ -627,6 +629,79 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
+    // R-W-05 — two-tier pause (integration via MultisigProxy)
+    // ========================================================================
+
+    /// @dev After R-W-05, the no-timelock emergency pause freezes the OUTFLOW
+    ///      path too — including the enclave/TEE release, which routes through
+    ///      Bridge.fundsOut. A signed fundsOut executed straight after
+    ///      emergencyPause must revert OutflowEnforcedPause, and inbound deposits
+    ///      must be frozen as well.
+    function test_emergencyPause_freezesEnclaveFundsOut() public {
+        // Federation triggers the emergency freeze (both paths).
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 digest   = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
+        (uint256[] memory fpks, uint256 fbitmap) = _fedSigSet2of3();
+        proxy.emergencyPause(nonce, deadline, fbitmap, MultisigHelper.signAll(vm, digest, fpks));
+
+        assertTrue(bridge.paused(),        'inflow frozen');
+        assertTrue(bridge.outflowPaused(), 'outflow frozen');
+
+        // Inbound deposits are frozen.
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
+
+        // Enclave-signed release is frozen too — the revert propagates from
+        // Bridge.fundsOut through proxy.execute.
+        bytes memory callData = _fundsOutCalldata();
+        uint256 encNonce      = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        bytes32 encDigest     = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, encNonce, deadline);
+        (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
+        bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
+
+        vm.expectRevert(BridgeBase.OutflowEnforcedPause.selector);
+        proxy.execute(callData, encNonce, deadline, ebitmap, esigs);
+    }
+
+    /// @dev The planned inflow-only pause runs through the timelocked
+    ///      propose -> execute path and blocks deposits while leaving the
+    ///      enclave release path open (liquidity migration scenario).
+    function test_proposePauseInflow_blocksFundsInButAllowsFundsOut() public {
+        uint256 t = block.timestamp; // read once; derive all timing from it (via_ir-safe)
+
+        // Propose the inflow-only pause (federation signed).
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = t + 1 days;
+        bytes32 digest   = MultisigHelper.digestProposePauseInflow(domainSep, nonce, deadline);
+        (uint256[] memory fpks, uint256 fbitmap) = _fedSigSet2of3();
+        bytes32 id = proxy.proposePauseInflow(nonce, deadline, fbitmap, MultisigHelper.signAll(vm, digest, fpks));
+
+        // Execute it after the timelock (no payload).
+        vm.warp(t + TIMELOCK + 1);
+        proxy.executeProposal(id, '');
+
+        assertTrue(bridge.paused(),         'inflow frozen');
+        assertFalse(bridge.outflowPaused(), 'outflow stays open');
+
+        // Deposits are frozen...
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
+
+        // ...but the enclave release still executes.
+        bytes memory callData = _fundsOutCalldata();
+        uint256 encNonce      = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        bytes32 encDigest     = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, encNonce, t + 1 days);
+        (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
+        bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
+
+        proxy.execute(callData, encNonce, t + 1 days, ebitmap, esigs);
+        assertEq(token.balanceOf(recipient), AMOUNT, 'withdrawal succeeded while inflow paused');
+    }
+
+    // ========================================================================
     // Propose + Execute — UpdateBridge
     // ========================================================================
 
@@ -763,7 +838,7 @@ contract MultisigProxyTest is Test {
     // ========================================================================
 
     function test_proposeAdminExecute_canCallBridge() public {
-        bytes memory callData = abi.encodeWithSignature('pause()');
+        bytes memory callData = abi.encodeWithSignature('pauseInflow()');
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
 

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
 

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -89,7 +89,8 @@ contract MultisigProxyTest is Test {
     address recipient          = makeAddr('recipient');
     address commissionReceiver = makeAddr('commissionReceiver');
 
-    uint256 constant TIMELOCK = 1 hours;
+    uint256 constant TIMELOCK     = 1 hours;
+    uint256 constant MIN_TIMELOCK = 1 hours; // floor passed to the proxy constructor in tests
 
     bytes32 domainSep;
 
@@ -177,7 +178,8 @@ contract MultisigProxyTest is Test {
             enc, 2,
             fed, 2,
             commissionReceiver,
-            TIMELOCK
+            TIMELOCK,
+            MIN_TIMELOCK
         );
 
         // Production-flow ownership transfer.
@@ -256,56 +258,87 @@ contract MultisigProxyTest is Test {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroBridge.selector);
-        new MultisigProxy(address(0), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(0), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommissionManager() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionManager.selector);
-        new MultisigProxy(address(bridge), address(0), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(0), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnNoEnclaveSigners() public {
         address[] memory enc = new address[](0);
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.NoSigners.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnBadEnclaveThreshold() public {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 3, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 3, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommission() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionRecipient.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, address(0), TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, address(0), TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnTimelockTooLong() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.TimelockTooLong.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 30 days);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 30 days, MIN_TIMELOCK);
+    }
+
+    // ---- R-W-11: MIN_TIMELOCK floor (post-fix) ----
+
+    /// @dev UT-FIX-13: deploying with a timelock below the requested floor reverts.
+    function test_constructor_revertsOnTimelockBelowMinTimelock() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        // timelock (1h) is below the requested floor (2h) -> TimelockTooShort
+        vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 1 hours, 2 hours);
+    }
+
+    /// @dev A zero floor is rejected — it would defeat the purpose of the fix.
+    function test_constructor_revertsOnZeroMinTimelock() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, 0);
+    }
+
+    /// @dev A floor at/above the upper bound leaves no valid range — rejected.
+    function test_constructor_revertsOnMinTimelockTooLong() public {
+        address[] memory enc = new address[](1); enc[0] = encA1;
+        address[] memory fed = new address[](1); fed[0] = fedA1;
+        vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, 30 days);
+    }
+
+    function test_minTimelock_returnsConfiguredFloor() public view {
+        assertEq(proxy.MIN_TIMELOCK(), MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnDuplicateSigner() public {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroAddressSigner() public {
         address[] memory enc = new address[](1); enc[0] = address(0);
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     // ========================================================================
@@ -830,6 +863,41 @@ contract MultisigProxyTest is Test {
         emit TimelockDurationUpdated(newDuration);
         proxy.executeProposal(id, abi.encode(newDuration));
 
+        assertEq(proxy.timelockDuration(), newDuration);
+    }
+
+    /// @dev UT-FIX-13: a SetTimelockDuration proposal below the immutable
+    ///      MIN_TIMELOCK floor is rejected at execution; the floor holds.
+    function test_proposeSetTimelockDuration_revertsBelowMinTimelock_afterFix() public {
+        uint256 t           = block.timestamp;
+        uint256 newDuration = MIN_TIMELOCK - 1; // just under the floor
+        uint256 nonce       = proxy.proposalNonce();
+        uint256 deadline    = t + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeSetTimelockDuration(domainSep, newDuration, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes32 id = proxy.proposeSetTimelockDuration(newDuration, nonce, deadline, bitmap, MultisigHelper.signAll(vm, digest, pks));
+
+        vm.warp(t + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
+        proxy.executeProposal(id, abi.encode(newDuration));
+
+        assertEq(proxy.timelockDuration(), TIMELOCK, 'timelock unchanged');
+    }
+
+    /// @dev A value exactly at MIN_TIMELOCK is still accepted (boundary).
+    function test_proposeSetTimelockDuration_acceptsAtMinTimelock_afterFix() public {
+        uint256 t           = block.timestamp;
+        uint256 newDuration = MIN_TIMELOCK; // exactly the floor
+        uint256 nonce       = proxy.proposalNonce();
+        uint256 deadline    = t + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeSetTimelockDuration(domainSep, newDuration, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes32 id = proxy.proposeSetTimelockDuration(newDuration, nonce, deadline, bitmap, MultisigHelper.signAll(vm, digest, pks));
+
+        vm.warp(t + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(newDuration));
         assertEq(proxy.timelockDuration(), newDuration);
     }
 

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -149,7 +149,8 @@ contract MultisigProxyTest is Test {
             address(token),
             address(routeRegistry),
             payable(address(cm)),
-            address(0)
+            address(0),
+            1 // minFundsInAmount: smallest non-zero floor for tests
         );
 
         rgbVerifier = new RGBVerifier(address(btcRelay));
@@ -221,6 +222,20 @@ contract MultisigProxyTest is Test {
         ids[0] = TX_ID;
     }
 
+    /// @dev Valid strict-majority signer sets (2-of-2) used as filler in
+    ///      constructor-revert tests that target a non-threshold revert.
+    function _validEnc() internal view returns (address[] memory a) {
+        a = new address[](2);
+        a[0] = encA1;
+        a[1] = encA2;
+    }
+
+    function _validFed() internal view returns (address[] memory a) {
+        a = new address[](2);
+        a[0] = fedA1;
+        a[1] = fedA2;
+    }
+
     function _fundsOutCalldata() internal view returns (bytes memory) {
         bytes memory proof          = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
         bytes memory settlementData = abi.encode(_fundsInIds());
@@ -283,44 +298,34 @@ contract MultisigProxyTest is Test {
     }
 
     function test_constructor_revertsOnZeroCommission() public {
-        address[] memory enc = new address[](1); enc[0] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionRecipient.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, address(0), TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, address(0), TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnTimelockTooLong() public {
-        address[] memory enc = new address[](1); enc[0] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.TimelockTooLong.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 30 days, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, 30 days, MIN_TIMELOCK);
     }
 
     // ---- R-W-11: MIN_TIMELOCK floor (post-fix) ----
 
     /// @dev UT-FIX-13: deploying with a timelock below the requested floor reverts.
     function test_constructor_revertsOnTimelockBelowMinTimelock() public {
-        address[] memory enc = new address[](1); enc[0] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         // timelock (1h) is below the requested floor (2h) -> TimelockTooShort
         vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 1 hours, 2 hours);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, 1 hours, 2 hours);
     }
 
     /// @dev A zero floor is rejected — it would defeat the purpose of the fix.
     function test_constructor_revertsOnZeroMinTimelock() public {
-        address[] memory enc = new address[](1); enc[0] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, 0);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, TIMELOCK, 0);
     }
 
     /// @dev A floor at/above the upper bound leaves no valid range — rejected.
     function test_constructor_revertsOnMinTimelockTooLong() public {
-        address[] memory enc = new address[](1); enc[0] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, 30 days);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, TIMELOCK, 30 days);
     }
 
     function test_minTimelock_returnsConfiguredFloor() public view {
@@ -328,17 +333,265 @@ contract MultisigProxyTest is Test {
     }
 
     function test_constructor_revertsOnDuplicateSigner() public {
+        // Duplicate enclave signer with an otherwise-valid 2-of-2 threshold, so
+        // the call clears the threshold guard and reverts in _validateSigners.
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroAddressSigner() public {
-        address[] memory enc = new address[](1); enc[0] = address(0);
-        address[] memory fed = new address[](1); fed[0] = fedA1;
+        // Zero-address enclave signer in a 2-signer set with a valid 2-of-2
+        // threshold, so the call clears the threshold guard and reverts in
+        // _validateSigners.
+        address[] memory enc = new address[](2); enc[0] = address(0); enc[1] = encA2;
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    // ========================================================================
+    // Strict-majority signer threshold floor (R-W-12 / UT-FIX-14)
+    //
+    // Both signer sets, at construction and on signer-update, must be a strict
+    // majority of at least 2 signers: n >= 2, threshold >= 2, threshold <= n,
+    // 2*threshold > n. Rejects 1-of-N, the degenerate 1-of-1, and sub-majority
+    // quorums; the smallest valid sets are 2-of-2 and 2-of-3. Signer-update
+    // validation runs at executeProposal time (in _executeByType), so the bad
+    // proposal is created successfully and reverts only on execution.
+    // ========================================================================
+
+    /// @dev Build an n-element signer array from a seed (distinct non-zero addrs).
+    function _signers(uint256 n) internal pure returns (address[] memory a) {
+        a = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            a[i] = address(uint160(0xA000 + i));
+        }
+    }
+
+    /// @dev A second n-element signer array disjoint from `_signers` — used as
+    ///      the counterpart set so the two trust domains do not overlap.
+    function _signersB(uint256 n) internal pure returns (address[] memory a) {
+        a = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            a[i] = address(uint160(0xB000 + i));
+        }
+    }
+
+    // ---- Constructor ----
+
+    function test_constructor_rejectsOneOfThree_enclave() public {
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        new MultisigProxy(address(bridge), address(cm), _signers(3), 1, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    function test_constructor_rejectsOneOfOne_enclave() public {
+        // n < 2 — single-key set, rejected even though 2*1 > 1.
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        new MultisigProxy(address(bridge), address(cm), _signers(1), 1, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    function test_constructor_rejectsSubMajority_enclave() public {
+        // 2-of-4: 2*2 == 4, not a strict majority.
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        new MultisigProxy(address(bridge), address(cm), _signers(4), 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    function test_constructor_rejectsOneOfThree_federation() public {
+        // Enclave valid, federation 1-of-3 — the floor applies to both sets.
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _signers(3), 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    function test_constructor_acceptsTwoOfTwo() public {
+        MultisigProxy p = new MultisigProxy(
+            address(bridge), address(cm), _signers(2), 2, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+        );
+        assertEq(p.enclaveThreshold(),    2);
+        assertEq(p.federationThreshold(), 2);
+    }
+
+    function test_constructor_acceptsThreeOfFour() public {
+        // Strict majority with a non-trivial set (2*3 > 4).
+        MultisigProxy p = new MultisigProxy(
+            address(bridge), address(cm), _signers(4), 3, _signersB(4), 3, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+        );
+        assertEq(p.enclaveThreshold(),    3);
+        assertEq(p.federationThreshold(), 3);
+    }
+
+    // ---- Signer update (validated at executeProposal) ----
+
+    function test_proposeUpdateEnclaveSigners_rejectsOneOfNAtExecute() public {
+        address[] memory newSigners = _signers(3);
+        uint256 badThreshold = 1; // 1-of-3
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, newSigners, badThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        // Propose succeeds — threshold validity is enforced on execution.
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, badThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        proxy.executeProposal(id, abi.encode(newSigners, badThreshold));
+    }
+
+    function test_proposeUpdateFederationSigners_rejectsSubMajorityAtExecute() public {
+        address[] memory newSigners = _signers(4);
+        uint256 badThreshold = 2; // 2-of-4, sub-majority
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(
+            domainSep, newSigners, badThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateFederationSigners(newSigners, badThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        proxy.executeProposal(id, abi.encode(newSigners, badThreshold));
+    }
+
+    function test_proposeUpdateFederationSigners_acceptsStrictMajority() public {
+        address[] memory newSigners = _signers(3);
+        uint256 newThreshold = 2; // 2-of-3
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(
+            domainSep, newSigners, newThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateFederationSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        assertEq(proxy.federationThreshold(), 2);
+        assertEq(proxy.getFederationSigners().length, 3);
+    }
+
+    // ========================================================================
+    // Disjoint signer sets (R-W-14 / UT-FIX-16)
+    //
+    // The enclave and federation sets must not share an address, at construction
+    // and on signer-update (validated at executeProposal). The setUp sets are
+    // already disjoint (encA* vs fedA*).
+    // ========================================================================
+
+    function test_constructor_rejectsOverlappingSignerSets() public {
+        // encA1 is present in both the enclave and the federation set.
+        address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
+        address[] memory fed = new address[](2); fed[0] = encA1; fed[1] = fedA2;
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, encA1));
+        new MultisigProxy(address(bridge), address(cm), enc, 2, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    function test_constructor_acceptsDisjointSignerSets() public {
+        MultisigProxy p = new MultisigProxy(
+            address(bridge), address(cm), _signers(2), 2, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+        );
+        assertEq(p.getEnclaveSigners().length,    2);
+        assertEq(p.getFederationSigners().length, 2);
+    }
+
+    function test_proposeUpdateEnclaveSigners_rejectsOverlapWithFederationAtExecute() public {
+        // New enclave set includes fedA1, a current federation signer.
+        address[] memory newSigners = new address[](2); newSigners[0] = fedA1; newSigners[1] = encA2;
+        uint256 newThreshold = 2;
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, newSigners, newThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, fedA1));
+        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+    }
+
+    function test_proposeUpdateFederationSigners_rejectsOverlapWithEnclaveAtExecute() public {
+        // New federation set includes encA1, a current enclave signer.
+        address[] memory newSigners = new address[](2); newSigners[0] = encA1; newSigners[1] = fedA2;
+        uint256 newThreshold = 2;
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(
+            domainSep, newSigners, newThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateFederationSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, encA1));
+        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+    }
+
+    // ========================================================================
+    // Signer-set size cap (R-I-06 / UT-FIX-27)
+    //
+    // Either set is capped at MAX_SIGNERS, at construction and on signer-update
+    // (validated in _validateSigners at executeProposal). The cap bounds the
+    // O(N^2) scan and keeps every index within the uint256 signature bitmap.
+    // ========================================================================
+
+    function test_constructor_rejectsTooManySigners() public {
+        uint256 max = proxy.MAX_SIGNERS();
+        address[] memory enc = _signers(max + 1); // 21 distinct enclave signers
+        uint256 encThreshold = (max + 1) / 2 + 1; // strict majority, so it clears the threshold guard
+
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
+        new MultisigProxy(
+            address(bridge), address(cm), enc, encThreshold, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+        );
+    }
+
+    function test_constructor_acceptsSignersAtMax() public {
+        uint256 max = proxy.MAX_SIGNERS();
+        uint256 threshold = max / 2 + 1; // 11-of-20 strict majority
+
+        MultisigProxy p = new MultisigProxy(
+            address(bridge), address(cm), _signers(max), threshold, _signersB(max), threshold, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+        );
+        assertEq(p.getEnclaveSigners().length,    max);
+        assertEq(p.getFederationSigners().length, max);
+    }
+
+    function test_proposeUpdateEnclaveSigners_rejectsTooManySignersAtExecute() public {
+        uint256 max = proxy.MAX_SIGNERS();
+        address[] memory newSigners = _signers(max + 1);
+        uint256 newThreshold = (max + 1) / 2 + 1; // valid strict majority
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, newSigners, newThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
+        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
     }
 
     // ========================================================================
@@ -374,6 +627,68 @@ contract MultisigProxyTest is Test {
 
         vm.expectRevert(IMultisigProxy.Expired.selector);
         proxy.execute(callData, nonce, deadline, bitmap, sigs);
+    }
+
+    // ========================================================================
+    // TEE deadline upper bound (R-I-01 / UT-FIX-23)
+    //
+    // execute / executeBatch reject a signed deadline further than
+    // MAX_TEE_DEADLINE into the future, so a leaked or pre-signed payload cannot
+    // stay executable indefinitely. The boundary (exactly now + MAX_TEE_DEADLINE)
+    // is still accepted — the guard is a strict `>`.
+    // ========================================================================
+
+    function test_execute_revertsOnDeadlineTooFar() public {
+        bytes memory callData = _fundsOutCalldata();
+        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE() + 1;
+
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.DeadlineTooFar.selector);
+        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_execute_acceptsDeadlineAtMaxBoundary() public {
+        bytes memory callData = _fundsOutCalldata();
+        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE(); // exact boundary, strict `>` lets it through
+
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+        assertEq(token.balanceOf(recipient), AMOUNT, 'executes at the exact deadline ceiling');
+    }
+
+    function test_executeBatch_revertsOnDeadlineTooFar() public {
+        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
+        uint256 nonce    = proxy.batchNonce();
+        uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE() + 1;
+
+        bytes32 digest = MultisigHelper.digestBridgeBatchOp(domainSep, targets, callDatas, values, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.DeadlineTooFar.selector);
+        proxy.executeBatch(targets, callDatas, values, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_executeBatch_acceptsDeadlineAtMaxBoundary() public {
+        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
+        uint256 nonce    = proxy.batchNonce();
+        uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE(); // exact boundary
+
+        bytes32 digest = MultisigHelper.digestBridgeBatchOp(domainSep, targets, callDatas, values, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        proxy.executeBatch(targets, callDatas, values, nonce, deadline, bitmap, sigs);
+        assertEq(token.balanceOf(recipient), AMOUNT,    'batch executes at the exact deadline ceiling');
+        assertEq(proxy.batchNonce(),         nonce + 1, 'batchNonce incremented');
     }
 
     function test_execute_revertsOnWrongNonce() public {
@@ -783,6 +1098,55 @@ contract MultisigProxyTest is Test {
 
         vm.expectRevert(IMultisigProxy.DeadlineTooFar.selector);
         proxy.proposeUpdateBridge(makeAddr('nb'), nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeUpdateBridge_revertsOnDeadlineBeforeTimelock() public {
+        uint256 nonce    = proxy.proposalNonce();
+        // One second short of the timelock window → dead on arrival.
+        uint256 deadline = block.timestamp + proxy.timelockDuration() - 1;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateBridge(domainSep, makeAddr('nb'), nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.DeadlineBeforeTimelock.selector);
+        proxy.proposeUpdateBridge(makeAddr('nb'), nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeUpdateBridge_acceptsDeadlineAtTimelockBoundary() public {
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + proxy.timelockDuration(); // exact boundary, `==` allowed
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateBridge(domainSep, makeAddr('nb'), nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 proposalId = proxy.proposeUpdateBridge(makeAddr('nb'), nonce, deadline, bitmap, sigs);
+        assertEq(
+            uint8(proxy.getProposal(proposalId).status),
+            uint8(IMultisigProxy.ProposalStatus.Pending),
+            'proposal at the exact boundary is created'
+        );
+    }
+
+    function test_proposeUpdateBridge_executableAtTimelockBoundary() public {
+        address newBridge = makeAddr('boundaryBridge');
+        uint256 nonce     = proxy.proposalNonce();
+        uint256 timelock  = proxy.timelockDuration();
+        uint256 deadline  = block.timestamp + timelock; // deadline == proposedAt + timelock
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 proposalId = proxy.proposeUpdateBridge(newBridge, nonce, deadline, bitmap, sigs);
+
+        // Execute at the single instant where block.timestamp == proposedAt +
+        // timelock == deadline: timelock has just elapsed and the deadline has
+        // not yet passed (both checks use strict comparisons).
+        vm.warp(block.timestamp + timelock);
+        proxy.executeProposal(proposalId, abi.encode(newBridge));
+        assertEq(proxy.bridge(), newBridge, 'boundary proposal executes at the exact instant');
     }
 
     // ========================================================================

--- a/ethereum/test/RgbSettlementModule.t.sol
+++ b/ethereum/test/RgbSettlementModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test }                from 'forge-std/Test.sol';
 import { RgbSettlementModule } from '../src/settlement/RgbSettlementModule.sol';

--- a/ethereum/test/RouteRegistry.t.sol
+++ b/ethereum/test/RouteRegistry.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test }    from 'forge-std/Test.sol';
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';

--- a/ethereum/test/mocks/MockAggregatorV3.sol
+++ b/ethereum/test/mocks/MockAggregatorV3.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { AggregatorV3Interface } from '@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol';
 

--- a/ethereum/test/mocks/MockAggregatorV3.sol
+++ b/ethereum/test/mocks/MockAggregatorV3.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.35;
 
-import { AggregatorV3Interface } from '@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol';
+import { AggregatorV3Interface } from '../../src/interfaces/AggregatorV3Interface.sol';
 
 /// @title MockAggregatorV3
 /// @notice Minimal Chainlink-compatible price feed for tests. Lets each test

--- a/ethereum/test/mocks/MockBtcRelay.sol
+++ b/ethereum/test/mocks/MockBtcRelay.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IBtcRelayView } from '../../src/interfaces/IBtcRelayView.sol';
 

--- a/ethereum/test/mocks/MockERC20.sol
+++ b/ethereum/test/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { ERC20 } from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 

--- a/ethereum/test/mocks/MockFinalityVerifier.sol
+++ b/ethereum/test/mocks/MockFinalityVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { IFinalityVerifier } from '../../src/interfaces/IFinalityVerifier.sol';
 import { FundsOutContext }   from '../../src/interfaces/RouteTypes.sol';

--- a/ethereum/test/mocks/MockSettlementModule.sol
+++ b/ethereum/test/mocks/MockSettlementModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { ISettlementModule } from '../../src/interfaces/ISettlementModule.sol';
 import { FundsInContext, FundsOutContext } from '../../src/interfaces/RouteTypes.sol';

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Vm } from 'forge-std/Vm.sol';
 

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -26,6 +26,14 @@ library MultisigHelper {
         'EmergencyUnpause(uint256 nonce,uint256 deadline)'
     );
 
+    bytes32 internal constant PROPOSE_PAUSE_INFLOW_TYPEHASH = keccak256(
+        'ProposePauseInflow(uint256 nonce,uint256 deadline)'
+    );
+
+    bytes32 internal constant PROPOSE_UNPAUSE_INFLOW_TYPEHASH = keccak256(
+        'ProposeUnpauseInflow(uint256 nonce,uint256 deadline)'
+    );
+
     bytes32 internal constant PROPOSE_ADMIN_EXECUTE_TYPEHASH = keccak256(
         'ProposeAdminExecute(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
     );
@@ -159,6 +167,14 @@ library MultisigHelper {
 
     function digestEmergencyUnpause(bytes32 domainSep, uint256 nonce, uint256 deadline) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(EMERGENCY_UNPAUSE_TYPEHASH, nonce, deadline)));
+    }
+
+    function digestProposePauseInflow(bytes32 domainSep, uint256 nonce, uint256 deadline) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(PROPOSE_PAUSE_INFLOW_TYPEHASH, nonce, deadline)));
+    }
+
+    function digestProposeUnpauseInflow(bytes32 domainSep, uint256 nonce, uint256 deadline) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(PROPOSE_UNPAUSE_INFLOW_TYPEHASH, nonce, deadline)));
     }
 
     function digestProposeAdminExecute(


### PR DESCRIPTION
## test(R-W-11): MIN_TIMELOCK floor regression tests

Companion test PR for the **R-W-11 / EXT-W-11** fix (branch `multisig-timelock-duration-fix`). Stacked on the fix branch.

### Added — post-fix regression
- `test_constructor_revertsOnTimelockBelowMinTimelock` (**UT-FIX-13**) — deploying with `timelockDuration < minTimelock` reverts `TimelockTooShort`.
- `test_constructor_revertsOnZeroMinTimelock` / `test_constructor_revertsOnMinTimelockTooLong` — `InvalidMinTimelock` for a zero or out-of-range floor.
- `test_proposeSetTimelockDuration_revertsBelowMinTimelock_afterFix` (**UT-FIX-13**) — a `SetTimelockDuration` proposal below the floor reverts at execution; `timelockDuration` is unchanged.
- `test_proposeSetTimelockDuration_acceptsAtMinTimelock_afterFix` — boundary: a value exactly at the floor is accepted.
- `test_minTimelock_returnsConfiguredFloor` — the `MIN_TIMELOCK()` view.