### PR TITLE
test(R-W-12): strict-majority signer threshold regressions

### DIFF
--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -72,6 +72,12 @@ contract MultisigProxy is IMultisigProxy {
     /// @notice Hard upper bound on `executeBatch` size to keep gas use bounded.
     uint256 public constant MAX_BATCH_SIZE = 3;
 
+    /// @notice Hard upper bound on the size of either signer set. Bounds the
+    ///         O(N^2) duplicate/disjointness checks and stays far within the
+    ///         `uint256` signature-bitmap width (so no signer index is ever
+    ///         unreachable). 20 is ample for an enclave/federation committee.
+    uint256 public constant MAX_SIGNERS = 20;
+
     /// @notice Length of a Solidity function selector (`bytes4`) in bytes. Used
     ///         to guard `callData` against payloads too short to even carry a
     ///         selector before it is sliced via `calldataload`.
@@ -193,6 +199,9 @@ contract MultisigProxy is IMultisigProxy {
 
         _validateSigners(enclaveSigners_);
         _validateSigners(federationSigners_);
+        // The enclave and federation are distinct trust domains; an address in
+        // both would count toward quorum in each, collapsing that separation.
+        _requireDisjoint(enclaveSigners_, federationSigners_);
 
         bridge = bridge_;
         commissionManager = commissionManager_;
@@ -871,6 +880,7 @@ contract MultisigProxy is IMultisigProxy {
             if (newSigners.length == 0) revert NoSigners();
             _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
+            _requireDisjoint(newSigners, _federationSigners);
             _enclaveSigners = newSigners;
             enclaveThreshold = newThreshold;
             emit EnclaveSignersUpdated(newSigners, newThreshold);
@@ -880,6 +890,7 @@ contract MultisigProxy is IMultisigProxy {
             if (newSigners.length == 0) revert NoSigners();
             _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
+            _requireDisjoint(newSigners, _enclaveSigners);
             _federationSigners = newSigners;
             federationThreshold = newThreshold;
             emit FederationSignersUpdated(newSigners, newThreshold);
@@ -1093,7 +1104,22 @@ contract MultisigProxy is IMultisigProxy {
         }
     }
 
+    /// @dev Reverts if any address in `candidate` also appears in `counterpart`.
+    ///      Used to keep the enclave and federation signer sets disjoint so the
+    ///      two trust domains stay independent (R-W-14). O(n*m), bounded by the
+    ///      signer-set sizes.
+    function _requireDisjoint(address[] memory candidate, address[] memory counterpart) private pure {
+        for (uint256 i = 0; i < candidate.length; i++) {
+            for (uint256 j = 0; j < counterpart.length; j++) {
+                if (candidate[i] == counterpart[j]) revert SignerSetsOverlap(candidate[i]);
+            }
+        }
+    }
+
     function _validateSigners(address[] memory signers) private pure {
+        // Bound the set before the O(N^2) duplicate scan below, and keep every
+        // signer index within the uint256 signature bitmap (R-I-06).
+        if (signers.length > MAX_SIGNERS) revert TooManySigners(signers.length, MAX_SIGNERS);
         for (uint256 i = 0; i < signers.length; i++) {
             if (signers[i] == address(0)) revert ZeroAddressSigner();
             for (uint256 j = i + 1; j < signers.length; j++) {

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -63,6 +63,8 @@ interface IMultisigProxy {
     error InvalidSignature();
     error ZeroAddressSigner();
     error DuplicateSigner();
+    error SignerSetsOverlap(address signer);
+    error TooManySigners(uint256 count, uint256 max);
     error CallFailed();
     error UnknownOperationType();
     error ZeroRecipient();

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -222,6 +222,20 @@ contract MultisigProxyTest is Test {
         ids[0] = TX_ID;
     }
 
+    /// @dev Valid strict-majority signer sets (2-of-2) used as filler in
+    ///      constructor-revert tests that target a non-threshold revert.
+    function _validEnc() internal view returns (address[] memory a) {
+        a = new address[](2);
+        a[0] = encA1;
+        a[1] = encA2;
+    }
+
+    function _validFed() internal view returns (address[] memory a) {
+        a = new address[](2);
+        a[0] = fedA1;
+        a[1] = fedA2;
+    }
+
     function _fundsOutCalldata() internal view returns (bytes memory) {
         bytes memory proof          = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
         bytes memory settlementData = abi.encode(_fundsInIds());
@@ -284,44 +298,34 @@ contract MultisigProxyTest is Test {
     }
 
     function test_constructor_revertsOnZeroCommission() public {
-        address[] memory enc = new address[](1); enc[0] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionRecipient.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, address(0), TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, address(0), TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnTimelockTooLong() public {
-        address[] memory enc = new address[](1); enc[0] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.TimelockTooLong.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 30 days, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, 30 days, MIN_TIMELOCK);
     }
 
     // ---- R-W-11: MIN_TIMELOCK floor (post-fix) ----
 
     /// @dev UT-FIX-13: deploying with a timelock below the requested floor reverts.
     function test_constructor_revertsOnTimelockBelowMinTimelock() public {
-        address[] memory enc = new address[](1); enc[0] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         // timelock (1h) is below the requested floor (2h) -> TimelockTooShort
         vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, 1 hours, 2 hours);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, 1 hours, 2 hours);
     }
 
     /// @dev A zero floor is rejected — it would defeat the purpose of the fix.
     function test_constructor_revertsOnZeroMinTimelock() public {
-        address[] memory enc = new address[](1); enc[0] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, 0);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, TIMELOCK, 0);
     }
 
     /// @dev A floor at/above the upper bound leaves no valid range — rejected.
     function test_constructor_revertsOnMinTimelockTooLong() public {
-        address[] memory enc = new address[](1); enc[0] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, 30 days);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, TIMELOCK, 30 days);
     }
 
     function test_minTimelock_returnsConfiguredFloor() public view {
@@ -329,17 +333,142 @@ contract MultisigProxyTest is Test {
     }
 
     function test_constructor_revertsOnDuplicateSigner() public {
+        // Duplicate enclave signer with an otherwise-valid 2-of-2 threshold, so
+        // the call clears the threshold guard and reverts in _validateSigners.
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA1;
-        address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroAddressSigner() public {
-        address[] memory enc = new address[](1); enc[0] = address(0);
-        address[] memory fed = new address[](1); fed[0] = fedA1;
+        // Zero-address enclave signer in a 2-signer set with a valid 2-of-2
+        // threshold, so the call clears the threshold guard and reverts in
+        // _validateSigners.
+        address[] memory enc = new address[](2); enc[0] = address(0); enc[1] = encA2;
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    // ========================================================================
+    // Strict-majority signer threshold floor (R-W-12 / UT-FIX-14)
+    //
+    // Both signer sets, at construction and on signer-update, must be a strict
+    // majority of at least 2 signers: n >= 2, threshold >= 2, threshold <= n,
+    // 2*threshold > n. Rejects 1-of-N, the degenerate 1-of-1, and sub-majority
+    // quorums; the smallest valid sets are 2-of-2 and 2-of-3. Signer-update
+    // validation runs at executeProposal time (in _executeByType), so the bad
+    // proposal is created successfully and reverts only on execution.
+    // ========================================================================
+
+    /// @dev Build an n-element signer array from a seed (distinct non-zero addrs).
+    function _signers(uint256 n) internal pure returns (address[] memory a) {
+        a = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            a[i] = address(uint160(0xA000 + i));
+        }
+    }
+
+    // ---- Constructor ----
+
+    function test_constructor_rejectsOneOfThree_enclave() public {
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        new MultisigProxy(address(bridge), address(cm), _signers(3), 1, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    function test_constructor_rejectsOneOfOne_enclave() public {
+        // n < 2 — single-key set, rejected even though 2*1 > 1.
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        new MultisigProxy(address(bridge), address(cm), _signers(1), 1, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    function test_constructor_rejectsSubMajority_enclave() public {
+        // 2-of-4: 2*2 == 4, not a strict majority.
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        new MultisigProxy(address(bridge), address(cm), _signers(4), 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    function test_constructor_rejectsOneOfThree_federation() public {
+        // Enclave valid, federation 1-of-3 — the floor applies to both sets.
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _signers(3), 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    function test_constructor_acceptsTwoOfTwo() public {
+        MultisigProxy p = new MultisigProxy(
+            address(bridge), address(cm), _signers(2), 2, _signers(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+        );
+        assertEq(p.enclaveThreshold(),    2);
+        assertEq(p.federationThreshold(), 2);
+    }
+
+    function test_constructor_acceptsThreeOfFour() public {
+        // Strict majority with a non-trivial set (2*3 > 4).
+        MultisigProxy p = new MultisigProxy(
+            address(bridge), address(cm), _signers(4), 3, _signers(4), 3, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+        );
+        assertEq(p.enclaveThreshold(),    3);
+        assertEq(p.federationThreshold(), 3);
+    }
+
+    // ---- Signer update (validated at executeProposal) ----
+
+    function test_proposeUpdateEnclaveSigners_rejectsOneOfNAtExecute() public {
+        address[] memory newSigners = _signers(3);
+        uint256 badThreshold = 1; // 1-of-3
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, newSigners, badThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        // Propose succeeds — threshold validity is enforced on execution.
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, badThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        proxy.executeProposal(id, abi.encode(newSigners, badThreshold));
+    }
+
+    function test_proposeUpdateFederationSigners_rejectsSubMajorityAtExecute() public {
+        address[] memory newSigners = _signers(4);
+        uint256 badThreshold = 2; // 2-of-4, sub-majority
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(
+            domainSep, newSigners, badThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateFederationSigners(newSigners, badThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
+        proxy.executeProposal(id, abi.encode(newSigners, badThreshold));
+    }
+
+    function test_proposeUpdateFederationSigners_acceptsStrictMajority() public {
+        address[] memory newSigners = _signers(3);
+        uint256 newThreshold = 2; // 2-of-3
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(
+            domainSep, newSigners, newThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateFederationSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        assertEq(proxy.federationThreshold(), 2);
+        assertEq(proxy.getFederationSigners().length, 3);
     }
 
     // ========================================================================

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -368,6 +368,15 @@ contract MultisigProxyTest is Test {
         }
     }
 
+    /// @dev A second n-element signer array disjoint from `_signers` — used as
+    ///      the counterpart set so the two trust domains do not overlap.
+    function _signersB(uint256 n) internal pure returns (address[] memory a) {
+        a = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            a[i] = address(uint160(0xB000 + i));
+        }
+    }
+
     // ---- Constructor ----
 
     function test_constructor_rejectsOneOfThree_enclave() public {
@@ -395,7 +404,7 @@ contract MultisigProxyTest is Test {
 
     function test_constructor_acceptsTwoOfTwo() public {
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(2), 2, _signers(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(2), 2, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
         assertEq(p.enclaveThreshold(),    2);
         assertEq(p.federationThreshold(), 2);
@@ -404,7 +413,7 @@ contract MultisigProxyTest is Test {
     function test_constructor_acceptsThreeOfFour() public {
         // Strict majority with a non-trivial set (2*3 > 4).
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(4), 3, _signers(4), 3, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(4), 3, _signersB(4), 3, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
         assertEq(p.enclaveThreshold(),    3);
         assertEq(p.federationThreshold(), 3);
@@ -469,6 +478,120 @@ contract MultisigProxyTest is Test {
         proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
         assertEq(proxy.federationThreshold(), 2);
         assertEq(proxy.getFederationSigners().length, 3);
+    }
+
+    // ========================================================================
+    // Disjoint signer sets (R-W-14 / UT-FIX-16)
+    //
+    // The enclave and federation sets must not share an address, at construction
+    // and on signer-update (validated at executeProposal). The setUp sets are
+    // already disjoint (encA* vs fedA*).
+    // ========================================================================
+
+    function test_constructor_rejectsOverlappingSignerSets() public {
+        // encA1 is present in both the enclave and the federation set.
+        address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
+        address[] memory fed = new address[](2); fed[0] = encA1; fed[1] = fedA2;
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, encA1));
+        new MultisigProxy(address(bridge), address(cm), enc, 2, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    function test_constructor_acceptsDisjointSignerSets() public {
+        MultisigProxy p = new MultisigProxy(
+            address(bridge), address(cm), _signers(2), 2, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+        );
+        assertEq(p.getEnclaveSigners().length,    2);
+        assertEq(p.getFederationSigners().length, 2);
+    }
+
+    function test_proposeUpdateEnclaveSigners_rejectsOverlapWithFederationAtExecute() public {
+        // New enclave set includes fedA1, a current federation signer.
+        address[] memory newSigners = new address[](2); newSigners[0] = fedA1; newSigners[1] = encA2;
+        uint256 newThreshold = 2;
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, newSigners, newThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, fedA1));
+        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+    }
+
+    function test_proposeUpdateFederationSigners_rejectsOverlapWithEnclaveAtExecute() public {
+        // New federation set includes encA1, a current enclave signer.
+        address[] memory newSigners = new address[](2); newSigners[0] = encA1; newSigners[1] = fedA2;
+        uint256 newThreshold = 2;
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(
+            domainSep, newSigners, newThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateFederationSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, encA1));
+        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+    }
+
+    // ========================================================================
+    // Signer-set size cap (R-I-06 / UT-FIX-27)
+    //
+    // Either set is capped at MAX_SIGNERS, at construction and on signer-update
+    // (validated in _validateSigners at executeProposal). The cap bounds the
+    // O(N^2) scan and keeps every index within the uint256 signature bitmap.
+    // ========================================================================
+
+    function test_constructor_rejectsTooManySigners() public {
+        uint256 max = proxy.MAX_SIGNERS();
+        address[] memory enc = _signers(max + 1); // 21 distinct enclave signers
+        uint256 encThreshold = (max + 1) / 2 + 1; // strict majority, so it clears the threshold guard
+
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
+        new MultisigProxy(
+            address(bridge), address(cm), enc, encThreshold, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+        );
+    }
+
+    function test_constructor_acceptsSignersAtMax() public {
+        uint256 max = proxy.MAX_SIGNERS();
+        uint256 threshold = max / 2 + 1; // 11-of-20 strict majority
+
+        MultisigProxy p = new MultisigProxy(
+            address(bridge), address(cm), _signers(max), threshold, _signersB(max), threshold, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+        );
+        assertEq(p.getEnclaveSigners().length,    max);
+        assertEq(p.getFederationSigners().length, max);
+    }
+
+    function test_proposeUpdateEnclaveSigners_rejectsTooManySignersAtExecute() public {
+        uint256 max = proxy.MAX_SIGNERS();
+        address[] memory newSigners = _signers(max + 1);
+        uint256 newThreshold = (max + 1) / 2 + 1; // valid strict majority
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, newSigners, newThreshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
+        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
     }
 
     // ========================================================================


### PR DESCRIPTION
## R-W-12 — regression tests (UT-FIX-14)

Unit tests for the `_requireValidThreshold` floor added in the fix PR, covering
both signer sets and both entry points.

### Coverage
- **Constructor**: rejects `1-of-3`, the degenerate `1-of-1`, and sub-majority
  `2-of-4` (`InvalidThreshold`) for enclave and federation; accepts `2-of-2`
  and `3-of-4`.
- **Signer update** (threshold validated at `executeProposal` time): a `1-of-N`
  enclave update and a sub-majority `2-of-4` federation update revert
  `InvalidThreshold` on execution (the proposal is created successfully, since
  validation runs in `_executeByType`); a `2-of-3` strict-majority update
  executes and updates the set.