### PR TITLE
test: add rollback coverage for COV-UT-06..09

### DIFF
--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -20,6 +20,7 @@ import {
 import { MockERC20 }        from './mocks/MockERC20.sol';
 import { MockBtcRelay }     from './mocks/MockBtcRelay.sol';
 import { MockAggregatorV3 } from './mocks/MockAggregatorV3.sol';
+import { MockSettlementModule } from './mocks/MockSettlementModule.sol';
 
 import { Ownable }   from '@openzeppelin/contracts/access/Ownable.sol';
 import { Pausable }  from '@openzeppelin/contracts/utils/Pausable.sol';
@@ -1024,5 +1025,199 @@ contract BridgeTest is Test {
             releaseAmount,
             'gross fundsOut conserved'
         );
+    }
+
+    // ========================================================================
+    // fundsIn — rollback snapshots
+    // ========================================================================
+
+    function test_fundsIn_routeModuleRevertRollsBackTokenPullAndEvents() public {
+        MockSettlementModule revertingModule = new MockSettlementModule();
+        revertingModule.setShouldRevertOnFundsIn(true);
+
+        // Route is intentionally rewired to a module that reverts after Bridge
+        // has already pulled tokens and before commission forwarding can run.
+        vm.prank(deployer);
+        routeRegistry.setRoute(
+            SOURCE_CHAIN_ID,
+            RGB_CHAIN_ID,
+            true,
+            address(rgbVerifier),
+            address(revertingModule)
+        );
+
+        uint256 userBefore       = usdt0.balanceOf(user);
+        uint256 bridgeBefore     = usdt0.balanceOf(address(bridge));
+        uint256 cmBefore         = usdt0.balanceOf(address(cm));
+        uint256 cmPoolBefore     = cm.tokenCommissionPool(address(usdt0));
+        uint256 nativePoolBefore = cm.nativeCommissionPool();
+        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+
+        assertEq(bridgeBefore, 0, 'pre bridge token');
+        assertEq(cmBefore,     0, 'pre cm token');
+        assertEq(cmPoolBefore, 0, 'pre cm pool');
+        assertEq(recordBefore, 0, 'pre rgb record');
+        assertEq(revertingModule.onFundsInCount(), 0, 'pre module calls');
+
+        // Bridge emits FundsIn/BridgeFundsIn only after route dispatch, so this
+        // module revert prevents successful Bridge events from persisting.
+        vm.expectRevert(MockSettlementModule.MockModuleForcedRevert.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertEq(usdt0.balanceOf(user),            userBefore,       'user token unchanged');
+        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore,     'bridge token unchanged');
+        assertEq(usdt0.balanceOf(address(cm)),     cmBefore,         'cm token unchanged');
+        assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
+        assertEq(cm.nativeCommissionPool(),        nativePoolBefore, 'native pool unchanged');
+        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore,     'rgb record unchanged');
+        assertEq(revertingModule.onFundsInCount(), 0,                'module state unchanged');
+    }
+
+    function test_fundsIn_commissionForwardingRevertRollsBackSettlementRecord() public {
+        uint256 percent = 400; // 4%
+        _setFundsInTokenRule(percent);
+
+        (uint256 tokenCommission,, uint256 netAmount) =
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
+        assertGt(tokenCommission, 0, 'token fee quoted');
+        assertLt(netAmount, AMOUNT, 'net below gross');
+
+        // Misconfigure only the CM bridge guard so the route/RGB write happens
+        // before commission forwarding fails in receiveTokenCommission().
+        vm.prank(deployer);
+        cm.setBridgeAddress(makeAddr('wrong-bridge'));
+
+        uint256 userBefore       = usdt0.balanceOf(user);
+        uint256 bridgeBefore     = usdt0.balanceOf(address(bridge));
+        uint256 cmBefore         = usdt0.balanceOf(address(cm));
+        uint256 cmPoolBefore     = cm.tokenCommissionPool(address(usdt0));
+        uint256 nativePoolBefore = cm.nativeCommissionPool();
+        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+
+        assertEq(bridgeBefore, 0, 'pre bridge token');
+        assertEq(cmBefore,     0, 'pre cm token');
+        assertEq(cmPoolBefore, 0, 'pre cm pool');
+        assertEq(recordBefore, 0, 'pre rgb record');
+
+        // FundsIn/BridgeFundsIn emit after commission forwarding, so this
+        // late revert prevents successful Bridge events from persisting.
+        vm.expectRevert(ICommissionManager.OnlyBridge.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertEq(usdt0.balanceOf(user),            userBefore,       'user token unchanged');
+        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore,     'bridge token unchanged');
+        assertEq(usdt0.balanceOf(address(cm)),     cmBefore,         'cm token unchanged');
+        assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
+        assertEq(cm.nativeCommissionPool(),        nativePoolBefore, 'native pool unchanged');
+        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore,     'rgb record unchanged');
+    }
+
+    // ========================================================================
+    // fundsOut — rollback snapshots
+    // ========================================================================
+
+    function test_fundsOut_verifierRevertRollsBackBurnIdAndRecords() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        bytes memory badProof = abi.encode(uint256(999_999), keccak256('unknown-block'));
+
+        uint256 bridgeBefore     = usdt0.balanceOf(address(bridge));
+        uint256 recipientBefore  = usdt0.balanceOf(recipient);
+        uint256 cmBefore         = usdt0.balanceOf(address(cm));
+        uint256 cmPoolBefore     = cm.tokenCommissionPool(address(usdt0));
+        uint256 nativePoolBefore = cm.nativeCommissionPool();
+        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+
+        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertEq(bridgeBefore, AMOUNT, 'pre bridge pool');
+        assertEq(recipientBefore, 0, 'pre recipient token');
+        assertEq(cmBefore, 0, 'pre cm token');
+        assertEq(cmPoolBefore, 0, 'pre cm pool');
+        assertEq(nativePoolBefore, 0, 'pre native pool');
+        assertEq(recordBefore, AMOUNT, 'pre rgb record');
+
+        // fundsOut marks the burn id before verifier dispatch. This verifier
+        // failure rolls that mark back and short-circuits before RGB records
+        // can be consumed.
+        vm.expectRevert('verify: block commitment');
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient,
+            AMOUNT,
+            BURN_ID,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            badProof,
+            _settlement(_singleFundsInId())
+        );
+
+        assertFalse(bridge.consumedBurnIds(BURN_ID), 'burn id unchanged');
+        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, 'bridge token unchanged');
+        assertEq(usdt0.balanceOf(recipient),       recipientBefore, 'recipient token unchanged');
+        assertEq(usdt0.balanceOf(address(cm)),     cmBefore, 'cm token unchanged');
+        assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
+        assertEq(cm.nativeCommissionPool(),        nativePoolBefore, 'native pool unchanged');
+        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore, 'rgb record unchanged');
+    }
+
+    function test_fundsOut_settlementRevertRollsBackBurnIdAndRecords() public {
+        uint256 txId1 = 100;
+        uint256 txId2 = 101;
+        uint256 amount1 = 50e18;
+        uint256 amount2 = 50e18;
+        uint256 releaseAmount = 60e18;
+
+        vm.prank(user);
+        bridge.fundsIn(amount1, RGB_CHAIN_ID, DST_ADDR, txId1, '');
+        vm.prank(user);
+        bridge.fundsIn(amount2, RGB_CHAIN_ID, DST_ADDR, txId2, '');
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = txId1;
+
+        uint256 bridgeBefore     = usdt0.balanceOf(address(bridge));
+        uint256 recipientBefore  = usdt0.balanceOf(recipient);
+        uint256 cmBefore         = usdt0.balanceOf(address(cm));
+        uint256 cmPoolBefore     = cm.tokenCommissionPool(address(usdt0));
+        uint256 nativePoolBefore = cm.nativeCommissionPool();
+        uint256 record1Before    = rgbModule.fundsInRecords(txId1);
+        uint256 record2Before    = rgbModule.fundsInRecords(txId2);
+
+        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertEq(bridgeBefore, amount1 + amount2, 'pre bridge pool');
+        assertEq(recipientBefore, 0, 'pre recipient token');
+        assertEq(cmBefore, 0, 'pre cm token');
+        assertEq(cmPoolBefore, 0, 'pre cm pool');
+        assertEq(nativePoolBefore, 0, 'pre native pool');
+        assertEq(record1Before, amount1, 'pre record 1');
+        assertEq(record2Before, amount2, 'pre record 2');
+
+        // The first record is deleted before the module discovers the release
+        // is underfunded; the revert must restore that consumed record too.
+        vm.expectRevert(RgbSettlementModule.FundsOutAmountExceedsFundsIn.selector);
+        vm.prank(multisig);
+        bridge.fundsOut(
+            recipient,
+            releaseAmount,
+            BURN_ID,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            _proof(),
+            _settlement(ids)
+        );
+
+        assertFalse(bridge.consumedBurnIds(BURN_ID), 'burn id unchanged');
+        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, 'bridge token unchanged');
+        assertEq(usdt0.balanceOf(recipient),       recipientBefore, 'recipient token unchanged');
+        assertEq(usdt0.balanceOf(address(cm)),     cmBefore, 'cm token unchanged');
+        assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
+        assertEq(cm.nativeCommissionPool(),        nativePoolBefore, 'native pool unchanged');
+        assertEq(rgbModule.fundsInRecords(txId1),  record1Before, 'record 1 rolled back');
+        assertEq(rgbModule.fundsInRecords(txId2),  record2Before, 'record 2 unchanged');
     }
 }

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -28,6 +28,7 @@ contract MockOutboundLZAdapter {
     address   public immutable oft;
     address   public immutable multisigProxy;
     uint256   public immutable nativeFee;
+    uint256   public sendOutCalls;
 
     event SendOut(bytes32 indexed guid, uint32 dstEid, bytes32 recipient, uint256 amountLD);
 
@@ -51,6 +52,7 @@ contract MockOutboundLZAdapter {
         require(recipient != bytes32(0), 'zero recipient');
         require(minAmountLD <= amount, 'min too high');
 
+        sendOutCalls++;
         token.transfer(oft, amount);
         (bool ok, ) = oft.call{ value: msg.value }('');
         require(ok, 'oft fee');
@@ -1569,5 +1571,229 @@ contract MultisigProxyTest is Test {
             AMOUNT,
             'gross batch payout conserved'
         );
+    }
+
+    // Batch rollback coverage for Bridge fundsOut followed by an outbound adapter send.
+    // Real UtexoLZAdapter insufficient-fee rollback belongs in a cross-repo integration test.
+    function test_executeBatch_sendOutInsufficientNativeFee_rollsBackBridgeState() public {
+        uint256 percent = 500; // 5%
+        vm.prank(address(proxy));
+        cm.setCommissionRule(
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            address(token),
+            CommissionConfig({
+                stablePercent: percent,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_OUT,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount) =
+            cm.calculateFundsOutCommission(RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token), AMOUNT);
+        assertGt(tokenCommission, 0, 'token fee quoted');
+        assertEq(nativeCommission, 0, 'native fee is zero');
+
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        bytes4 sendOutSelector = MockOutboundLZAdapter.sendOut.selector;
+        _allowTeeCall(address(adapter), sendOutSelector);
+
+        bytes memory bridgeCallData = _fundsOutCalldata(address(adapter), AMOUNT, BURN_ID);
+        bytes memory adapterCallData = abi.encodeWithSelector(
+            sendOutSelector,
+            DST_EID,
+            LZ_RECIPIENT,
+            netAmount,
+            netAmount,
+            hex'0003010011010000000000000000000000000000ea60'
+        );
+
+        address[] memory targets = new address[](2);
+        bytes[] memory callDatas = new bytes[](2);
+        uint256[] memory values = new uint256[](2);
+        targets[0] = address(bridge);
+        targets[1] = address(adapter);
+        callDatas[0] = bridgeCallData;
+        callDatas[1] = adapterCallData;
+        values[0] = 0;
+        values[1] = LZ_NATIVE_FEE - 1;
+
+        uint256 nonce = proxy.batchNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
+            domainSep, targets, callDatas, values, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        // Snapshot all state touched by the first Bridge leg and the failed adapter leg.
+        uint256 bridgeBefore     = token.balanceOf(address(bridge));
+        uint256 adapterBefore    = token.balanceOf(address(adapter));
+        uint256 oftBefore        = token.balanceOf(mockOft);
+        uint256 cmBefore         = token.balanceOf(address(cm));
+        uint256 cmPoolBefore     = cm.tokenCommissionPool(address(token));
+        uint256 nativePoolBefore = cm.nativeCommissionPool();
+        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+        uint256 proxyEthBefore   = address(proxy).balance;
+        uint256 adapterEthBefore = address(adapter).balance;
+        uint256 oftEthBefore     = mockOft.balance;
+
+        assertEq(bridgeBefore,     AMOUNT * 5, 'pre bridge pool');
+        assertEq(adapterBefore,    0,          'pre adapter token');
+        assertEq(oftBefore,        0,          'pre oft token');
+        assertEq(cmBefore,         0,          'pre cm token');
+        assertEq(cmPoolBefore,     0,          'pre cm pool');
+        assertEq(nativePoolBefore, 0,          'pre native pool');
+        assertEq(recordBefore,     AMOUNT * 5, 'pre record');
+        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+
+        // msg.value matches the batch values sum, so the revert happens in sendOut,
+        // after Bridge.fundsOut already ran inside the same batch transaction.
+        vm.deal(address(this), LZ_NATIVE_FEE - 1);
+        vm.expectRevert(bytes('native fee'));
+        proxy.executeBatch{ value: LZ_NATIVE_FEE - 1 }(
+            targets,
+            callDatas,
+            values,
+            nonce,
+            deadline,
+            bitmap,
+            sigs
+        );
+
+        assertEq(proxy.batchNonce(),              nonce,            'batch nonce unchanged');
+        assertFalse(bridge.consumedBurnIds(BURN_ID),                'burn id unchanged');
+        assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
+        assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter token unchanged');
+        assertEq(token.balanceOf(mockOft),          oftBefore,      'oft token unchanged');
+        assertEq(token.balanceOf(address(cm)),      cmBefore,       'cm token unchanged');
+        assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore, 'cm pool unchanged');
+        assertEq(cm.nativeCommissionPool(),         nativePoolBefore,  'native pool unchanged');
+        assertEq(rgbModule.fundsInRecords(TX_ID),   recordBefore,      'record unchanged');
+        assertEq(address(proxy).balance,            proxyEthBefore,    'proxy native unchanged');
+        assertEq(address(adapter).balance,          adapterEthBefore,  'adapter native unchanged');
+        assertEq(mockOft.balance,                   oftEthBefore,      'oft native unchanged');
+    }
+
+    // Batch rollback coverage when the Bridge fundsOut leg fails before adapter send.
+    // Real UtexoLZAdapter call-skipping coverage belongs in a cross-repo integration test.
+    function test_executeBatch_bridgeVerifierFailure_doesNotCallAdapter() public {
+        uint256 percent = 500; // 5%
+        vm.prank(address(proxy));
+        cm.setCommissionRule(
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            address(token),
+            CommissionConfig({
+                stablePercent: percent,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_OUT,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount) =
+            cm.calculateFundsOutCommission(RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token), AMOUNT);
+        assertGt(tokenCommission, 0, 'token fee quoted');
+        assertEq(nativeCommission, 0, 'native fee is zero');
+
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        bytes4 sendOutSelector = MockOutboundLZAdapter.sendOut.selector;
+        _allowTeeCall(address(adapter), sendOutSelector);
+
+        bytes memory badProof = abi.encode(uint256(999_999), keccak256('unknown-block'));
+        bytes memory settlementData = abi.encode(_fundsInIds());
+        bytes memory bridgeCallData = abi.encodeWithSelector(
+            FUNDS_OUT_SELECTOR,
+            address(adapter),
+            AMOUNT,
+            BURN_ID,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            badProof,
+            settlementData
+        );
+        bytes memory adapterCallData = abi.encodeWithSelector(
+            sendOutSelector,
+            DST_EID,
+            LZ_RECIPIENT,
+            netAmount,
+            netAmount,
+            hex'0003010011010000000000000000000000000000ea60'
+        );
+
+        address[] memory targets = new address[](2);
+        bytes[] memory callDatas = new bytes[](2);
+        uint256[] memory values = new uint256[](2);
+        targets[0] = address(bridge);
+        targets[1] = address(adapter);
+        callDatas[0] = bridgeCallData;
+        callDatas[1] = adapterCallData;
+        values[0] = 0;
+        values[1] = LZ_NATIVE_FEE;
+
+        uint256 nonce = proxy.batchNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
+            domainSep, targets, callDatas, values, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        // The adapter call is valid and funded; only the Bridge verifier failure should stop dispatch.
+        uint256 bridgeBefore     = token.balanceOf(address(bridge));
+        uint256 adapterBefore    = token.balanceOf(address(adapter));
+        uint256 oftBefore        = token.balanceOf(mockOft);
+        uint256 cmBefore         = token.balanceOf(address(cm));
+        uint256 cmPoolBefore     = cm.tokenCommissionPool(address(token));
+        uint256 nativePoolBefore = cm.nativeCommissionPool();
+        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+        uint256 proxyEthBefore   = address(proxy).balance;
+        uint256 adapterEthBefore = address(adapter).balance;
+        uint256 oftEthBefore     = mockOft.balance;
+
+        assertEq(bridgeBefore,     AMOUNT * 5, 'pre bridge pool');
+        assertEq(adapterBefore,    0,          'pre adapter token');
+        assertEq(oftBefore,        0,          'pre oft token');
+        assertEq(cmBefore,         0,          'pre cm token');
+        assertEq(cmPoolBefore,     0,          'pre cm pool');
+        assertEq(nativePoolBefore, 0,          'pre native pool');
+        assertEq(recordBefore,     AMOUNT * 5, 'pre record');
+        assertEq(adapter.sendOutCalls(), 0,    'pre adapter calls');
+        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        vm.expectRevert(bytes('verify: block commitment'));
+        proxy.executeBatch{ value: LZ_NATIVE_FEE }(
+            targets,
+            callDatas,
+            values,
+            nonce,
+            deadline,
+            bitmap,
+            sigs
+        );
+
+        assertEq(proxy.batchNonce(),              nonce,            'batch nonce unchanged');
+        assertFalse(bridge.consumedBurnIds(BURN_ID),                'burn id unchanged');
+        assertEq(adapter.sendOutCalls(),           0,               'adapter not called');
+        assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
+        assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter token unchanged');
+        assertEq(token.balanceOf(mockOft),          oftBefore,      'oft token unchanged');
+        assertEq(token.balanceOf(address(cm)),      cmBefore,       'cm token unchanged');
+        assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore, 'cm pool unchanged');
+        assertEq(cm.nativeCommissionPool(),         nativePoolBefore,  'native pool unchanged');
+        assertEq(rgbModule.fundsInRecords(TX_ID),   recordBefore,      'record unchanged');
+        assertEq(address(proxy).balance,            proxyEthBefore,    'proxy native unchanged');
+        assertEq(address(adapter).balance,          adapterEthBefore,  'adapter native unchanged');
+        assertEq(mockOft.balance,                   oftEthBefore,      'oft native unchanged');
     }
 }


### PR DESCRIPTION
## Summary

Adds rollback-focused security tests for `fundsIn`, `fundsOut`, and batched Bridge + adapter execution.

Covered audit test IDs:
- COV-UT-06
- COV-UT-07
- COV-UT-08
- COV-UT-09

## What changed

- Added `fundsIn` rollback coverage when route/module execution reverts.
- Added `fundsIn` rollback coverage when commission forwarding fails after settlement bookkeeping.
- Added `fundsOut` rollback coverage when verifier/settlement checks revert after `burnId` is marked.
- Added `executeBatch` rollback coverage when adapter `sendOut` fails after the Bridge leg succeeds.

## Validation

- New tests were added only to existing Foundry test suites.
- The tests assert pre/post state for balances, records, commission pools, and replay guards.