### PR TITLE
test: add pre-fix reproduction coverage for UT-MISS-01, UT-MISS-02, UT-MISS-03, UT-MISS-05, UT-MISS-09

### DIFF
--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -1220,4 +1220,72 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(txId1),  record1Before, 'record 1 rolled back');
         assertEq(rgbModule.fundsInRecords(txId2),  record2Before, 'record 2 unchanged');
     }
+
+    // Current behavior reproduction
+    // ========================================================================
+
+    function test_fundsOutAcceptsProofNotBoundToReleaseContext_currentBehavior() public {
+        address alternateRecipient = makeAddr('alternateRecipient');
+        uint256 releaseAmount = 37e18;
+        uint256 alternateBurnId = BURN_ID + 777;
+        uint256 alternateSourceChainId = RGB_CHAIN_ID + 77;
+        uint256 alternateDestinationChainId = SOURCE_CHAIN_ID + 77;
+        string memory alternateSourceAddress = 'rgb:unbound/source/utxo999';
+
+        vm.prank(deployer);
+        routeRegistry.setRoute(
+            alternateSourceChainId,
+            alternateDestinationChainId,
+            true,
+            address(rgbVerifier),
+            address(rgbModule)
+        );
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
+        uint256 recipientBefore = usdt0.balanceOf(alternateRecipient);
+        uint256 recordBefore = rgbModule.fundsInRecords(TX_ID);
+
+        assertEq(bridgeBefore, AMOUNT, 'pre bridge pool');
+        assertEq(recipientBefore, 0, 'pre recipient token');
+        assertEq(recordBefore, AMOUNT, 'pre record');
+        assertFalse(bridge.consumedBurnIds(alternateBurnId), 'pre burn id');
+
+        // Current behavior: this is still an authorized fundsOut call, but the
+        // RGBVerifier checks only the encoded BTC block commitment proof. The
+        // record was created on the default route and is consumed on this
+        // alternate enabled route because the proof is not bound to release
+        // context on-chain. If that binding is enforced later, invert this to
+        // expect a revert.
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit BridgeFundsOut(
+            alternateRecipient,
+            releaseAmount,
+            releaseAmount,
+            0,
+            alternateBurnId,
+            alternateSourceChainId,
+            alternateDestinationChainId,
+            alternateSourceAddress
+        );
+
+        vm.prank(multisig);
+        bridge.fundsOut(
+            alternateRecipient,
+            releaseAmount,
+            alternateBurnId,
+            alternateSourceChainId,
+            alternateDestinationChainId,
+            alternateSourceAddress,
+            _proof(),
+            _settlement(_singleFundsInId())
+        );
+
+        assertTrue(bridge.consumedBurnIds(alternateBurnId), 'burn id consumed');
+        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore - releaseAmount, 'bridge debit');
+        assertEq(usdt0.balanceOf(alternateRecipient), recipientBefore + releaseAmount, 'recipient credited');
+        assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore - releaseAmount, 'record residual');
+    }
 }

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -2088,4 +2088,130 @@ contract MultisigProxyTest is Test {
         assertEq(address(adapter).balance,          adapterEthBefore, 'adapter native unchanged');
         assertEq(mockOft.balance,                   oftEthBefore + LZ_NATIVE_FEE, 'oft native fee');
     }
