### PR TITLE
test: add pre-fix reproduction coverage for UT-MISS-11, UT-MISS-13, UT-MISS-16, UT-MISS-17, UT-MISS-18, UT-MISS-19

### DIFF
--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -1288,4 +1288,120 @@ contract BridgeTest is Test {
         assertEq(usdt0.balanceOf(alternateRecipient), recipientBefore + releaseAmount, 'recipient credited');
         assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore - releaseAmount, 'record residual');
     }
+
+    function test_operationIdPreemptionBlocksVictimRgbDeposit_currentBehavior() public {
+        address preemptor = makeAddr('operationIdPreemptor');
+        uint256 predictedOperationId = TX_ID + 9_000;
+        uint256 preemptAmount = 25e18;
+
+        usdt0.mint(preemptor, preemptAmount);
+        vm.prank(preemptor);
+        usdt0.approve(address(bridge), preemptAmount);
+
+        uint256 preemptorBefore = usdt0.balanceOf(preemptor);
+        uint256 victimBefore = usdt0.balanceOf(user);
+        uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
+        uint256 recordBefore = rgbModule.fundsInRecords(predictedOperationId);
+
+        assertEq(preemptorBefore, preemptAmount, 'pre preemptor token');
+        assertEq(recordBefore, 0, 'pre predicted record');
+
+        // Current behavior: operationId uniqueness is enforced only by the
+        // settlement record. A different address can occupy a predicted id
+        // first, but doing so locks that address's own USDT0 in the Bridge.
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit FundsIn(preemptor, predictedOperationId, preemptAmount);
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit BridgeFundsIn(
+            preemptor,
+            predictedOperationId,
+            preemptAmount,
+            preemptAmount,
+            0,
+            0,
+            SOURCE_CHAIN_ID,
+            RGB_CHAIN_ID,
+            DST_ADDR
+        );
+
+        vm.prank(preemptor);
+        bridge.fundsIn(preemptAmount, RGB_CHAIN_ID, DST_ADDR, predictedOperationId, '');
+
+        uint256 bridgeAfterPreempt = usdt0.balanceOf(address(bridge));
+        uint256 recordAfterPreempt = rgbModule.fundsInRecords(predictedOperationId);
+
+        assertEq(usdt0.balanceOf(preemptor), preemptorBefore - preemptAmount, 'preemptor funds locked');
+        assertEq(bridgeAfterPreempt, bridgeBefore + preemptAmount, 'bridge credited by preemptor');
+        assertEq(recordAfterPreempt, recordBefore + preemptAmount, 'record occupied');
+
+        vm.expectRevert(RgbSettlementModule.DuplicateOperationId.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, predictedOperationId, '');
+
+        assertEq(usdt0.balanceOf(user), victimBefore, 'victim token unchanged');
+        assertEq(usdt0.balanceOf(address(bridge)), bridgeAfterPreempt, 'bridge unchanged after victim revert');
+        assertEq(rgbModule.fundsInRecords(predictedOperationId), recordAfterPreempt, 'preempted record unchanged');
+    }
+
+    // Bridge calls the settlement hook after pulling gross funds but before
+    // forwarding token commission, so a hook that reads Bridge's raw balance
+    // sees funds that will not remain as Bridge liquidity after the call.
+    function test_onFundsInHookSeesBalanceIncludingFutureCommission_currentBehavior() public {
+        uint256 percent = 400; // 4%
+        _setFundsInTokenRule(percent);
+
+        (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount) =
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
+        assertGt(tokenCommission, 0, 'token fee quoted');
+        assertEq(nativeCommission, 0, 'native fee is zero');
+
+        MockSettlementModule observingModule = new MockSettlementModule();
+        observingModule.setFundsInBalanceProbe(address(usdt0), address(bridge));
+
+        vm.prank(deployer);
+        routeRegistry.setRoute(
+            SOURCE_CHAIN_ID,
+            RGB_CHAIN_ID,
+            true,
+            address(rgbVerifier),
+            address(observingModule)
+        );
+
+        uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
+        uint256 cmBefore = usdt0.balanceOf(address(cm));
+        uint256 cmPoolBefore = cm.tokenCommissionPool(address(usdt0));
+
+        assertEq(bridgeBefore, 0, 'pre bridge token');
+        assertEq(cmBefore, 0, 'pre cm token');
+        assertEq(cmPoolBefore, 0, 'pre cm pool');
+
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit FundsIn(user, TX_ID + 10_000, netAmount);
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit BridgeFundsIn(
+            user,
+            TX_ID + 10_000,
+            AMOUNT,
+            netAmount,
+            tokenCommission,
+            nativeCommission,
+            SOURCE_CHAIN_ID,
+            RGB_CHAIN_ID,
+            DST_ADDR
+        );
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 10_000, '');
+
+        assertEq(observingModule.onFundsInCount(), 1, 'module called once');
+        assertEq(observingModule.lastNetAmount(), netAmount, 'module got net amount');
+        assertEq(
+            observingModule.lastObservedBalanceOnFundsIn(),
+            bridgeBefore + AMOUNT,
+            'hook saw gross bridge balance'
+        );
+        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore + netAmount, 'final bridge net');
+        assertEq(usdt0.balanceOf(address(cm)), cmBefore + tokenCommission, 'cm token delta');
+        assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore + tokenCommission, 'cm pool delta');
+    }
 }

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -84,6 +84,7 @@ contract MultisigProxyTest is Test {
     event TeeAllowedCallUpdated(address indexed target, bytes4 indexed selector, bool allowed);
     event TimelockDurationUpdated(uint256 newDuration);
     event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
+    event TokenCommissionWithdrawn(address indexed token, address indexed to, uint256 amount);
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
     event BatchExecuted(uint256 indexed nonce, uint256 enclaveBitmap, address[] targets, bytes4[] selectors);
@@ -2213,5 +2214,287 @@ contract MultisigProxyTest is Test {
 
         assertEq(proxy.getNonce(selector), nonce + 1, 'setter nonce incremented');
         assertEq(bridge.lzAdapter(), newAdapter, 'bridge adapter updated');
+    }
+
+    function test_timelockCanBeSetToZero_currentBehavior() public {
+        uint256 newDuration = 0;
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        assertEq(proxy.timelockDuration(), TIMELOCK, 'pre timelock');
+
+        bytes32 digest = MultisigHelper.digestProposeSetTimelockDuration(
+            domainSep, newDuration, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeSetTimelockDuration(newDuration, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        // Current behavior: the update path rejects only durations at or above
+        // MAX_PROPOSAL_LIFETIME, so zero removes the governance observation
+        // delay for future proposals.
+        vm.expectEmit(false, false, false, true, address(proxy));
+        emit TimelockDurationUpdated(newDuration);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit ProposalExecuted(id, IMultisigProxy.OperationType.SetTimelockDuration);
+
+        proxy.executeProposal(id, abi.encode(newDuration));
+
+        assertEq(proxy.timelockDuration(), 0, 'timelock cleared');
+    }
+
+    // Pending proposals do not snapshot their timelock delay; execution checks
+    // the live timelockDuration, so a later governance update can re-lock an
+    // already mature proposal until the new duration elapses.
+    function test_pendingProposalUsesLiveTimelock_currentBehavior() public {
+        uint256 proposedAt = block.timestamp;
+        address newBridge = makeAddr('liveTimelockBridge');
+        uint256 newDuration = 2 hours;
+        uint256 deadline = proposedAt + 1 days;
+
+        assertEq(proxy.timelockDuration(), TIMELOCK, 'pre timelock');
+
+        uint256 bridgeNonce = proxy.proposalNonce();
+        bytes32 bridgeDigest = MultisigHelper.digestProposeUpdateBridge(
+            domainSep, newBridge, bridgeNonce, deadline
+        );
+        (uint256[] memory bridgePks, uint256 bridgeBitmap) = _fedSigSet2of3();
+        bytes[] memory bridgeSigs = MultisigHelper.signAll(vm, bridgeDigest, bridgePks);
+
+        bytes32 bridgeProposalId =
+            proxy.proposeUpdateBridge(newBridge, bridgeNonce, deadline, bridgeBitmap, bridgeSigs);
+
+        uint256 timelockNonce = proxy.proposalNonce();
+        bytes32 timelockDigest = MultisigHelper.digestProposeSetTimelockDuration(
+            domainSep, newDuration, timelockNonce, deadline
+        );
+        (uint256[] memory timelockPks, uint256 timelockBitmap) = _fedSigSet2of3();
+        bytes[] memory timelockSigs = MultisigHelper.signAll(vm, timelockDigest, timelockPks);
+
+        bytes32 timelockProposalId = proxy.proposeSetTimelockDuration(
+            newDuration, timelockNonce, deadline, timelockBitmap, timelockSigs
+        );
+
+        vm.warp(proposedAt + TIMELOCK + 1);
+
+        vm.expectEmit(false, false, false, true, address(proxy));
+        emit TimelockDurationUpdated(newDuration);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit ProposalExecuted(timelockProposalId, IMultisigProxy.OperationType.SetTimelockDuration);
+
+        proxy.executeProposal(timelockProposalId, abi.encode(newDuration));
+
+        assertEq(proxy.timelockDuration(), newDuration, 'live timelock increased');
+
+        // Current behavior: execution compares the frozen proposedAt against
+        // the live timelockDuration, so raising the timelock re-locks this
+        // already mature bridge proposal.
+        vm.expectRevert(IMultisigProxy.TimelockActive.selector);
+        proxy.executeProposal(bridgeProposalId, abi.encode(newBridge));
+
+        assertEq(proxy.bridge(), address(bridge), 'bridge unchanged while re-locked');
+
+        vm.warp(proposedAt + newDuration + 1);
+
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit BridgeAddressUpdated(address(bridge), newBridge);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit ProposalExecuted(bridgeProposalId, IMultisigProxy.OperationType.UpdateBridge);
+
+        proxy.executeProposal(bridgeProposalId, abi.encode(newBridge));
+
+        assertEq(proxy.bridge(), newBridge, 'bridge updated after live timelock');
+    }
+
+    // The typed commission-withdraw path pins the recipient to
+    // commissionRecipient, while generic CM admin execution forwards arbitrary
+    // calldata and lets the encoded withdrawal recipient win.
+    function test_adminExecuteCommissionManagerBypassesRecipientPin_currentBehavior() public {
+        address arbitraryRecipient = makeAddr('arbitraryCommissionRecipient');
+
+        vm.prank(address(proxy));
+        cm.setCommissionRule(
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token),
+            CommissionConfig({
+                stablePercent: 400, // 4%
+                multiplier: 100,
+                side: CommissionSide.FUNDS_IN,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        uint256 depositAmount = 100e18;
+        vm.prank(user);
+        bridge.fundsIn(depositAmount, RGB_CHAIN_ID, DST_ADDR, TX_ID + 777, '');
+
+        uint256 expectedCommission = (depositAmount * 400) / 100 / 100;
+        uint256 poolBefore = cm.tokenCommissionPool(address(token));
+        uint256 pinnedRecipientBefore = token.balanceOf(commissionReceiver);
+        uint256 arbitraryRecipientBefore = token.balanceOf(arbitraryRecipient);
+
+        assertEq(poolBefore, expectedCommission, 'pre cm pool');
+        assertEq(pinnedRecipientBefore, 0, 'pre pinned recipient');
+        assertEq(arbitraryRecipientBefore, 0, 'pre arbitrary recipient');
+
+        bytes memory callData = abi.encodeWithSignature(
+            'withdrawTokenCommission(address,address,uint256)',
+            address(token),
+            arbitraryRecipient,
+            expectedCommission
+        );
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteCM(
+            domainSep,
+            bytes4(callData),
+            callData,
+            nonce,
+            deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteCommissionManager(callData, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+
+        // Current behavior: generic CM admin execution emits only the
+        // CommissionManager withdrawal event and sends funds to the calldata
+        // recipient, not to the proxy's pinned commissionRecipient.
+        vm.expectEmit(true, true, false, true, address(cm));
+        emit TokenCommissionWithdrawn(address(token), arbitraryRecipient, expectedCommission);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit ProposalExecuted(id, IMultisigProxy.OperationType.AdminExecuteCommissionManager);
+
+        proxy.executeProposal(id, callData);
+
+        assertEq(cm.tokenCommissionPool(address(token)), 0, 'cm pool drained');
+        assertEq(token.balanceOf(commissionReceiver), pinnedRecipientBefore, 'pinned recipient unchanged');
+        assertEq(
+            token.balanceOf(arbitraryRecipient),
+            arbitraryRecipientBefore + expectedCommission,
+            'arbitrary recipient credited'
+        );
+    }
+
+    // executeBatch validates signatures, allowlisted calls, and total native
+    // value, but it does not bind the Bridge payout amount to the adapter send
+    // amount. A smaller send leaves the remainder on the adapter.
+    function test_executeBatchAcceptsUnpairedFundsOutAndSendOut_currentBehavior() public {
+        uint256 percent = 500; // 5%
+        vm.prank(address(proxy));
+        cm.setCommissionRule(
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            address(token),
+            CommissionConfig({
+                stablePercent: percent,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_OUT,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount) =
+            cm.calculateFundsOutCommission(RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token), AMOUNT);
+        uint256 adapterSendAmount = netAmount - 1e18;
+        assertGt(tokenCommission, 0, 'token fee quoted');
+        assertEq(nativeCommission, 0, 'native fee is zero');
+        assertLt(adapterSendAmount, netAmount, 'send amount smaller than bridge payout');
+
+        address mockOft = makeAddr('mismatchMockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        bytes4 sendOutSelector = MockOutboundLZAdapter.sendOut.selector;
+        _allowTeeCall(address(adapter), sendOutSelector);
+
+        bytes memory bridgeCallData = _fundsOutCalldata(address(adapter), AMOUNT, BURN_ID + 88);
+        bytes memory adapterCallData = abi.encodeWithSelector(
+            sendOutSelector,
+            DST_EID,
+            LZ_RECIPIENT,
+            adapterSendAmount,
+            adapterSendAmount,
+            bytes('')
+        );
+
+        address[] memory targets = new address[](2);
+        bytes[] memory callDatas = new bytes[](2);
+        uint256[] memory values = new uint256[](2);
+        targets[0] = address(bridge);
+        targets[1] = address(adapter);
+        callDatas[0] = bridgeCallData;
+        callDatas[1] = adapterCallData;
+        values[0] = 0;
+        values[1] = LZ_NATIVE_FEE;
+
+        uint256 nonce = proxy.batchNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
+            domainSep, targets, callDatas, values, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        uint256 bridgeBefore = token.balanceOf(address(bridge));
+        uint256 adapterBefore = token.balanceOf(address(adapter));
+        uint256 oftBefore = token.balanceOf(mockOft);
+        uint256 cmBefore = token.balanceOf(address(cm));
+        uint256 cmPoolBefore = cm.tokenCommissionPool(address(token));
+        uint256 recordBefore = rgbModule.fundsInRecords(TX_ID);
+
+        assertEq(bridgeBefore, AMOUNT * 5, 'pre bridge pool');
+        assertEq(adapterBefore, 0, 'pre adapter token');
+        assertEq(oftBefore, 0, 'pre oft token');
+        assertEq(recordBefore, AMOUNT * 5, 'pre record');
+
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = FUNDS_OUT_SELECTOR;
+        selectors[1] = sendOutSelector;
+        bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, adapterSendAmount));
+
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit BridgeFundsOut(
+            address(adapter),
+            AMOUNT,
+            netAmount,
+            tokenCommission,
+            BURN_ID + 88,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR
+        );
+        vm.expectEmit(true, false, false, true, address(adapter));
+        emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, adapterSendAmount);
+        vm.expectEmit(true, false, false, true, address(proxy));
+        emit BatchExecuted(nonce, bitmap, targets, selectors);
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        proxy.executeBatch{ value: LZ_NATIVE_FEE }(targets, callDatas, values, nonce, deadline, bitmap, sigs);
+
+        assertEq(proxy.batchNonce(), nonce + 1, 'batch nonce incremented');
+        assertTrue(bridge.consumedBurnIds(BURN_ID + 88), 'burn id consumed');
+        assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge gross debit');
+        assertEq(token.balanceOf(address(cm)), cmBefore + tokenCommission, 'cm fee delta');
+        assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore + tokenCommission, 'cm pool delta');
+        assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore - AMOUNT, 'record consumed');
+        assertEq(token.balanceOf(mockOft), oftBefore + adapterSendAmount, 'oft receives smaller send');
+        assertEq(
+            token.balanceOf(address(adapter)),
+            adapterBefore + (netAmount - adapterSendAmount),
+            'adapter keeps unpaired remainder'
+        );
+        assertEq(
+            (token.balanceOf(address(cm)) - cmBefore) +
+            (token.balanceOf(mockOft) - oftBefore) +
+            (token.balanceOf(address(adapter)) - adapterBefore),
+            AMOUNT,
+            'gross batch payout conserved'
+        );
     }
 }

--- a/ethereum/test/mocks/MockSettlementModule.sol
+++ b/ethereum/test/mocks/MockSettlementModule.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
+import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+
 import { ISettlementModule } from '../../src/interfaces/ISettlementModule.sol';
 import { FundsInContext, FundsOutContext } from '../../src/interfaces/RouteTypes.sol';
 
@@ -29,12 +31,21 @@ contract MockSettlementModule is ISettlementModule {
     uint256 public lastBurnId;
     bytes   public lastSettlementData;
 
+    address public balanceProbeToken;
+    address public balanceProbeTarget;
+    uint256 public lastObservedBalanceOnFundsIn;
+
     function setShouldRevertOnFundsIn(bool v) external {
         shouldRevertOnFundsIn = v;
     }
 
     function setShouldRevertOnBeforeFundsOut(bool v) external {
         shouldRevertOnBeforeFundsOut = v;
+    }
+
+    function setFundsInBalanceProbe(address token, address target) external {
+        balanceProbeToken = token;
+        balanceProbeTarget = target;
     }
 
     /// @inheritdoc ISettlementModule
@@ -48,6 +59,9 @@ contract MockSettlementModule is ISettlementModule {
         lastOperationId     = ctx.operationId;
         lastNetAmount       = ctx.netAmount;
         lastSettlementData  = settlementData;
+        if (balanceProbeToken != address(0)) {
+            lastObservedBalanceOnFundsIn = IERC20(balanceProbeToken).balanceOf(balanceProbeTarget);
+        }
     }
 
     /// @inheritdoc ISettlementModule


### PR DESCRIPTION
## Summary

Adds pre-fix reproduction tests for governance, batch execution, fundsIn accounting, and operationId behavior.

Covered audit test IDs:

- UT-MISS-11
- UT-MISS-13
- UT-MISS-16
- UT-MISS-17
- UT-MISS-18
- UT-MISS-19

## What changed

- Added current-behavior coverage for RGB `operationId` preemption.
- Added current-behavior coverage for setting governance timelock to zero.
- Added current-behavior coverage for generic CommissionManager admin execution bypassing the pinned commission recipient.
- Added current-behavior coverage for batched `fundsOut` + adapter `sendOut` calls with unpaired amounts.
- Added current-behavior coverage for settlement hooks observing Bridge balance before commission forwarding.
- Added current-behavior coverage for pending proposals using live `timelockDuration`.