### PR TITLE
test: add pre-fix reproduction coverage for UT-MISS-24, UT-MISS-25, UT-MISS-30, UT-MISS-31, UT-MISS-34, UT-MISS-35, UT-MISS-41, UT-MISS-42

### DIFF
--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -1016,6 +1016,35 @@ contract BridgeTest is Test {
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
     }
 
+    function test_nativeValueMismatchRejectsSmallOverpay_currentBehavior() public {
+        _setFundsInNativeRule(100);
+
+        (, uint256 nativeCommission,) =
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
+        assertGt(nativeCommission, 0, 'native fee quoted');
+
+        vm.deal(user, nativeCommission + 1);
+
+        uint256 userTokenBefore   = usdt0.balanceOf(user);
+        uint256 bridgeTokenBefore = usdt0.balanceOf(address(bridge));
+        uint256 cmNativeBefore    = address(cm).balance;
+        uint256 nativePoolBefore  = cm.nativeCommissionPool();
+        uint256 recordBefore      = rgbModule.fundsInRecords(TX_ID);
+
+        // Current behavior: native fundsIn requires exact msg.value. Even a
+        // 1-wei overpay reverts before token pull, commission credit, or RGB
+        // settlement bookkeeping.
+        vm.expectRevert(IBridge.NativeValueMismatch.selector);
+        vm.prank(user);
+        bridge.fundsIn{ value: nativeCommission + 1 }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        assertEq(usdt0.balanceOf(user),           userTokenBefore,   'user token unchanged');
+        assertEq(usdt0.balanceOf(address(bridge)), bridgeTokenBefore, 'bridge token unchanged');
+        assertEq(address(cm).balance,             cmNativeBefore,    'cm native unchanged');
+        assertEq(cm.nativeCommissionPool(),       nativePoolBefore,  'native pool unchanged');
+        assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore,      'record unchanged');
+    }
+
     // ========================================================================
     // pause / unpause / renounceOwnership
     // ========================================================================
@@ -1603,9 +1632,99 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(predictedOperationId), recordAfterPreempt, 'preempted record unchanged');
     }
 