+
+    // ========================================================================
+    // Current behavior reproduction
+    // ========================================================================
+
+    function test_enclaveSignedFundsOutCanDrainPool_currentBehavior() public {
+        address drainRecipient = makeAddr('drainRecipient');
+
+        // The TEE path checks signatures and allowlist membership, but it does
+        // not impose an on-chain amount cap on the signed Bridge fundsOut.
+        uint256 bridgeBefore    = token.balanceOf(address(bridge));
+        uint256 recipientBefore = token.balanceOf(drainRecipient);
+        uint256 recordBefore    = rgbModule.fundsInRecords(TX_ID);
+
+        assertEq(bridgeBefore,    AMOUNT * 5, 'pre bridge pool');
+        assertEq(recipientBefore, 0,          'pre recipient token');
+        assertEq(recordBefore,    bridgeBefore, 'pre record backs full pool');
+        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+
+        // Current behavior: if an on-chain amount cap or rate limit is added
+        // later, this test should be inverted to expect a revert.
+        bytes memory callData = _fundsOutCalldata(drainRecipient, bridgeBefore, BURN_ID);
+        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit BridgeFundsOut(
+            drainRecipient,
+            bridgeBefore,
+            bridgeBefore,
+            0,
+            BURN_ID,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR
+        );
+        vm.expectEmit(true, false, false, true, address(proxy));
+        emit Executed(FUNDS_OUT_SELECTOR, nonce, bitmap);
+
+        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+
+        assertEq(proxy.getNonce(FUNDS_OUT_SELECTOR), nonce + 1, 'nonce incremented');
+        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
+        assertEq(token.balanceOf(address(bridge)), 0, 'bridge pool drained');
+        assertEq(token.balanceOf(drainRecipient), recipientBefore + bridgeBefore, 'recipient got full pool');
+        assertEq(rgbModule.fundsInRecords(TX_ID), 0, 'record fully consumed');
+    }
+
+    function test_governanceCanRotateEnclaveToUnattestedEOA_currentBehavior() public {
+        address[] memory newSigners = new address[](3);
+        newSigners[0] = makeAddr('unattestedEnc1');
+        newSigners[1] = makeAddr('unattestedEnc2');
+        newSigners[2] = makeAddr('unattestedEnc3');
+        uint256 newThreshold = 2;
+
+        address[] memory before_ = proxy.getEnclaveSigners();
+        assertEq(before_.length, 3, 'pre enclave count');
+        assertEq(before_[0], encA1, 'pre signer 0');
+        assertEq(before_[1], encA2, 'pre signer 1');
+        assertEq(before_[2], encA3, 'pre signer 2');
+        assertEq(proxy.enclaveThreshold(), 2, 'pre enclave threshold');
+
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, newSigners, newThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        // Current behavior: the normal rotation path is already covered above;
+        // this case documents that only address shape and threshold are checked,
+        // with no on-chain enclave attestation evidence. If attestation is
+        // enforced later, this test should be inverted to expect a revert.
+        vm.expectEmit(false, false, false, true, address(proxy));
+        emit EnclaveSignersUpdated(newSigners, newThreshold);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit ProposalExecuted(id, IMultisigProxy.OperationType.UpdateEnclaveSigners);
+
+        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+
+        address[] memory after_ = proxy.getEnclaveSigners();
+        assertEq(after_.length, 3, 'post enclave count');
+        assertEq(after_[0], newSigners[0], 'post signer 0');
+        assertEq(after_[1], newSigners[1], 'post signer 1');
+        assertEq(after_[2], newSigners[2], 'post signer 2');
+        assertEq(proxy.enclaveThreshold(), newThreshold, 'post enclave threshold');
+    }
+
+    function test_teeAllowlistCanEnablePrivilegedSetter_currentBehavior() public {
+        address newAdapter = makeAddr('teeSetAdapter');
+        bytes4 selector = Bridge.setLZAdapter.selector;
+
+        assertFalse(proxy.teeAllowedCalls(address(bridge), selector), 'pre setter disallowed');
+        assertEq(bridge.lzAdapter(), address(0), 'pre bridge adapter');
+
+        _allowTeeCall(address(bridge), selector);
+        assertTrue(proxy.teeAllowedCalls(address(bridge), selector), 'setter allowed');
+
+        bytes memory callData = abi.encodeWithSelector(selector, newAdapter);
+        uint256 nonce = proxy.getNonce(selector);
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, selector, callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        // Current behavior: federation governance can allowlist an owner-only
+        // Bridge setter, after which the TEE path can execute that setter
+        // directly through the proxy-owned Bridge.
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit LZAdapterUpdated(address(0), newAdapter);
+        vm.expectEmit(true, false, false, true, address(proxy));
+        emit Executed(selector, nonce, bitmap);
+
+        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+
+        assertEq(proxy.getNonce(selector), nonce + 1, 'setter nonce incremented');
+        assertEq(bridge.lzAdapter(), newAdapter, 'bridge adapter updated');
+    }
 }