-    // Bridge calls the settlement hook after pulling gross funds but before
-    // forwarding token commission, so a hook that reads Bridge's raw balance
-    // sees funds that will not remain as Bridge liquidity after the call.
+    // Current behavior: a plain ERC20 transfer can change Bridge's raw balance,
+    // but it does not enter the Bridge.fundsIn accounting path.
+    function test_directTokenTransferDoesNotCreateFundsInAccounting_currentBehavior() public {
+        address donor = makeAddr('directTransferDonor');
+        uint256 directAmount = 17e18;
+        uint256 operationId = TX_ID + 11_000;
+
+        usdt0.mint(donor, directAmount);
+
+        uint256 donorBefore = usdt0.balanceOf(donor);
+        uint256 userBefore = usdt0.balanceOf(user);
+        uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
+        uint256 cmBefore = usdt0.balanceOf(address(cm));
+        uint256 cmPoolBefore = cm.tokenCommissionPool(address(usdt0));
+        uint256 nativePoolBefore = cm.nativeCommissionPool();
+        uint256 recordBefore = rgbModule.fundsInRecords(operationId);
+
+        assertEq(donorBefore, directAmount, 'pre donor token');
+        assertEq(bridgeBefore, 0, 'pre bridge token');
+        assertEq(recordBefore, 0, 'pre record');
+
+        vm.prank(donor);
+        usdt0.transfer(address(bridge), directAmount);
+
+        assertEq(usdt0.balanceOf(donor), donorBefore - directAmount, 'donor direct transfer spent');
+        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore + directAmount, 'bridge raw balance increased');
+        assertEq(usdt0.balanceOf(address(cm)), cmBefore, 'cm token unchanged');
+        assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
+        assertEq(cm.nativeCommissionPool(), nativePoolBefore, 'native pool unchanged');
+        assertEq(rgbModule.fundsInRecords(operationId), recordBefore, 'record not created');
+
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit FundsIn(user, operationId, AMOUNT);
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit BridgeFundsIn(
+            user,
+            operationId,
+            AMOUNT,
+            AMOUNT,
+            0,
+            0,
+            SOURCE_CHAIN_ID,
+            RGB_CHAIN_ID,
+            DST_ADDR
+        );
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, operationId, '');
+
+        assertEq(usdt0.balanceOf(user), userBefore - AMOUNT, 'user fundsIn spent');
+        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore + directAmount + AMOUNT, 'bridge includes direct plus fundsIn');
+        assertEq(rgbModule.fundsInRecords(operationId), recordBefore + AMOUNT, 'record created only by fundsIn');
+    }
+
+    // Current behavior: Bridge only rejects an empty destination address, so a
+    // non-empty string is accepted and emitted without format validation.
+    function test_fundsIn_acceptsInvalidButNonEmptyDestinationAddress_currentBehavior() public {
+        string memory invalidDestination = 'not-rgb-destination';
+        uint256 operationId = TX_ID + 12_000;
+
+        uint256 userBefore = usdt0.balanceOf(user);
+        uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
+        uint256 recordBefore = rgbModule.fundsInRecords(operationId);
+
+        assertEq(bridgeBefore, 0, 'pre bridge token');
+        assertEq(recordBefore, 0, 'pre record');
+
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit FundsIn(user, operationId, AMOUNT);
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit BridgeFundsIn(
+            user,
+            operationId,
+            AMOUNT,
+            AMOUNT,
+            0,
+            0,
+            SOURCE_CHAIN_ID,
+            RGB_CHAIN_ID,
+            invalidDestination
+        );
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, invalidDestination, operationId, '');
+
+        assertEq(usdt0.balanceOf(user), userBefore - AMOUNT, 'user fundsIn spent');
+        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore + AMOUNT, 'bridge credited');
+        assertEq(rgbModule.fundsInRecords(operationId), recordBefore + AMOUNT, 'record created');
+    }
+
+    // Current behavior: Bridge calls the settlement hook after pulling gross
+    // funds but before forwarding token commission, so a hook can observe funds
+    // that will not remain as Bridge liquidity after the call.
     function test_onFundsInHookSeesBalanceIncludingFutureCommission_currentBehavior() public {
         uint256 percent = 400; // 4%
         _setFundsInTokenRule(percent);

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -44,6 +44,7 @@ contract CommissionManagerTest is Test {
         CommissionCurrency currency
     );
     event EthUsdFeedUpdated(address indexed feed, uint256 heartbeat);
+    event TokenCommissionReceived(address indexed token, uint256 amount);
 
     function setUp() public {
         // Anvil starts at timestamp 1; warp past the heartbeat so staleness
@@ -141,6 +142,18 @@ contract CommissionManagerTest is Test {
     function test_convertTokenFeeToNative_revertsIfTokenDecimalsTooLarge() public {
         vm.expectRevert(ICommissionManager.TokenDecimalsTooLarge.selector);
         cm.convertTokenFeeToNative(1, 19);
+    }
+
+    // Current behavior: native quote validation only requires a fresh positive
+    // Chainlink answer. There is no sequencer uptime feed or min/max bound, so
+    // a fresh outlier price is still used for conversion.
+    function test_nativeQuoteDoesNotCheckSequencerUptime_currentBehavior() public {
+        ethUsdFeed.setAnswer(1);
+        ethUsdFeed.setUpdatedAt(block.timestamp);
+
+        uint256 nativeFee = cm.convertTokenFeeToNative(1e18, 18);
+
+        assertEq(nativeFee, 1e26, 'fresh positive outlier accepted');
     }
 
     function test_buildRouteKey_matchesEncodeHash() public view {
@@ -701,6 +714,34 @@ contract CommissionManagerTest is Test {
         vm.expectRevert(ICommissionManager.NothingReceived.selector);
         cm.receiveTokenCommission(address(token));
         vm.stopPrank();
+    }
+
+    // Current behavior: token commission accounting records the whole balance
+    // delta since the last pool update, so unsolicited tokens already sitting
+    // in the CommissionManager are credited with the next bridge commission.
+    function test_unsolicitedTokenBalanceIncludedInNextCommissionCredit_currentBehavior() public {
+        uint256 unsolicitedAmount = 3 ether;
+        uint256 legitimateAmount  = 7 ether;
+        uint256 expectedCredit    = unsolicitedAmount + legitimateAmount;
+
+        token.mint(user, unsolicitedAmount);
+        vm.prank(user);
+        token.transfer(address(cm), unsolicitedAmount);
+
+        token.mint(BRIDGE, legitimateAmount);
+        vm.prank(BRIDGE);
+        token.transfer(address(cm), legitimateAmount);
+
+        assertEq(token.balanceOf(address(cm)), expectedCredit, 'pre cm token balance');
+        assertEq(cm.tokenCommissionPool(address(token)), 0, 'pre cm pool');
+
+        vm.expectEmit(true, false, false, true, address(cm));
+        emit TokenCommissionReceived(address(token), expectedCredit);
+
+        vm.prank(BRIDGE);
+        cm.receiveTokenCommission(address(token));
+
+        assertEq(cm.tokenCommissionPool(address(token)), expectedCredit, 'pool includes unsolicited balance');
     }
 
     function test_withdrawTokenCommission_transfersAndUpdatesPool() public {

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
+import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
 
 import { MultisigProxy }  from '../src/MultisigProxy.sol';
 import { IMultisigProxy } from '../src/interfaces/IMultisigProxy.sol';
@@ -89,6 +90,7 @@ contract MultisigProxyTest is Test {
     event TokenCommissionWithdrawn(address indexed token, address indexed to, uint256 amount);
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event BatchExecuted(uint256 indexed nonce, uint256 enclaveBitmap, address[] targets, bytes4[] selectors);
     event SendOut(bytes32 indexed guid, uint32 dstEid, bytes32 recipient, uint256 amountLD);
     event BridgeFundsOut(
@@ -2822,6 +2824,111 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.bridge(), newBridge, 'bridge updated after live timelock');
     }
 
+    // Current behavior: emergency actions and regular proposals share
+    // proposalNonce, so an emergency pause can stale an already signed regular
+    // proposal before it is submitted on-chain.
+    function test_emergencyAndRegularProposalNonceCollide_currentBehavior() public {
+        address newBridge = makeAddr('nonceCollisionBridge');
+        uint256 regularNonce = proxy.proposalNonce();
+        uint256 regularDeadline = block.timestamp + 1 days;
+
+        bytes32 regularDigest = MultisigHelper.digestProposeUpdateBridge(
+            domainSep, newBridge, regularNonce, regularDeadline
+        );
+        (uint256[] memory regularPks, uint256 regularBitmap) = _fedSigSet2of3();
+        bytes[] memory regularSigs = MultisigHelper.signAll(vm, regularDigest, regularPks);
+
+        uint256 emergencyDeadline = block.timestamp + 1 hours;
+        bytes32 emergencyDigest = MultisigHelper.digestEmergencyPause(domainSep, regularNonce, emergencyDeadline);
+        (uint256[] memory emergencyPks, uint256 emergencyBitmap) = _fedSigSet2of3();
+        bytes[] memory emergencySigs = MultisigHelper.signAll(vm, emergencyDigest, emergencyPks);
+
+        assertFalse(bridge.paused(), 'pre bridge active');
+        assertEq(proxy.proposalNonce(), regularNonce, 'pre proposal nonce');
+        assertEq(proxy.bridge(), address(bridge), 'pre bridge target');
+
+        vm.expectEmit(false, false, false, true, address(proxy));
+        emit EmergencyPaused(regularNonce, emergencyBitmap);
+
+        proxy.emergencyPause(regularNonce, emergencyDeadline, emergencyBitmap, emergencySigs);
+
+        assertTrue(bridge.paused(), 'bridge paused by emergency action');
+        assertEq(proxy.proposalNonce(), regularNonce + 1, 'emergency consumed proposal nonce');
+
+        vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
+        proxy.proposeUpdateBridge(newBridge, regularNonce, regularDeadline, regularBitmap, regularSigs);
+
+        assertEq(proxy.proposalNonce(), regularNonce + 1, 'stale proposal leaves nonce unchanged');
+        assertEq(proxy.bridge(), address(bridge), 'stale proposal leaves bridge unchanged');
+    }
+
+    // Current behavior: generic Bridge admin execution can call standard
+    // Ownable transferOwnership directly. A wrong nonzero owner leaves the
+    // proxy unable to execute future Bridge owner-only operations.
+    function test_singleStepOwnershipTransferCanOrphanGovernance_currentBehavior() public {
+        address wrongOwner = makeAddr('wrongBridgeOwner');
+        uint256 startTime = block.timestamp;
+
+        bytes memory transferCallData = abi.encodeWithSignature('transferOwnership(address)', wrongOwner);
+        uint256 transferNonce = proxy.proposalNonce();
+        uint256 transferDeadline = startTime + 1 days;
+        bytes32 transferDigest = MultisigHelper.digestProposeAdminExecute(
+            domainSep,
+            bytes4(transferCallData),
+            transferCallData,
+            transferNonce,
+            transferDeadline
+        );
+        (uint256[] memory transferPks, uint256 transferBitmap) = _fedSigSet2of3();
+        bytes[] memory transferSigs = MultisigHelper.signAll(vm, transferDigest, transferPks);
+
+        address routeRegistryBefore = bridge.routeRegistry();
+
+        assertEq(bridge.owner(), address(proxy), 'pre bridge owner');
+        assertFalse(bridge.paused(), 'pre bridge active');
+        assertEq(routeRegistryBefore, address(routeRegistry), 'pre route registry');
+
+        bytes32 transferProposalId =
+            proxy.proposeAdminExecute(transferCallData, transferNonce, transferDeadline, transferBitmap, transferSigs);
+
+        uint256 transferReadyAt = startTime + TIMELOCK + 1;
+        vm.warp(transferReadyAt);
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit OwnershipTransferred(address(proxy), wrongOwner);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit ProposalExecuted(transferProposalId, IMultisigProxy.OperationType.AdminExecute);
+
+        proxy.executeProposal(transferProposalId, transferCallData);
+
+        assertEq(bridge.owner(), wrongOwner, 'bridge owner moved away from proxy');
+
+        address replacementRegistry = makeAddr('replacementRouteRegistry');
+        bytes memory registryCallData = abi.encodeWithSignature('setRouteRegistry(address)', replacementRegistry);
+        uint256 registryNonce = proxy.proposalNonce();
+        uint256 registryDeadline = transferReadyAt + 1 days;
+        bytes32 registryDigest = MultisigHelper.digestProposeAdminExecute(
+            domainSep,
+            bytes4(registryCallData),
+            registryCallData,
+            registryNonce,
+            registryDeadline
+        );
+        (uint256[] memory registryPks, uint256 registryBitmap) = _fedSigSet2of3();
+        bytes[] memory registrySigs = MultisigHelper.signAll(vm, registryDigest, registryPks);
+
+        bytes32 registryProposalId =
+            proxy.proposeAdminExecute(registryCallData, registryNonce, registryDeadline, registryBitmap, registrySigs);
+
+        vm.warp(transferReadyAt + TIMELOCK + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(proxy)));
+        proxy.executeProposal(registryProposalId, registryCallData);
+
+        assertEq(bridge.owner(), wrongOwner, 'wrong owner remains');
+        assertEq(bridge.routeRegistry(), routeRegistryBefore, 'proxy cannot update bridge config');
+    }
+
     // The typed commission-withdraw path pins the recipient to
     // commissionRecipient, while generic CM admin execution forwards arbitrary
     // calldata and lets the encoded withdrawal recipient win.
@@ -2894,9 +3001,9 @@ contract MultisigProxyTest is Test {
         );
     }
 
-    // executeBatch validates signatures, allowlisted calls, and total native
-    // value, but it does not bind the Bridge payout amount to the adapter send
-    // amount. A smaller send leaves the remainder on the adapter.
+    // Current behavior: executeBatch validates signatures, allowlisted calls,
+    // and total native value, but it does not bind the Bridge payout amount to
+    // the adapter send amount. A smaller send leaves the remainder on the adapter.
     function test_executeBatchAcceptsUnpairedFundsOutAndSendOut_currentBehavior() public {
         uint256 percent = 500; // 5%
         vm.prank(address(proxy));

--- a/ethereum/test/RgbSettlementModule.t.sol
+++ b/ethereum/test/RgbSettlementModule.t.sol
@@ -264,4 +264,24 @@ contract RgbSettlementModuleTest is Test {
 
         assertEq(module.fundsInRecords(TX_ID_1), AMOUNT, 'record restored on revert');
     }
+
+    function test_beforeFundsOut_trailingUnknownIdsUnread_currentBehavior() public {
+        _record(TX_ID_1, AMOUNT);
+
+        uint256 trailingUnknownId = TX_ID_2;
+        uint256[] memory ids = new uint256[](2);
+        ids[0] = TX_ID_1;
+        ids[1] = trailingUnknownId;
+
+        assertEq(module.fundsInRecords(TX_ID_1), AMOUNT, 'pre first record');
+        assertEq(module.fundsInRecords(trailingUnknownId), 0, 'pre trailing unknown');
+
+        // Current behavior: the loop exits once the requested amount is
+        // satisfied, so trailing ids are not read or validated.
+        vm.prank(routeRegistry);
+        module.beforeFundsOut(_fundsOutCtx(AMOUNT), _settlementData(ids));
+
+        assertEq(module.fundsInRecords(TX_ID_1), 0, 'first record consumed');
+        assertEq(module.fundsInRecords(trailingUnknownId), 0, 'trailing unknown unread');
+    }
 }


### PR DESCRIPTION
## Summary

Adds pre-fix reproduction tests for several current behaviors found during the internal audit.

Covered audit test IDs:

- `UT-MISS-24`
- `UT-MISS-25`
- `UT-MISS-30`
- `UT-MISS-34`
- `UT-MISS-35`
- `UT-MISS-41`
- `UT-MISS-42`
- UT-MISS-31

## What changed

- Added strict native-value mismatch coverage for native-commission `fundsIn`.
- Added token-commission accounting coverage for unsolicited USDT0 sent directly to `CommissionManager`.
- Added proposal nonce collision coverage between emergency actions and regular governance proposals.
- Added native quote coverage showing that current validation relies on a fresh positive feed value.
- Added single-step `Bridge` ownership transfer coverage showing how governance can be orphaned.
- Added direct-token-transfer coverage showing raw Bridge balance changes do not enter `fundsIn` accounting.
- Added destination-address coverage showing non-empty invalid strings are accepted and emitted unchanged.
- Added RgbSettlementModule coverage showing that trailing fundsInIds are not read once the requested fundsOut amount is already satisfied.