--- a/ethereum/test/RGBVerifier.t.sol
+++ b/ethereum/test/RGBVerifier.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import { Test } from 'forge-std/Test.sol';
+
+import { RGBVerifier } from '../src/verifiers/RGBVerifier.sol';
+import { FundsOutContext } from '../src/interfaces/RouteTypes.sol';
+import { MockBtcRelay } from './mocks/MockBtcRelay.sol';
+
+contract RGBVerifierTest is Test {
+    MockBtcRelay btcRelay;
+    RGBVerifier verifier;
+
+    address token = makeAddr('token');
+    address recipient = makeAddr('recipient');
+
+    uint256 constant SOURCE_CHAIN_ID = 1_000_001;
+    uint256 constant DEST_CHAIN_ID = 42161;
+    uint256 constant AMOUNT = 100e18;
+    uint256 constant BURN_ID = 9_001;
+
+    uint256 constant LOW_CONFIRMATION_HEIGHT = 850_000;
+    bytes32 constant LOW_CONFIRMATION_COMMITMENT = keccak256('low-confirmation-block');
+    uint256 constant HIGH_CONFIRMATION_HEIGHT = 860_000;
+    bytes32 constant HIGH_CONFIRMATION_COMMITMENT = keccak256('high-confirmation-block');
+
+    function setUp() public {
+        btcRelay = new MockBtcRelay();
+        verifier = new RGBVerifier(address(btcRelay));
+    }
+
+    function _ctx() internal view returns (FundsOutContext memory) {
+        return FundsOutContext({
+            token:         token,
+            recipient:     recipient,
+            amount:        AMOUNT,
+            burnId:        BURN_ID,
+            sourceChainId: SOURCE_CHAIN_ID,
+            destChainId:   DEST_CHAIN_ID,
+            sourceAddress: 'rgb:sender/utxo1src'
+        });
+    }
+
+    function _proof(uint256 blockHeight, bytes32 commitmentHash) internal pure returns (bytes memory) {
+        return abi.encode(blockHeight, commitmentHash);
+    }
+
+    // =========================================================================
+    // Current behavior reproduction
+    // =========================================================================
+
+    function test_confirmationsReturnedByRelayAreIgnored_currentBehavior() public {
+        btcRelay.setBlock(LOW_CONFIRMATION_HEIGHT, LOW_CONFIRMATION_COMMITMENT, 1);
+        btcRelay.setBlock(HIGH_CONFIRMATION_HEIGHT, HIGH_CONFIRMATION_COMMITMENT, 100);
+
+        // Current behavior: RGBVerifier only requires the relay call to succeed;
+        // it does not enforce a minimum confirmation count from the returned value.
+        verifier.verify(_ctx(), _proof(LOW_CONFIRMATION_HEIGHT, LOW_CONFIRMATION_COMMITMENT));
+        verifier.verify(_ctx(), _proof(HIGH_CONFIRMATION_HEIGHT, HIGH_CONFIRMATION_COMMITMENT));
+    }
+}


### PR DESCRIPTION
## Summary

Adds pre-fix current-behavior tests for several security findings around TEE-controlled outflows, proof/context binding, enclave signer rotation, privileged selector allowlisting, and ignored BTC confirmation counts.

Covered audit test IDs:

- UT-MISS-01
- UT-MISS-02
- UT-MISS-03
- UT-MISS-05
- UT-MISS-09

## What changed

- Added coverage showing that a TEE-signed `fundsOut` can release the full Bridge pool when signatures and allowlist checks pass.
- Added coverage showing that governance can rotate enclave signers to arbitrary EOA addresses without on-chain attestation evidence.
- Added coverage showing that `fundsOut` accepts a valid proof even when release context fields are changed.
- Added coverage showing that TEE allowlisting can enable a privileged Bridge setter.
- Added `RGBVerifier` coverage showing returned BTC confirmation counts are ignored on-chain.