### PR TITLE
fix(R-W-18): snapshot timelockDuration into each proposal at creation

### DIFF
--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -200,49 +200,45 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     }
 
     // =========================================================================
-    // External — owner-only (called via MultisigProxy.execute)
+    // External — owner-only (called via MultisigProxy)
     // =========================================================================
 
     /// @inheritdoc IBridge
-    function fundsOut(
-        address recipient,
-        uint256 amount,
-        uint256 burnId,
-        uint256 sourceChainId,
-        uint256 destinationChainId,
-        string  calldata sourceAddress,
-        bytes   calldata proof,
-        bytes   calldata settlementData
-    ) external override onlyOwner nonReentrant whenOutflowNotPaused {
-        if (amount             == 0)                         revert ZeroAmount();
-        if (recipient          == address(0))                revert InvalidRecipientAddress();
-        if (sourceChainId      == 0)                         revert InvalidSourceChainId();
-        if (destinationChainId == 0)                         revert InvalidDestinationChainId();
-        if (bytes(sourceAddress).length > MAX_ADDRESS_LENGTH) {
-            revert AddressTooLong(bytes(sourceAddress).length, MAX_ADDRESS_LENGTH);
+    function fundsOut(FundsOutParams calldata fundsOutParams)
+        external
+        override
+        onlyOwner
+        nonReentrant
+        whenOutflowNotPaused
+    {
+        if (fundsOutParams.amount             == 0)                       revert ZeroAmount();
+        if (fundsOutParams.recipient          == address(0))              revert InvalidRecipientAddress();
+        if (fundsOutParams.sourceChainId      == 0)                       revert InvalidSourceChainId();
+        if (fundsOutParams.destinationChainId == 0)                       revert InvalidDestinationChainId();
+        if (bytes(fundsOutParams.sourceAddress).length > MAX_ADDRESS_LENGTH) {
+            revert AddressTooLong(bytes(fundsOutParams.sourceAddress).length, MAX_ADDRESS_LENGTH);
         }
-        if (proof.length > MAX_PROOF_LENGTH) revert ProofTooLong(proof.length, MAX_PROOF_LENGTH);
-        if (amount > IERC20(TOKEN).balanceOf(address(this))) revert AmountExceedBridgePool();
+        if (fundsOutParams.proof.length > MAX_PROOF_LENGTH) revert ProofTooLong(fundsOutParams.proof.length, MAX_PROOF_LENGTH);
+        if (fundsOutParams.amount > IERC20(TOKEN).balanceOf(address(this))) revert AmountExceedBridgePool();
 
         // Common replay guard. Set the flag before any external interaction
         // so a revert anywhere downstream rolls the mark back with the rest
         // of the call.
-        if (consumedBurnIds[burnId]) revert BurnIdAlreadyConsumed(burnId);
-        consumedBurnIds[burnId] = true;
+        if (consumedBurnIds[fundsOutParams.burnId]) revert BurnIdAlreadyConsumed(fundsOutParams.burnId);
+        consumedBurnIds[fundsOutParams.burnId] = true;
 
         // Quote commission. NATIVE on fundsOut is unrepresentable: the
         // CommissionManager setters reject a (NATIVE, FUNDS_OUT) rule at config,
-        // so `nativeCommission` is always 0 on this path. The
-        // value is ignored here.
+        // so `nativeCommission` is always 0 on this path. The value is ignored here.
         (
             uint256 tokenCommission,
             ,
             uint256 netAmount
         ) = commissionManager.calculateFundsOutCommission(
-            sourceChainId,
-            destinationChainId,
+            fundsOutParams.sourceChainId,
+            fundsOutParams.destinationChainId,
             TOKEN,
-            amount
+            fundsOutParams.amount
         );
 
         // Delegate route-specific finality verification + settlement-state
@@ -251,15 +247,15 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         IRouteRegistry(routeRegistry).beforeFundsOut(
             FundsOutContext({
                 token:         TOKEN,
-                recipient:     recipient,
-                amount:        amount,
-                burnId:        burnId,
-                sourceChainId: sourceChainId,
-                destChainId:   destinationChainId,
-                sourceAddress: sourceAddress
+                recipient:     fundsOutParams.recipient,
+                amount:        fundsOutParams.amount,
+                burnId:        fundsOutParams.burnId,
+                sourceChainId: fundsOutParams.sourceChainId,
+                destChainId:   fundsOutParams.destinationChainId,
+                sourceAddress: fundsOutParams.sourceAddress
             }),
-            proof,
-            settlementData
+            fundsOutParams.proof,
+            fundsOutParams.settlementData
         );
 
         // Forward token commission to the CommissionManager pool.
@@ -269,17 +265,17 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         }
 
         // Deliver the net amount to the recipient.
-        IERC20(TOKEN).safeTransfer(recipient, netAmount);
+        IERC20(TOKEN).safeTransfer(fundsOutParams.recipient, netAmount);
 
         emit BridgeFundsOut(
-            recipient,
-            amount,
+            fundsOutParams.recipient,
+            fundsOutParams.amount,
             netAmount,
             tokenCommission,
-            burnId,
-            sourceChainId,
-            destinationChainId,
-            sourceAddress
+            fundsOutParams.burnId,
+            fundsOutParams.sourceChainId,
+            fundsOutParams.destinationChainId,
+            fundsOutParams.sourceAddress
         );
     }
 

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -778,7 +778,9 @@ contract MultisigProxy is IMultisigProxy {
     function executeProposal(bytes32 proposalId, bytes calldata opData) external {
         Proposal storage p = _proposals[proposalId];
         if (p.status != ProposalStatus.Pending) revert NotPending();
-        if (block.timestamp < p.proposedAt + timelockDuration) revert TimelockActive();
+        // Enforce the timelock that was in force when the proposal was created,
+        // not the current one — a later SetTimelockDuration cannot reschedule.
+        if (block.timestamp < p.proposedAt + p.timelockSnapshot) revert TimelockActive();
         if (block.timestamp > p.deadline) revert ProposalExpired();
         if (keccak256(opData) != p.dataHash) revert DataMismatch();
 
@@ -857,6 +859,7 @@ contract MultisigProxy is IMultisigProxy {
             dataHash: dataHash,
             proposedAt: block.timestamp,
             deadline: deadline,
+            timelockSnapshot: timelockDuration,
             opType: opType,
             status: ProposalStatus.Pending
         });

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -1,10 +1,32 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.35;
 
-import { ECDSA } from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+import { ECDSA }  from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { IMultisigProxy } from './interfaces/IMultisigProxy.sol';
 import { IBridge }        from './interfaces/IBridge.sol';
 import { IRouteRegistry } from './interfaces/IRouteRegistry.sol';
+
+/// @notice Minimal view of the LayerZero adapter's outbound entry point. The
+///         adapter itself lives in the `utexo-usdt0-contracts` repo; this
+///         interface pins the ABI `lzFundsOut` calls. Keep it in sync with
+///         `UtexoLZAdapter.sendOut`.
+interface ILZAdapterSendOut {
+    function sendOut(
+        uint32  dstEid,
+        bytes32 recipient,
+        uint256 amount,
+        uint256 minAmountLD,
+        bytes   calldata extraOptions
+    ) external payable;
+}
+
+/// @notice Minimal view of the Bridge's custodied-token getter. `Bridge`
+///         exposes `TOKEN` as a public immutable; this avoids adding it to
+///         `IBridge` (which would clash with the `BridgeBase` state variable).
+interface IBridgeToken {
+    function TOKEN() external view returns (address);
+}
 
 contract MultisigProxy is IMultisigProxy {
     using ECDSA for bytes32;
@@ -29,15 +51,11 @@ contract MultisigProxy is IMultisigProxy {
 
     address public commissionRecipient;
 
-    /// @notice Per-selector nonce for TEE execute() calls.
-    mapping(bytes4 => uint256) public nonces;
-
-    /// @notice Sequential nonce for TEE executeBatch() calls.
-    uint256 public batchNonce;
-
-    /// @notice Allowed (target, selector) pairs for TEE execute() / executeBatch().
-    ///         Federation governance maintains this allowlist via SetTeeAllowedCall.
-    mapping(address => mapping(bytes4 => bool)) public teeAllowedCalls;
+    /// @notice Sequential nonce shared by the typed TEE methods (`fundsOut` /
+    ///         `lzFundsOut`). Each successful call must match the current value
+    ///         and then increments it, giving all enclave releases a single
+    ///         total order and one-shot replay protection.
+    uint256 public teeNonce;
 
     /// @notice Federation proposals.
     mapping(bytes32 => Proposal) private _proposals;
@@ -83,18 +101,19 @@ contract MultisigProxy is IMultisigProxy {
     ///         selector before it is sliced via `calldataload`.
     uint256 public constant SELECTOR_LENGTH = 4;
 
-    bytes32 public immutable DOMAIN_SEPARATOR;
+    uint256 private immutable _cachedChainId;
+    bytes32 private immutable _cachedDomainSeparator;
 
     bytes32 private constant _DOMAIN_TYPEHASH = keccak256(
         'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'
     );
 
-    // TEE
-    bytes32 private constant _BRIDGE_OP_TYPEHASH = keccak256(
-        'BridgeOperation(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
+    // TEE — typed enclave release operations
+    bytes32 private constant _TEE_FUNDS_OUT_TYPEHASH = keccak256(
+        'TeeFundsOut(address recipient,uint256 amount,uint256 burnId,uint256 sourceChainId,uint256 destinationChainId,string sourceAddress,bytes proof,bytes settlementData,uint256 nonce,uint256 deadline)'
     );
-    bytes32 private constant _BRIDGE_BATCH_OP_TYPEHASH = keccak256(
-        'BridgeBatchOperation(address[] targets,bytes[] callDatas,uint256[] values,uint256 nonce,uint256 deadline)'
+    bytes32 private constant _TEE_LZ_FUNDS_OUT_TYPEHASH = keccak256(
+        'TeeLzFundsOut(uint256 amount,uint256 burnId,uint256 sourceChainId,uint256 destinationChainId,string sourceAddress,bytes proof,bytes settlementData,uint32 dstEid,bytes32 recipient,uint256 minAmountLD,bytes extraOptions,uint256 nonce,uint256 deadline)'
     );
 
     // Federation propose — typed EIP-712 structs per operation (Bridge side)
@@ -112,9 +131,6 @@ contract MultisigProxy is IMultisigProxy {
     );
     bytes32 private constant _PROPOSE_SET_COMMISSION_RECIPIENT_TYPEHASH = keccak256(
         'ProposeSetCommissionRecipient(address newRecipient,uint256 nonce,uint256 deadline)'
-    );
-    bytes32 private constant _PROPOSE_SET_TEE_CALL_TYPEHASH = keccak256(
-        'ProposeSetTeeAllowedCall(address target,bytes4 selector,bool allowed,uint256 nonce,uint256 deadline)'
     );
     bytes32 private constant _PROPOSE_SET_TIMELOCK_DURATION_TYPEHASH = keccak256(
         'ProposeSetTimelockDuration(uint256 newDuration,uint256 nonce,uint256 deadline)'
@@ -213,22 +229,8 @@ contract MultisigProxy is IMultisigProxy {
         timelockDuration = timelockDuration_;
         MIN_TIMELOCK = minTimelock_;
 
-        // Default TEE allowlist: Bridge.fundsOut. Additional (target, selector) pairs
-        // (e.g. for the LayerZero adapter's outbound `sendOut`) are added later via
-        // federation governance through `proposeSetTeeAllowedCall`.
-        teeAllowedCalls[bridge_][
-            bytes4(keccak256(
-                'fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)'
-            ))
-        ] = true;
-
-        DOMAIN_SEPARATOR = keccak256(abi.encode(
-            _DOMAIN_TYPEHASH,
-            keccak256('MultisigProxy'),
-            keccak256('1'),
-            block.chainid,
-            address(this)
-        ));
+        _cachedChainId = block.chainid;
+        _cachedDomainSeparator = _buildDomainSeparator();
     }
 
     // =========================================================================
@@ -236,86 +238,142 @@ contract MultisigProxy is IMultisigProxy {
     // =========================================================================
 
     /// @inheritdoc IMultisigProxy
-    function execute(
-        bytes calldata callData,
+    /// @dev Typed enclave release: the only call this makes is `Bridge.fundsOut`.
+    function fundsOutCall(
+        IBridge.FundsOutParams calldata params,
         uint256 nonce,
         uint256 deadline,
         uint256 enclaveBitmap,
         bytes[] calldata enclaveSigs
     ) external {
-        if (block.timestamp > deadline) revert Expired();
-        // Bound how far in the future a signed deadline may sit, so a leaked or
-        // pre-signed payload cannot stay executable indefinitely while its
-        // nonce is unconsumed.
-        if (deadline > block.timestamp + MAX_TEE_DEADLINE) revert DeadlineTooFar();
-        if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
+        _checkTeeTiming(deadline);
+        if (nonce != teeNonce) revert InvalidNonce();
 
-        bytes4 selector;
-        assembly { selector := calldataload(callData.offset) }
+        _verifySignatures(
+            _hashTypedData(_fundsOutStructHash(params, nonce, deadline)),
+            enclaveBitmap, enclaveSigs, _enclaveSigners, enclaveThreshold
+        );
 
-        if (!teeAllowedCalls[bridge][selector]) revert CallNotAllowed(bridge, selector);
-        if (nonce != nonces[selector]) revert InvalidNonce();
+        teeNonce++;
 
-        bytes32 digest = _buildDigest(_BRIDGE_OP_TYPEHASH, selector, callData, nonce, deadline);
-        _verifySignatures(digest, enclaveBitmap, enclaveSigs, _enclaveSigners, enclaveThreshold);
+        IBridge(bridge).fundsOut(params);
 
-        nonces[selector]++;
+        emit FundsOutExecuted(nonce, enclaveBitmap);
+    }
 
-        (bool ok, bytes memory ret) = bridge.call(callData);
-        _propagateRevert(ok, ret);
-
-        emit Executed(selector, nonce, enclaveBitmap);
+    /// @dev EIP-712 struct hash for `TeeFundsOut`. Isolated in its own frame to
+    ///      keep `fundsOutCall` within stack limits.
+    function _fundsOutStructHash(
+        IBridge.FundsOutParams calldata params,
+        uint256 nonce,
+        uint256 deadline
+    ) private pure returns (bytes32) {
+        return keccak256(abi.encode(
+            _TEE_FUNDS_OUT_TYPEHASH,
+            params.recipient,
+            params.amount,
+            params.burnId,
+            params.sourceChainId,
+            params.destinationChainId,
+            keccak256(bytes(params.sourceAddress)),
+            keccak256(params.proof),
+            keccak256(params.settlementData),
+            nonce,
+            deadline
+        ));
     }
 
     /// @inheritdoc IMultisigProxy
-    function executeBatch(
-        address[] calldata targets,
-        bytes[]   calldata callDatas,
-        uint256[] calldata values,
+    /// @dev Typed Flow-4 release: releases to the LZ adapter and bridges onward
+    ///      in one signed operation. The Bridge recipient is forced to
+    ///      `lzAdapter`, and the amount sent out is the balance actually
+    ///      delivered to the adapter (measured here), so the two legs are bound
+    ///      on-chain and cannot be mismatched (R-W-16).
+    function lzFundsOutCall(
+        LzFundsOutParams calldata params,
         uint256 nonce,
         uint256 deadline,
         uint256 enclaveBitmap,
         bytes[] calldata enclaveSigs
     ) external payable {
+        _checkTeeTiming(deadline);
+        if (nonce != teeNonce) revert InvalidNonce();
+
+        address adapter = lzAdapter;
+        if (adapter == address(0)) revert LZAdapterNotSet();
+
+        _verifySignatures(
+            _hashTypedData(_lzFundsOutStructHash(params, nonce, deadline)),
+            enclaveBitmap, enclaveSigs, _enclaveSigners, enclaveThreshold
+        );
+
+        teeNonce++;
+
+        // Release to the adapter, then bridge exactly what the adapter received,
+        // so the release and the cross-chain send are bound on-chain. The Bridge
+        // recipient is forced to the adapter (not taken from params).
+        uint256 delivered;
+        {
+            address token = IBridgeToken(bridge).TOKEN();
+            uint256 balanceBefore = IERC20(token).balanceOf(adapter);
+            IBridge(bridge).fundsOut(IBridge.FundsOutParams({
+                recipient:          adapter,
+                amount:             params.amount,
+                burnId:             params.burnId,
+                sourceChainId:      params.sourceChainId,
+                destinationChainId: params.destinationChainId,
+                sourceAddress:      params.sourceAddress,
+                proof:              params.proof,
+                settlementData:     params.settlementData
+            }));
+            delivered = IERC20(token).balanceOf(adapter) - balanceBefore;
+        }
+
+        ILZAdapterSendOut(adapter).sendOut{ value: msg.value }(
+            params.dstEid, params.recipient, delivered, params.minAmountLD, params.extraOptions
+        );
+
+        emit LzFundsOutExecuted(nonce, enclaveBitmap, params.dstEid, params.recipient, delivered);
+    }
+
+    /// @dev EIP-712 struct hash for `TeeLzFundsOut`. Isolated in its own frame
+    ///      to keep `lzFundsOutCall` within stack limits.
+    function _lzFundsOutStructHash(
+        LzFundsOutParams calldata params,
+        uint256 nonce,
+        uint256 deadline
+    ) private pure returns (bytes32) {
+        // Built in two `abi.encode` halves joined with `bytes.concat`. Every
+        // field is a 32-byte word (dynamic ones are pre-hashed), so the result
+        // is byte-identical to encoding all fields at once, but each half is
+        // shallow enough to compile without the optimizer (e.g. `forge coverage`).
+        return keccak256(bytes.concat(
+            abi.encode(
+                _TEE_LZ_FUNDS_OUT_TYPEHASH,
+                params.amount,
+                params.burnId,
+                params.sourceChainId,
+                params.destinationChainId,
+                keccak256(bytes(params.sourceAddress)),
+                keccak256(params.proof)
+            ),
+            abi.encode(
+                keccak256(params.settlementData),
+                params.dstEid,
+                params.recipient,
+                params.minAmountLD,
+                keccak256(params.extraOptions),
+                nonce,
+                deadline
+            )
+        ));
+    }
+
+    /// @dev Shared timing guard for the typed enclave methods: not expired, and
+    ///      the signed deadline cannot sit further than `MAX_TEE_DEADLINE` ahead.
+    function _checkTeeTiming(uint256 deadline) private view {
         if (block.timestamp > deadline) revert Expired();
-        // Bound the signed deadline's distance into the future;
         if (deadline > block.timestamp + MAX_TEE_DEADLINE) revert DeadlineTooFar();
-        uint256 n = targets.length;
-        if (n == 0) revert BatchEmpty();
-        if (n > MAX_BATCH_SIZE) revert BatchTooLarge();
-        if (callDatas.length != n || values.length != n) revert BatchLengthMismatch();
-        if (nonce != batchNonce) revert InvalidNonce();
-
-        // 1. Allowlist + selector extraction + native value accounting.
-        bytes4[] memory selectors = new bytes4[](n);
-        uint256 totalValue;
-        for (uint256 i = 0; i < n; i++) {
-            if (callDatas[i].length < SELECTOR_LENGTH) revert CallDataTooShort();
-
-            bytes calldata cd = callDatas[i];
-            bytes4 sel;
-            assembly { sel := calldataload(cd.offset) }
-
-            if (!teeAllowedCalls[targets[i]][sel]) revert CallNotAllowed(targets[i], sel);
-
-            selectors[i] = sel;
-            totalValue  += values[i];
-        }
-        if (totalValue != msg.value) revert BatchValueMismatch();
-
-        // 2. EIP-712 digest over the whole batch + M-of-N enclave verification.
-        bytes32 digest = _buildBatchDigest(targets, callDatas, values, nonce, deadline);
-        _verifySignatures(digest, enclaveBitmap, enclaveSigs, _enclaveSigners, enclaveThreshold);
-
-        batchNonce++;
-
-        // 3. Atomic dispatch — any inner revert rolls back the whole batch.
-        for (uint256 i = 0; i < n; i++) {
-            (bool ok, bytes memory ret) = targets[i].call{ value: values[i] }(callDatas[i]);
-            _propagateRevert(ok, ret);
-        }
-
-        emit BatchExecuted(nonce, enclaveBitmap, targets, selectors);
     }
 
     // =========================================================================
@@ -472,29 +530,6 @@ contract MultisigProxy is IMultisigProxy {
         return _propose(
             OperationType.SetCommissionRecipient,
             abi.encode(newRecipient),
-            nonce, deadline, structHash, fedBitmap, fedSigs
-        );
-    }
-
-    /// @inheritdoc IMultisigProxy
-    function proposeSetTeeAllowedCall(
-        address target,
-        bytes4 selector,
-        bool allowed,
-        uint256 nonce,
-        uint256 deadline,
-        uint256 fedBitmap,
-        bytes[] calldata fedSigs
-    ) external returns (bytes32) {
-        if (target == address(0)) revert ZeroTarget();
-
-        bytes32 structHash = keccak256(abi.encode(
-            _PROPOSE_SET_TEE_CALL_TYPEHASH, target, selector, allowed, nonce, deadline
-        ));
-
-        return _propose(
-            OperationType.SetTeeAllowedCall,
-            abi.encode(target, selector, allowed),
             nonce, deadline, structHash, fedBitmap, fedSigs
         );
     }
@@ -806,10 +841,6 @@ contract MultisigProxy is IMultisigProxy {
         return recovered == _enclaveSigners[signerIndex];
     }
 
-    /// @inheritdoc IMultisigProxy
-    function getNonce(bytes4 selector) external view returns (uint256) {
-        return nonces[selector];
-    }
 
     /// @inheritdoc IMultisigProxy
     function getEnclaveSigners() external view returns (address[] memory) {
@@ -912,12 +943,6 @@ contract MultisigProxy is IMultisigProxy {
             commissionRecipient = newRecipient;
             emit CommissionRecipientUpdated(old, newRecipient);
 
-        } else if (opType == OperationType.SetTeeAllowedCall) {
-            (address target, bytes4 sel, bool allowed) = abi.decode(opData, (address, bytes4, bool));
-            if (target == address(0)) revert ZeroTarget();
-            teeAllowedCalls[target][sel] = allowed;
-            emit TeeAllowedCallUpdated(target, sel, allowed);
-
         } else if (opType == OperationType.SetTimelockDuration) {
             uint256 newDuration = abi.decode(opData, (uint256));
             if (newDuration < MIN_TIMELOCK) revert TimelockTooShort();
@@ -1017,49 +1042,35 @@ contract MultisigProxy is IMultisigProxy {
     // Internal — cryptography helpers
     // =========================================================================
 
+    /// @notice EIP-712 domain separator for this contract on the current chain.
+    /// @dev Returns the value cached at deploy while `block.chainid` is
+    ///      unchanged; after a chain-id change it is rebuilt, so pre-fork
+    ///      signatures are not valid on the forked chain (R-W-13).
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        return _domainSeparator();
+    }
+
+    /// @dev Cached domain separator on the original chain; rebuilt on a fork.
+    function _domainSeparator() private view returns (bytes32) {
+        return block.chainid == _cachedChainId
+            ? _cachedDomainSeparator
+            : _buildDomainSeparator();
+    }
+
+    /// @dev Computes the EIP-712 domain separator over the current chain id.
+    function _buildDomainSeparator() private view returns (bytes32) {
+        return keccak256(abi.encode(
+            _DOMAIN_TYPEHASH,
+            keccak256('MultisigProxy'),
+            keccak256('1'),
+            block.chainid,
+            address(this)
+        ));
+    }
+
     /// @dev Wraps a struct hash into a full EIP-712 digest.
     function _hashTypedData(bytes32 structHash) private view returns (bytes32) {
-        return keccak256(abi.encodePacked('\x19\x01', DOMAIN_SEPARATOR, structHash));
-    }
-
-    /// @dev Builds an EIP-712 digest for TEE execute().
-    function _buildDigest(
-        bytes32 typeHash,
-        bytes4 selector,
-        bytes calldata callData,
-        uint256 nonce,
-        uint256 deadline
-    ) private view returns (bytes32) {
-        return _hashTypedData(
-            keccak256(abi.encode(typeHash, selector, keccak256(callData), nonce, deadline))
-        );
-    }
-
-    /// @dev Builds an EIP-712 digest for TEE executeBatch().
-    ///      Per EIP-712 array encoding:
-    ///        - address[] / uint256[] hashes are keccak256 of their packed elements,
-    ///        - bytes[] hashes are keccak256 of the packed per-element keccak256.
-    function _buildBatchDigest(
-        address[] calldata targets,
-        bytes[]   calldata callDatas,
-        uint256[] calldata values,
-        uint256 nonce,
-        uint256 deadline
-    ) private view returns (bytes32) {
-        bytes32[] memory cdHashes = new bytes32[](callDatas.length);
-        for (uint256 i = 0; i < callDatas.length; i++) {
-            cdHashes[i] = keccak256(callDatas[i]);
-        }
-
-        bytes32 structHash = keccak256(abi.encode(
-            _BRIDGE_BATCH_OP_TYPEHASH,
-            keccak256(abi.encodePacked(targets)),
-            keccak256(abi.encodePacked(cdHashes)),
-            keccak256(abi.encodePacked(values)),
-            nonce,
-            deadline
-        ));
-        return _hashTypedData(structHash);
+        return keccak256(abi.encodePacked('\x19\x01', _domainSeparator(), structHash));
     }
 
     /// @dev Verifies M-of-N bitmap signatures against the given signer set.

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -121,29 +121,34 @@ interface IBridge {
     ) external payable;
 
     // =========================================================================
-    // External — owner-only (called via MultisigProxy.execute)
+    // External — owner-only (called via MultisigProxy)
     // =========================================================================
 
-    /// @notice Release tokens to a recipient.
-    ///
-    ///       Only callable by owner (`MultisigProxy` via `execute()`).
-    /// @dev `destinationChainId` is part of the CommissionManager route key
-    ///      and lets the same Bridge serve multi-hop routes.
-    /// @dev `burnId` is the common single-use replay guard enforced by Bridge
-    ///      itself; it MUST be unique across every successful fundsOut call.
-    /// @dev `proof` is opaque per-route data consumed by `IFinalityVerifier`.
-    ///      `settlementData` is opaque per-route data consumed by
-    ///      `ISettlementModule`. Each plugin owns its own encoding.
-    function fundsOut(
-        address recipient,
-        uint256 amount,
-        uint256 burnId,
-        uint256 sourceChainId,
-        uint256 destinationChainId,
-        string  calldata sourceAddress,
-        bytes   calldata proof,
-        bytes   calldata settlementData
-    ) external;
+    /// @notice Release parameters for `fundsOut`.
+    /// @param recipient          Recipient on this chain.
+    /// @param amount             Gross amount to release (pre-commission).
+    /// @param burnId             Single-use replay guard; MUST be unique across
+    ///                           every successful `fundsOut`.
+    /// @param sourceChainId      Source chain id.
+    /// @param destinationChainId Destination chain id; part of the
+    ///                           CommissionManager route key.
+    /// @param sourceAddress      Sender address on the source chain.
+    /// @param proof              Opaque per-route data for `IFinalityVerifier`.
+    /// @param settlementData     Opaque per-route data for `ISettlementModule`.
+    struct FundsOutParams {
+        address recipient;
+        uint256 amount;
+        uint256 burnId;
+        uint256 sourceChainId;
+        uint256 destinationChainId;
+        string  sourceAddress;
+        bytes   proof;
+        bytes   settlementData;
+    }
+
+    /// @notice Release tokens to a recipient. Only callable by owner
+    ///         (`MultisigProxy`). Parameters are bundled in `FundsOutParams`.
+    function fundsOut(FundsOutParams calldata params) external;
 
     // =========================================================================
     // External — admin (called via MultisigProxy)

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.35;
 
+import { IBridge } from './IBridge.sol';
+
 /// @title IMultisigProxy
 /// @notice Two-level ECDSA multisig proxy that owns the Bridge and the CommissionManager.
 ///
 /// @dev ENCLAVE SIGNERS (TEE / Nitro Enclave)
-///      Authorise routine value-transfer operations via `execute()` (single call to
-///      Bridge) or `executeBatch()` (atomic multi-call to any allowlisted target,
-///      e.g. Bridge.fundsOut + LZAdapter.sendOut for outbound RGB → non-Arbitrum).
-///      Restricted to a configurable per-(target, selector) allowlist.
-///      Uses per-selector nonces for `execute()` and a sequential `batchNonce` for
-///      `executeBatch()`.
+///      Authorise releases through two purpose-built, typed methods — there is
+///      no generic call dispatch, so the enclave path can never reach a
+///      privileged setter:
+///        - `fundsOutCall`   — a single `Bridge.fundsOut` (RGB → Arbitrum);
+///        - `lzFundsOutCall`  — `Bridge.fundsOut` to the LZ adapter then
+///          `adapter.sendOut`, with the two legs bound on-chain (RGB → non-Arbitrum).
+///      Both share a single sequential `teeNonce` for replay protection.
 ///
 ///      FEDERATION SIGNERS (governance / admin nodes)
 ///      All administrative operations go through a two-phase timelock:
@@ -69,6 +72,7 @@ interface IMultisigProxy {
     error UnknownOperationType();
     error ZeroRecipient();
     error ZeroTarget();
+    error LZAdapterNotSet();
     error BatchEmpty();
     error BatchLengthMismatch();
     error BatchTooLarge();
@@ -80,25 +84,41 @@ interface IMultisigProxy {
 
     enum OperationType {
         AdminExecute,                    // 0  — generic call into Bridge
-        UpdateEnclaveSigners,            // 1
-        UpdateFederationSigners,         // 2
-        UpdateBridge,                    // 3
-        SetCommissionRecipient,          // 4
-        SetTeeAllowedCall,               // 5  — (target, selector, allowed) entry in TEE allowlist
-        SetTimelockDuration,             // 6
-        AdminExecuteCommissionManager,   // 7  — generic call into CommissionManager
-        WithdrawTokenCommissionCM,       // 8  — CM.withdrawTokenCommission -> commissionRecipient
-        WithdrawNativeCommissionCM,      // 9  — CM.withdrawNativeCommission -> commissionRecipient
-        UpdateCommissionManager,         // 10 — migrate to a new CommissionManager address
-        AdminExecuteAdapter,             // 11 — generic call into LZAdapter (setTrustedEntrypoint, refundStuckFunds, …)
-        UpdateLZAdapter,                 // 12 — rotate the routing target for AdminExecuteAdapter
-        SetRoute,                        // 13 — RouteRegistry.setRoute(src, dst, enabled, verifier, module)
-        UpdateRouteRegistry,             // 14 — Bridge.setRouteRegistry(newRouteRegistry)
-        PauseInflow,                     // 15 — Bridge.pauseInflow()  (planned inflow-only freeze, timelocked)
-        UnpauseInflow                    // 16 — Bridge.unpauseInflow()
+        UpdateEnclaveSigners,            // 1  — replace the enclave signer set + threshold
+        UpdateFederationSigners,         // 2  — replace the federation signer set + threshold
+        UpdateBridge,                    // 3  — repoint the owned Bridge address
+        SetCommissionRecipient,          // 4  — set the pinned commission payout recipient
+        SetTimelockDuration,             // 5  — change the governance timelock (>= MIN_TIMELOCK)
+        AdminExecuteCommissionManager,   // 6  — generic call into CommissionManager
+        WithdrawTokenCommissionCM,       // 7  — CM.withdrawTokenCommission -> commissionRecipient
+        WithdrawNativeCommissionCM,      // 8  — CM.withdrawNativeCommission -> commissionRecipient
+        UpdateCommissionManager,         // 9  — migrate to a new CommissionManager address
+        AdminExecuteAdapter,             // 10 — generic call into LZAdapter (setTrustedEntrypoint, refundStuckFunds, …)
+        UpdateLZAdapter,                 // 11 — rotate the routing target for AdminExecuteAdapter
+        SetRoute,                        // 12 — RouteRegistry.setRoute(src, dst, enabled, verifier, module)
+        UpdateRouteRegistry,             // 13 — Bridge.setRouteRegistry(newRouteRegistry)
+        PauseInflow,                     // 14 — Bridge.pauseInflow()  (planned inflow-only freeze, timelocked)
+        UnpauseInflow                    // 15 — Bridge.unpauseInflow()
     }
 
     enum ProposalStatus { None, Pending, Executed, Cancelled }
+
+    /// @notice Business parameters for `lzFundsOut`, bundled to keep the call
+    ///         within stack limits. Signed as the EIP-712 `TeeLzFundsOut` struct
+    ///         (these fields plus `nonce` and `deadline`).
+    struct LzFundsOutParams {
+        uint256 amount;
+        uint256 burnId;
+        uint256 sourceChainId;
+        uint256 destinationChainId;
+        string  sourceAddress;
+        bytes   proof;
+        bytes   settlementData;
+        uint32  dstEid;
+        bytes32 recipient;
+        uint256 minAmountLD;
+        bytes   extraOptions;
+    }
 
     struct Proposal {
         bytes32 dataHash;
@@ -113,9 +133,15 @@ interface IMultisigProxy {
     // Events
     // =========================================================================
 
-    // TEE
-    event Executed(bytes4 indexed selector, uint256 nonce, uint256 enclaveBitmap);
-    event BatchExecuted(uint256 indexed nonce, uint256 enclaveBitmap, address[] targets, bytes4[] selectors);
+    // TEE — typed enclave releases
+    event FundsOutExecuted(uint256 indexed nonce, uint256 enclaveBitmap);
+    event LzFundsOutExecuted(
+        uint256 indexed nonce,
+        uint256 enclaveBitmap,
+        uint32  dstEid,
+        bytes32 recipient,
+        uint256 amount
+    );
 
     // Federation proposals
     event ProposalCreated(
@@ -140,7 +166,6 @@ interface IMultisigProxy {
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event CommissionRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
-    event TeeAllowedCallUpdated(address indexed target, bytes4 indexed selector, bool allowed);
     event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
     event NativeCommissionWithdrawn(uint256 amount, address indexed recipient);
     event TimelockDurationUpdated(uint256 newDuration);
@@ -149,25 +174,25 @@ interface IMultisigProxy {
     // TEE-authorized
     // =========================================================================
 
-    /// @notice Execute a Bridge call authorised by M-of-N enclave signatures.
-    ///         Selector must be in the TEE allowlist for the Bridge target. Per-selector nonces.
-    function execute(
-        bytes calldata callData,
+    /// @notice Typed enclave release: authorise `Bridge.fundsOut` with M-of-N
+    ///         enclave signatures over the release parameters. The only call this
+    ///         makes is `Bridge.fundsOut` — there is no generic dispatch, so the
+    ///         enclave path can never reach a privileged setter.
+    function fundsOutCall(
+        IBridge.FundsOutParams calldata params,
         uint256 nonce,
         uint256 deadline,
         uint256 enclaveBitmap,
         bytes[] calldata enclaveSigs
     ) external;
 
-    /// @notice Execute multiple calls atomically, authorised by a single set of M-of-N
-    ///         enclave signatures over the whole batch.
-    /// @dev Each `(targets[i], selector(callDatas[i]))` must be in the TEE allowlist.
-    ///      `sum(values) == msg.value`. Either all succeed or the batch reverts.
-    ///      Uses sequential `batchNonce` for replay protection.
-    function executeBatch(
-        address[] calldata targets,
-        bytes[] calldata callDatas,
-        uint256[] calldata values,
+    /// @notice Typed Flow-4 enclave release: release to the LZ adapter and bridge
+    ///         onward in one signed operation. The Bridge recipient is forced to
+    ///         `lzAdapter` and the amount sent out equals the balance the adapter
+    ///         actually received, so the release and the cross-chain send are
+    ///         bound on-chain. `msg.value` funds the LayerZero native fee.
+    function lzFundsOutCall(
+        LzFundsOutParams calldata params,
         uint256 nonce,
         uint256 deadline,
         uint256 enclaveBitmap,
@@ -251,17 +276,6 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose adding/removing a TEE-allowed (target, selector) pair.
-    /// @dev opData = abi.encode(address target, bytes4 selector, bool allowed)
-    function proposeSetTeeAllowedCall(
-        address target,
-        bytes4 selector,
-        bool allowed,
-        uint256 nonce,
-        uint256 deadline,
-        uint256 fedBitmap,
-        bytes[] calldata fedSigs
-    ) external returns (bytes32);
 
     /// @notice Propose changing the timelock duration.
     /// @dev opData = abi.encode(uint256 newDuration)
@@ -431,7 +445,7 @@ interface IMultisigProxy {
         uint256 signerIndex
     ) external view returns (bool);
 
-    function getNonce(bytes4 selector) external view returns (uint256);
+    function teeNonce() external view returns (uint256);
     function bridge() external view returns (address);
     function commissionManager() external view returns (address);
     function lzAdapter() external view returns (address);
@@ -440,8 +454,6 @@ interface IMultisigProxy {
     function getFederationSigners() external view returns (address[] memory);
     function federationThreshold() external view returns (uint256);
     function commissionRecipient() external view returns (address);
-    function teeAllowedCalls(address target, bytes4 selector) external view returns (bool);
-    function batchNonce() external view returns (uint256);
     function DOMAIN_SEPARATOR() external view returns (bytes32);
     function proposalNonce() external view returns (uint256);
     function timelockDuration() external view returns (uint256);

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -104,6 +104,7 @@ interface IMultisigProxy {
         bytes32 dataHash;
         uint256 proposedAt;
         uint256 deadline;
+        uint256 timelockSnapshot;
         OperationType opType;
         ProposalStatus status;
     }

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -155,6 +155,25 @@ contract BridgeTest is Test {
         return abi.encode(ids);
     }
 
+    /// @dev Wrap the former 8 positional `fundsOut` args into the typed struct
+    ///      and make the external Bridge call. Keeps `vm.prank` / `vm.expectRevert`
+    ///      working: the inner `bridge.fundsOut` is the next external call.
+    function _fundsOut(
+        address recipient_,
+        uint256 amount,
+        uint256 burnId,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory sourceAddress,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal {
+        bridge.fundsOut(IBridge.FundsOutParams(
+            recipient_, amount, burnId, sourceChainId, destinationChainId,
+            sourceAddress, proof, settlementData
+        ));
+    }
+
     /// @dev Build an ASCII string of exactly `len` bytes (for address-length caps).
     function _str(uint256 len) internal pure returns (string memory) {
         bytes memory b = new bytes(len);
@@ -371,7 +390,7 @@ contract BridgeTest is Test {
         // fires before the burn-id and balance checks.
         vm.expectRevert(IBridge.ZeroAmount.selector);
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, 0, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(_singleFundsInId())
@@ -471,7 +490,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.AddressTooLong.selector, max + 1, max));
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, tooLong,
             _proof(), _settlement(_singleFundsInId())
@@ -485,7 +504,7 @@ contract BridgeTest is Test {
         uint256 max = bridge.MAX_ADDRESS_LENGTH();
 
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, _str(max),
             _proof(), _settlement(_singleFundsInId())
@@ -519,7 +538,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.ProofTooLong.selector, max + 1, max));
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             tooLong, _settlement(_singleFundsInId())
@@ -538,11 +557,11 @@ contract BridgeTest is Test {
         bytes memory atMax = _bytesOfLength(max);
 
         vm.prank(multisig);
-        try bridge.fundsOut(
+        try bridge.fundsOut(IBridge.FundsOutParams(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             atMax, _settlement(_singleFundsInId())
-        ) {
+        )) {
             // a decodable proof would succeed; this blob won't, so we don't
             // expect to land here — but if a future verifier accepts it, the
             // length guard still passed, which is what this test asserts.
@@ -562,7 +581,7 @@ contract BridgeTest is Test {
         assertLt(_proof().length, bridge.MAX_PROOF_LENGTH(), 'sanity: real proof under cap');
 
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(_singleFundsInId())
@@ -706,7 +725,7 @@ contract BridgeTest is Test {
         );
 
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(_singleFundsInId())
@@ -721,7 +740,7 @@ contract BridgeTest is Test {
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
 
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(_singleFundsInId())
@@ -746,7 +765,7 @@ contract BridgeTest is Test {
         ids[1] = txId2;
 
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, amount1 + amount2, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(ids)
@@ -770,7 +789,7 @@ contract BridgeTest is Test {
         // RGBVerifier → BtcRelay reverts with the relay's string message.
         vm.expectRevert('verify: block commitment');
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             badProof, _settlement(_singleFundsInId())
@@ -791,7 +810,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, 999));
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(ids)
@@ -811,7 +830,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(RgbSettlementModule.FundsOutAmountExceedsFundsIn.selector);
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, 60e18, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(ids)
@@ -830,7 +849,7 @@ contract BridgeTest is Test {
         uint256[] memory ids2 = new uint256[](1); ids2[0] = txId2;
 
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(ids1)
@@ -841,7 +860,7 @@ contract BridgeTest is Test {
         // module mutation, leaving the second record untouched.
         vm.expectRevert(abi.encodeWithSelector(IBridge.BurnIdAlreadyConsumed.selector, BURN_ID));
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(ids2)
@@ -854,7 +873,7 @@ contract BridgeTest is Test {
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
 
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(_singleFundsInId())
@@ -866,7 +885,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, TX_ID));
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID + 1,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(_singleFundsInId())
@@ -883,7 +902,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(_singleFundsInId())
@@ -896,7 +915,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(BridgeBase.InvalidRecipientAddress.selector);
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             address(0), AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(_singleFundsInId())
@@ -909,7 +928,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(BridgeBase.AmountExceedBridgePool.selector);
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT + 1, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(_singleFundsInId())
@@ -975,7 +994,7 @@ contract BridgeTest is Test {
         uint256 expectedNet        = AMOUNT - expectedCommission;
 
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(_singleFundsInId())
@@ -1255,7 +1274,7 @@ contract BridgeTest is Test {
 
         // Release only part of the RGB record; the module should preserve the residual.
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient,
             releaseAmount,
             BURN_ID,
@@ -1404,7 +1423,7 @@ contract BridgeTest is Test {
         // can be consumed.
         vm.expectRevert('verify: block commitment');
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient,
             AMOUNT,
             BURN_ID,
@@ -1460,7 +1479,7 @@ contract BridgeTest is Test {
         // is underfunded; the revert must restore that consumed record too.
         vm.expectRevert(RgbSettlementModule.FundsOutAmountExceedsFundsIn.selector);
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             recipient,
             releaseAmount,
             BURN_ID,
@@ -1532,7 +1551,7 @@ contract BridgeTest is Test {
         );
 
         vm.prank(multisig);
-        bridge.fundsOut(
+        _fundsOut(
             alternateRecipient,
             releaseAmount,
             alternateBurnId,

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -7,6 +7,7 @@ import { Bridge } from '../src/Bridge.sol';
 import { CommissionManager } from '../src/CommissionManager.sol';
 import { MultisigProxy } from '../src/MultisigProxy.sol';
 import { IMultisigProxy } from '../src/interfaces/IMultisigProxy.sol';
+import { IBridge }        from '../src/interfaces/IBridge.sol';
 import { RouteRegistry } from '../src/RouteRegistry.sol';
 import { RGBVerifier } from '../src/verifiers/RGBVerifier.sol';
 import { RgbSettlementModule } from '../src/settlement/RgbSettlementModule.sol';
@@ -93,21 +94,6 @@ contract IntegrationTest is Test {
 
     uint256 constant TIMELOCK     = 1 hours;
     uint256 constant MIN_TIMELOCK = 1 hours; // floor passed to the proxy constructor in tests
-
-    /// @dev New 8-arg fundsOut selector:
-    ///        fundsOut(
-    ///          address recipient,
-    ///          uint256 amount,
-    ///          uint256 burnId,
-    ///          uint256 sourceChainId,
-    ///          uint256 destinationChainId,
-    ///          string  sourceAddress,
-    ///          bytes   proof,
-    ///          bytes   settlementData
-    ///        )
-    bytes4 constant FUNDS_OUT_SELECTOR = bytes4(keccak256(
-        'fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)'
-    ));
 
     // =========================================================================
     // Re-declared events for vm.expectEmit
@@ -300,8 +286,7 @@ contract IntegrationTest is Test {
         bytes memory proof          = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
         bytes memory settlementData = abi.encode(fundsInIds);
 
-        bytes memory callData = abi.encodeWithSelector(
-            FUNDS_OUT_SELECTOR,
+        IBridge.FundsOutParams memory params = IBridge.FundsOutParams(
             recipient,
             netBridgedIn,          // amount = full bridged pool from this deposit
             BURN_ID,
@@ -312,10 +297,10 @@ contract IntegrationTest is Test {
             settlementData
         );
 
-        uint256 outNonce    = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        uint256 outNonce    = proxy.teeNonce();
         uint256 outDeadline = block.timestamp + 1 hours;
-        bytes32 outDigest   = MultisigHelper.digestBridgeOp(
-            domainSep, FUNDS_OUT_SELECTOR, callData, outNonce, outDeadline
+        bytes32 outDigest   = MultisigHelper.digestTeeFundsOut(
+            domainSep, params, outNonce, outDeadline
         );
         bytes[] memory teeSigs = _signEnclave2of3(outDigest); // signers 0 and 1
 
@@ -334,7 +319,7 @@ contract IntegrationTest is Test {
             'rgb:sender/utxo1src'
         );
 
-        proxy.execute(callData, outNonce, outDeadline, 3, teeSigs);
+        proxy.fundsOutCall(params, outNonce, outDeadline, 3, teeSigs);
 
         assertEq(token.balanceOf(address(bridge)),       0,                                      'bridge drained');
         assertEq(token.balanceOf(recipient),             netOut,                                 'recipient got net');

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -5,6 +5,7 @@ import { Test } from 'forge-std/Test.sol';
 
 import { MultisigProxy }  from '../src/MultisigProxy.sol';
 import { IMultisigProxy } from '../src/interfaces/IMultisigProxy.sol';
+import { IBridge }        from '../src/interfaces/IBridge.sol';
 import { Bridge }              from '../src/Bridge.sol';
 import { BridgeBase }          from '../src/BridgeBase.sol';
 import { Pausable }            from '@openzeppelin/contracts/utils/Pausable.sol';
@@ -66,7 +67,14 @@ contract MultisigProxyTest is Test {
     using MultisigHelper for bytes32;
 
     // ---- Re-declared events ------------------------------------------------
-    event Executed(bytes4 indexed selector, uint256 nonce, uint256 enclaveBitmap);
+    event FundsOutExecuted(uint256 indexed nonce, uint256 enclaveBitmap);
+    event LzFundsOutExecuted(
+        uint256 indexed nonce,
+        uint256 enclaveBitmap,
+        uint32  dstEid,
+        bytes32 recipient,
+        uint256 amount
+    );
     event EmergencyPaused(uint256 nonce, uint256 fedBitmap);
     event EmergencyUnpaused(uint256 nonce, uint256 fedBitmap);
     event ProposalCreated(
@@ -83,13 +91,11 @@ contract MultisigProxyTest is Test {
     event FederationSignersUpdated(address[] newSigners, uint256 newThreshold);
     event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
-    event TeeAllowedCallUpdated(address indexed target, bytes4 indexed selector, bool allowed);
     event TimelockDurationUpdated(uint256 newDuration);
     event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
     event TokenCommissionWithdrawn(address indexed token, address indexed to, uint256 amount);
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
-    event BatchExecuted(uint256 indexed nonce, uint256 enclaveBitmap, address[] targets, bytes4[] selectors);
     event SendOut(bytes32 indexed guid, uint32 dstEid, bytes32 recipient, uint256 amountLD);
     event BridgeFundsOut(
         address indexed recipient,
@@ -160,14 +166,6 @@ contract MultisigProxyTest is Test {
     uint256 constant BLOCK_HEIGHT      = 850_000;
     bytes32 constant COMMITMENT_HASH   = keccak256('test-btc-block-commitment');
     uint256 constant BTC_CONFIRMATIONS = 6;
-
-    /// @dev 8-arg fundsOut selector:
-    ///        fundsOut(address recipient, uint256 amount, uint256 burnId,
-    ///                 uint256 sourceChainId, uint256 destinationChainId,
-    ///                 string sourceAddress, bytes proof, bytes settlementData)
-    bytes4  constant FUNDS_OUT_SELECTOR = bytes4(keccak256(
-        'fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)'
-    ));
 
     function setUp() public {
         encA1 = vm.addr(encPk1);
@@ -289,38 +287,76 @@ contract MultisigProxyTest is Test {
         a[1] = fedA2;
     }
 
-    function _fundsOutCalldata() internal view returns (bytes memory) {
-        bytes memory proof          = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
-        bytes memory settlementData = abi.encode(_fundsInIds());
-        return abi.encodeWithSelector(
-            FUNDS_OUT_SELECTOR,
-            recipient, AMOUNT, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            proof, settlementData
-        );
+    /// @dev Standard single-release params (recipient = `recipient`, AMOUNT, BURN_ID).
+    function _fundsOutParams() internal view returns (IBridge.FundsOutParams memory) {
+        return _fundsOutParams(recipient, AMOUNT, BURN_ID);
     }
 
-    function _fundsOutCalldata(address payoutRecipient, uint256 amount, uint256 burnId) internal pure returns (bytes memory) {
-        bytes memory proof          = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
-        bytes memory settlementData = abi.encode(_fundsInIds());
-        return abi.encodeWithSelector(
-            FUNDS_OUT_SELECTOR,
-            payoutRecipient, amount, burnId, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            proof, settlementData
-        );
+    function _fundsOutParams(address payoutRecipient, uint256 amount, uint256 burnId)
+        internal
+        view
+        returns (IBridge.FundsOutParams memory)
+    {
+        return IBridge.FundsOutParams({
+            recipient:          payoutRecipient,
+            amount:             amount,
+            burnId:             burnId,
+            sourceChainId:      RGB_CHAIN_ID,
+            destinationChainId: SOURCE_CHAIN_ID,
+            sourceAddress:      SRC_ADDR,
+            proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH),
+            settlementData:     abi.encode(_fundsInIds())
+        });
     }
 
-    function _allowTeeCall(address target, bytes4 selector) internal {
-        uint256 nonce = proxy.proposalNonce();
+    /// @dev Flow-4 LZ release params. The Bridge recipient is forced to the
+    ///      adapter on-chain, so it is not part of these params; `recipient`
+    ///      here is the bytes32 destination on the far chain.
+    function _lzFundsOutParams(uint256 amount, uint256 burnId, uint256[] memory ids)
+        internal
+        view
+        returns (IMultisigProxy.LzFundsOutParams memory)
+    {
+        return IMultisigProxy.LzFundsOutParams({
+            amount:             amount,
+            burnId:             burnId,
+            sourceChainId:      RGB_CHAIN_ID,
+            destinationChainId: SOURCE_CHAIN_ID,
+            sourceAddress:      SRC_ADDR,
+            proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH),
+            settlementData:     abi.encode(ids),
+            dstEid:             DST_EID,
+            recipient:          LZ_RECIPIENT,
+            minAmountLD:        0,
+            extraOptions:       hex'0003010011010000000000000000000000000000ea60'
+        });
+    }
+
+    /// @dev Sign an lz release with the 2-of-3 enclave set at the live teeNonce.
+    ///      Returns the nonce/bitmap/sigs so the heavy snapshot tests keep fewer
+    ///      locals live (avoids via_ir stack-too-deep with the optimizer off).
+    function _signLzEnclave(IMultisigProxy.LzFundsOutParams memory params, uint256 deadline)
+        internal
+        view
+        returns (uint256 nonce, uint256 bitmap, bytes[] memory sigs)
+    {
+        nonce = proxy.teeNonce();
+        bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
+        uint256[] memory pks;
+        (pks, bitmap) = _encSigSet2of3();
+        sigs = MultisigHelper.signAll(vm, digest, pks);
+    }
+
+    /// @dev Set the proxy's `lzAdapter` via the timelocked governance path so the
+    ///      typed `lzFundsOutCall` flow can run end-to-end.
+    function _setLzAdapter(address adapter) internal {
+        uint256 nonce    = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
-        bytes32 digest = MultisigHelper.digestProposeSetTeeAllowedCall(
-            domainSep, target, selector, true, nonce, deadline
-        );
+        bytes32 digest   = MultisigHelper.digestProposeUpdateLZAdapter(domainSep, adapter, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
-
-        bytes32 id = proxy.proposeSetTeeAllowedCall(target, selector, true, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateLZAdapter(adapter, nonce, deadline, bitmap, MultisigHelper.signAll(vm, digest, pks));
         vm.warp(block.timestamp + TIMELOCK + 1);
-        proxy.executeProposal(id, abi.encode(target, selector, true));
+        proxy.executeProposal(id, abi.encode(adapter));
     }
 
     // ========================================================================
@@ -335,8 +371,7 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.commissionRecipient(), commissionReceiver);
         assertEq(proxy.timelockDuration(), TIMELOCK);
         assertEq(proxy.proposalNonce(), 0);
-        // Default TEE allowlist uses the new 8-arg fundsOut selector.
-        assertTrue(proxy.teeAllowedCalls(address(bridge), FUNDS_OUT_SELECTOR));
+        assertEq(proxy.teeNonce(),      0);
 
         address[] memory enc = proxy.getEnclaveSigners();
         assertEq(enc.length, 3);
@@ -672,323 +707,197 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
-    // TEE execute — happy path
+    // TEE fundsOutCall — happy path
     // ========================================================================
 
-    function test_execute_fundsOutViaBridge() public {
-        bytes memory callData = _fundsOutCalldata();
-        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+    function test_fundsOutCall_releasesViaBridge() public {
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 nonce = proxy.teeNonce();
         uint256 deadline = block.timestamp + 1 hours;
 
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectEmit(true, false, false, true);
-        emit Executed(FUNDS_OUT_SELECTOR, nonce, bitmap);
+        emit FundsOutExecuted(nonce, bitmap);
 
-        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+        proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
         assertEq(token.balanceOf(recipient), AMOUNT);
-        assertEq(proxy.getNonce(FUNDS_OUT_SELECTOR), nonce + 1);
+        assertEq(proxy.teeNonce(), nonce + 1);
     }
 
-    function test_execute_revertsOnExpired() public {
-        bytes memory callData = _fundsOutCalldata();
-        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+    function test_fundsOutCall_revertsOnExpired() public {
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 nonce = proxy.teeNonce();
         uint256 deadline = block.timestamp - 1;
 
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.Expired.selector);
-        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+        proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
     }
 
     // ========================================================================
     // TEE deadline upper bound (R-I-01 / UT-FIX-23)
     //
-    // execute / executeBatch reject a signed deadline further than
+    // fundsOutCall / lzFundsOutCall reject a signed deadline further than
     // MAX_TEE_DEADLINE into the future, so a leaked or pre-signed payload cannot
     // stay executable indefinitely. The boundary (exactly now + MAX_TEE_DEADLINE)
     // is still accepted — the guard is a strict `>`.
     // ========================================================================
 
-    function test_execute_revertsOnDeadlineTooFar() public {
-        bytes memory callData = _fundsOutCalldata();
-        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+    function test_fundsOutCall_revertsOnDeadlineTooFar() public {
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 nonce = proxy.teeNonce();
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE() + 1;
 
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.DeadlineTooFar.selector);
-        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+        proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
     }
 
-    function test_execute_acceptsDeadlineAtMaxBoundary() public {
-        bytes memory callData = _fundsOutCalldata();
-        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+    function test_fundsOutCall_acceptsDeadlineAtMaxBoundary() public {
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 nonce = proxy.teeNonce();
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE(); // exact boundary, strict `>` lets it through
 
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+        proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
         assertEq(token.balanceOf(recipient), AMOUNT, 'executes at the exact deadline ceiling');
     }
 
-    function test_executeBatch_revertsOnDeadlineTooFar() public {
-        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
-        uint256 nonce    = proxy.batchNonce();
+    function test_lzFundsOutCall_revertsOnDeadlineTooFar() public {
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));
+
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        uint256 nonce    = proxy.teeNonce();
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE() + 1;
 
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(domainSep, targets, callDatas, values, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
+        vm.deal(address(this), LZ_NATIVE_FEE);
         vm.expectRevert(IMultisigProxy.DeadlineTooFar.selector);
-        proxy.executeBatch(targets, callDatas, values, nonce, deadline, bitmap, sigs);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
     }
 
-    function test_executeBatch_acceptsDeadlineAtMaxBoundary() public {
-        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
-        uint256 nonce    = proxy.batchNonce();
+    function test_lzFundsOutCall_acceptsDeadlineAtMaxBoundary() public {
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));
+
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        uint256 nonce    = proxy.teeNonce();
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE(); // exact boundary
 
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(domainSep, targets, callDatas, values, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        proxy.executeBatch(targets, callDatas, values, nonce, deadline, bitmap, sigs);
-        assertEq(token.balanceOf(recipient), AMOUNT,    'batch executes at the exact deadline ceiling');
-        assertEq(proxy.batchNonce(),         nonce + 1, 'batchNonce incremented');
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
+        assertEq(token.balanceOf(mockOft), AMOUNT, 'lz release executes at the exact deadline ceiling');
+        assertEq(proxy.teeNonce(),         nonce + 1, 'teeNonce incremented');
     }
 
-    function test_execute_revertsOnWrongNonce() public {
-        bytes memory callData = _fundsOutCalldata();
+    function test_fundsOutCall_revertsOnWrongNonce() public {
+        IBridge.FundsOutParams memory params = _fundsOutParams();
         uint256 nonce = 99;
         uint256 deadline = block.timestamp + 1 hours;
 
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
-        proxy.execute(callData, nonce, deadline, bitmap, sigs);
-    }
-
-    function test_execute_revertsOnDisallowedSelector() public {
-        bytes memory callData = abi.encodeWithSignature('pauseInflow()');
-        uint256 nonce = 0;
-        uint256 deadline = block.timestamp + 1 hours;
-
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, bytes4(callData), callData, nonce, deadline);
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
-
-        vm.expectRevert(abi.encodeWithSelector(
-            IMultisigProxy.CallNotAllowed.selector, address(bridge), bytes4(callData)
-        ));
-        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+        proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
     }
 
     // ========================================================================
-    // executeBatch
+    // TEE fundsOutCall — signature / bitmap reverts
     // ========================================================================
 
-    /// @dev Helper: build a single-element batch around the standard fundsOut call.
-    function _singleFundsOutBatch() internal view returns (
-        address[] memory targets,
-        bytes[]   memory callDatas,
-        uint256[] memory values
-    ) {
-        targets = new address[](1);
-        callDatas = new bytes[](1);
-        values = new uint256[](1);
-        targets[0]   = address(bridge);
-        callDatas[0] = _fundsOutCalldata();
-        values[0]    = 0;
-    }
-
-    function test_executeBatch_singleFundsOut_happyPath() public {
-        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
-
-        uint256 nonce    = proxy.batchNonce();
+    function test_fundsOutCall_revertsOnBelowThreshold() public {
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 nonce = proxy.teeNonce();
         uint256 deadline = block.timestamp + 1 hours;
 
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
-            domainSep, targets, callDatas, values, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
-
-        proxy.executeBatch(targets, callDatas, values, nonce, deadline, bitmap, sigs);
-
-        assertEq(token.balanceOf(recipient), AMOUNT,    'fundsOut delivered');
-        assertEq(proxy.batchNonce(),         nonce + 1, 'batchNonce incremented');
-    }
-
-    function test_executeBatch_revertsOnEmpty() public {
-        address[] memory targets = new address[](0);
-        bytes[]   memory callDatas = new bytes[](0);
-        uint256[] memory values = new uint256[](0);
-
-        bytes[] memory sigs = new bytes[](2);
-
-        vm.expectRevert(IMultisigProxy.BatchEmpty.selector);
-        proxy.executeBatch(targets, callDatas, values, 0, block.timestamp + 1 hours, 0x3, sigs);
-    }
-
-    function test_executeBatch_revertsOnLengthMismatch() public {
-        address[] memory targets   = new address[](2);
-        bytes[]   memory callDatas = new bytes[](1);
-        uint256[] memory values    = new uint256[](2);
-        targets[0] = address(bridge); targets[1] = address(bridge);
-        callDatas[0] = _fundsOutCalldata();
-
-        bytes[] memory sigs = new bytes[](2);
-
-        vm.expectRevert(IMultisigProxy.BatchLengthMismatch.selector);
-        proxy.executeBatch(targets, callDatas, values, 0, block.timestamp + 1 hours, 0x3, sigs);
-    }
-
-    function test_executeBatch_revertsOnDisallowedTargetSelector() public {
-        address[] memory targets   = new address[](1);
-        bytes[]   memory callDatas = new bytes[](1);
-        uint256[] memory values    = new uint256[](1);
-        targets[0]   = makeAddr('random-target');
-        callDatas[0] = abi.encodeWithSignature('pauseInflow()');
-
-        uint256 nonce    = proxy.batchNonce();
-        uint256 deadline = block.timestamp + 1 hours;
-
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
-            domainSep, targets, callDatas, values, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
-
-        vm.expectRevert(abi.encodeWithSelector(
-            IMultisigProxy.CallNotAllowed.selector, targets[0], bytes4(callDatas[0])
-        ));
-        proxy.executeBatch(targets, callDatas, values, nonce, deadline, bitmap, sigs);
-    }
-
-    function test_executeBatch_revertsOnValueMismatch() public {
-        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
-        values[0] = 1 ether;
-
-        uint256 nonce    = proxy.batchNonce();
-        uint256 deadline = block.timestamp + 1 hours;
-
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
-            domainSep, targets, callDatas, values, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
-
-        vm.expectRevert(IMultisigProxy.BatchValueMismatch.selector);
-        proxy.executeBatch{ value: 0 }(targets, callDatas, values, nonce, deadline, bitmap, sigs);
-    }
-
-    function test_executeBatch_revertsOnTooLarge() public {
-        uint256 size = proxy.MAX_BATCH_SIZE() + 1;
-        address[] memory targets   = new address[](size);
-        bytes[]   memory callDatas = new bytes[](size);
-        uint256[] memory values    = new uint256[](size);
-
-        bytes[] memory sigs = new bytes[](2);
-        vm.expectRevert(IMultisigProxy.BatchTooLarge.selector);
-        proxy.executeBatch(targets, callDatas, values, 0, block.timestamp + 1 hours, 0x3, sigs);
-    }
-
-    function test_executeBatch_revertsOnExpired() public {
-        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
-
-        bytes[] memory sigs = new bytes[](2);
-        vm.expectRevert(IMultisigProxy.Expired.selector);
-        proxy.executeBatch(targets, callDatas, values, 0, block.timestamp - 1, 0x3, sigs);
-    }
-
-    function test_executeBatch_revertsOnWrongNonce() public {
-        (address[] memory targets, bytes[] memory callDatas, uint256[] memory values) = _singleFundsOutBatch();
-
-        uint256 wrongNonce = 99;
-        uint256 deadline   = block.timestamp + 1 hours;
-
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
-            domainSep, targets, callDatas, values, wrongNonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
-
-        vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
-        proxy.executeBatch(targets, callDatas, values, wrongNonce, deadline, bitmap, sigs);
-    }
-
-    function test_execute_revertsOnCallDataTooShort() public {
-        bytes memory callData = hex'aabb';
-        vm.expectRevert(IMultisigProxy.CallDataTooShort.selector);
-        proxy.execute(callData, 0, block.timestamp + 1 hours, 0x3, new bytes[](2));
-    }
-
-    function test_execute_revertsOnBelowThreshold() public {
-        bytes memory callData = _fundsOutCalldata();
-        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
-        uint256 deadline = block.timestamp + 1 hours;
-
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         uint256[] memory pks = new uint256[](1); pks[0] = encPk1;
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.BelowThreshold.selector);
-        proxy.execute(callData, nonce, deadline, 0x1, sigs);
+        proxy.fundsOutCall(params, nonce, deadline, 0x1, sigs);
     }
 
-    function test_execute_revertsOnBadSignature() public {
-        bytes memory callData = _fundsOutCalldata();
-        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+    function test_fundsOutCall_revertsOnBadSignature() public {
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 nonce = proxy.teeNonce();
         uint256 deadline = block.timestamp + 1 hours;
 
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         uint256[] memory pks = new uint256[](2);
         pks[0] = encPk1;
         pks[1] = 0xBADBAD;
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
-        proxy.execute(callData, nonce, deadline, 0x3, sigs);
+        proxy.fundsOutCall(params, nonce, deadline, 0x3, sigs);
     }
 
-    function test_execute_revertsOnSigCountMismatch() public {
-        bytes memory callData = _fundsOutCalldata();
-        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+    function test_fundsOutCall_revertsOnSigCountMismatch() public {
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 nonce = proxy.teeNonce();
         uint256 deadline = block.timestamp + 1 hours;
 
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         uint256[] memory pks = new uint256[](3);
         pks[0] = encPk1; pks[1] = encPk2; pks[2] = encPk3;
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.SigCountMismatch.selector);
-        proxy.execute(callData, nonce, deadline, 0x3, sigs);
+        proxy.fundsOutCall(params, nonce, deadline, 0x3, sigs);
     }
 
-    function test_execute_revertsOnBitmapOutOfRange() public {
-        bytes memory callData = _fundsOutCalldata();
-        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+    function test_fundsOutCall_revertsOnBitmapOutOfRange() public {
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 nonce = proxy.teeNonce();
         uint256 deadline = block.timestamp + 1 hours;
 
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks,) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.BitmapOutOfRange.selector);
-        proxy.execute(callData, nonce, deadline, 0x100, sigs);
+        proxy.fundsOutCall(params, nonce, deadline, 0x100, sigs);
+    }
+
+    function test_lzFundsOutCall_revertsIfAdapterUnset() public {
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        uint256 nonce    = proxy.teeNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.LZAdapterNotSet.selector);
+        proxy.lzFundsOutCall(params, nonce, deadline, bitmap, sigs);
     }
 
     // ========================================================================
@@ -1079,15 +988,15 @@ contract MultisigProxyTest is Test {
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
 
         // Enclave-signed release is frozen too — the revert propagates from
-        // Bridge.fundsOut through proxy.execute.
-        bytes memory callData = _fundsOutCalldata();
-        uint256 encNonce      = proxy.getNonce(FUNDS_OUT_SELECTOR);
-        bytes32 encDigest     = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, encNonce, deadline);
+        // Bridge.fundsOut through proxy.fundsOutCall.
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 encNonce      = proxy.teeNonce();
+        bytes32 encDigest     = MultisigHelper.digestTeeFundsOut(domainSep, params, encNonce, deadline);
         (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
         bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
 
         vm.expectRevert(BridgeBase.OutflowEnforcedPause.selector);
-        proxy.execute(callData, encNonce, deadline, ebitmap, esigs);
+        proxy.fundsOutCall(params, encNonce, deadline, ebitmap, esigs);
     }
 
     /// @dev The planned inflow-only pause runs through the timelocked
@@ -1116,13 +1025,13 @@ contract MultisigProxyTest is Test {
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
 
         // ...but the enclave release still executes.
-        bytes memory callData = _fundsOutCalldata();
-        uint256 encNonce      = proxy.getNonce(FUNDS_OUT_SELECTOR);
-        bytes32 encDigest     = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, encNonce, t + 1 days);
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 encNonce      = proxy.teeNonce();
+        bytes32 encDigest     = MultisigHelper.digestTeeFundsOut(domainSep, params, encNonce, t + 1 days);
         (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
         bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
 
-        proxy.execute(callData, encNonce, t + 1 days, ebitmap, esigs);
+        proxy.fundsOutCall(params, encNonce, t + 1 days, ebitmap, esigs);
         assertEq(token.balanceOf(recipient), AMOUNT, 'withdrawal succeeded while inflow paused');
     }
 
@@ -1254,33 +1163,6 @@ contract MultisigProxyTest is Test {
         assertEq(after_.length, 2);
         assertEq(after_[1], newSigner);
         assertEq(proxy.enclaveThreshold(), newThreshold);
-    }
-
-    // ========================================================================
-    // Propose + Execute — SetTeeAllowedCall
-    // ========================================================================
-
-    function test_proposeSetTeeAllowedCall_execute() public {
-        address target = makeAddr('lzAdapter');
-        bytes4  sel    = bytes4(0xdeadbeef);
-        uint256 nonce  = proxy.proposalNonce();
-        uint256 deadline = block.timestamp + 1 days;
-
-        bytes32 digest = MultisigHelper.digestProposeSetTeeAllowedCall(
-            domainSep, target, sel, true, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
-
-        bytes32 id = proxy.proposeSetTeeAllowedCall(target, sel, true, nonce, deadline, bitmap, sigs);
-
-        vm.warp(block.timestamp + TIMELOCK + 1);
-
-        vm.expectEmit(true, true, false, true);
-        emit TeeAllowedCallUpdated(target, sel, true);
-
-        proxy.executeProposal(id, abi.encode(target, sel, true));
-        assertTrue(proxy.teeAllowedCalls(target, sel));
     }
 
     // ========================================================================
@@ -1878,6 +1760,46 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
+    // Domain separator rebuild on chain-id change (R-W-13 / UT-FIX-15)
+    //
+    // The separator is cached at deploy with the chain id. After a chain-id
+    // change (e.g. a hard fork) it is rebuilt, so a signature made before the
+    // fork no longer verifies on the forked chain (no cross-fork replay).
+    // ========================================================================
+
+    function test_domainSeparator_rebuiltOnChainIdChange_afterFix() public {
+        uint256 originalChainId = block.chainid;
+        bytes32 dsBefore = proxy.DOMAIN_SEPARATOR();
+        assertEq(dsBefore, MultisigHelper.domainSeparator(address(proxy), originalChainId), 'cached on original chain');
+
+        uint256 forkedChainId = originalChainId + 1;
+        vm.chainId(forkedChainId);
+
+        bytes32 dsAfter = proxy.DOMAIN_SEPARATOR();
+        assertTrue(dsAfter != dsBefore, 'separator rebuilt after chain-id change');
+        assertEq(dsAfter, MultisigHelper.domainSeparator(address(proxy), forkedChainId), 'rebuilt over new chain id');
+    }
+
+    function test_fundsOutCallSignatureNotReplayableAfterChainIdChange_afterFix() public {
+        // Sign a valid TEE fundsOut on the original chain (domainSep was cached
+        // at setUp for block.chainid).
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 nonce = proxy.teeNonce();
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        // Simulate a hard fork: same state/nonces, different chain id. The
+        // domain separator is rebuilt, so the pre-fork signatures recover to the
+        // wrong addresses and verification fails — the release cannot be replayed.
+        vm.chainId(block.chainid + 1);
+        vm.expectRevert();
+        proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
+    }
+
+    // ========================================================================
     // TEE execute — full-flow state snapshots
     // ========================================================================
 
@@ -1904,10 +1826,10 @@ contract MultisigProxyTest is Test {
         assertEq(netAmount, AMOUNT - tokenCommission, 'net recipient amount');
 
         // Prepare signed TEE execution and snapshot proxy + Bridge accounting.
-        bytes memory callData = _fundsOutCalldata();
-        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        IBridge.FundsOutParams memory params = _fundsOutParams();
+        uint256 nonce = proxy.teeNonce();
         uint256 deadline = block.timestamp + 1 hours;
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
@@ -1938,11 +1860,11 @@ contract MultisigProxyTest is Test {
             SRC_ADDR
         );
         vm.expectEmit(true, false, false, true);
-        emit Executed(FUNDS_OUT_SELECTOR, nonce, bitmap);
+        emit FundsOutExecuted(nonce, bitmap);
 
-        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+        proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.getNonce(FUNDS_OUT_SELECTOR), nonce + 1, 'nonce incremented');
+        assertEq(proxy.teeNonce(), nonce + 1, 'nonce incremented');
         assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT,        'bridge gross debit');
         assertEq(token.balanceOf(recipient),       recipientBefore + netAmount, 'recipient net delta');
@@ -1964,9 +1886,10 @@ contract MultisigProxyTest is Test {
         );
     }
 
-    // Batch coverage for Bridge fundsOut followed by an outbound adapter send.
+    // Flow-4 coverage for the typed lzFundsOutCall: Bridge fundsOut to the
+    // adapter, then adapter.sendOut of the net delivered amount, in one signed op.
     // Real UtexoLZAdapter + OFT coverage belongs in a cross-repo integration test.
-    function test_executeBatch_bridgeFundsOutThenAdapterSendOut_snapshot() public {
+    function test_lzFundsOutCall_bridgeFundsOutThenAdapterSendOut_snapshot() public {
         uint256 percent = 500; // 5%
         vm.prank(address(proxy));
         cm.setCommissionRule(
@@ -1991,38 +1914,12 @@ contract MultisigProxyTest is Test {
         address mockOft = makeAddr('mockOft');
         MockOutboundLZAdapter adapter =
             new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
-        bytes4 sendOutSelector = MockOutboundLZAdapter.sendOut.selector;
-        _allowTeeCall(address(adapter), sendOutSelector);
-        assertTrue(proxy.teeAllowedCalls(address(adapter), sendOutSelector), 'adapter sendOut allowed');
+        _setLzAdapter(address(adapter));
 
-        bytes memory bridgeCallData = _fundsOutCalldata(address(adapter), AMOUNT, BURN_ID);
-        bytes memory extraOptions = hex'0003010011010000000000000000000000000000ea60';
-        bytes memory adapterCallData = abi.encodeWithSelector(
-            sendOutSelector,
-            DST_EID,
-            LZ_RECIPIENT,
-            netAmount,
-            netAmount,
-            extraOptions
-        );
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
 
-        address[] memory targets = new address[](2);
-        bytes[] memory callDatas = new bytes[](2);
-        uint256[] memory values = new uint256[](2);
-        targets[0] = address(bridge);
-        targets[1] = address(adapter);
-        callDatas[0] = bridgeCallData;
-        callDatas[1] = adapterCallData;
-        values[0] = 0;
-        values[1] = LZ_NATIVE_FEE;
-
-        uint256 nonce = proxy.batchNonce();
         uint256 deadline = block.timestamp + 1 hours;
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
-            domainSep, targets, callDatas, values, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
 
         uint256 bridgeBefore    = token.balanceOf(address(bridge));
         uint256 adapterBefore   = token.balanceOf(address(adapter));
@@ -2044,9 +1941,6 @@ contract MultisigProxyTest is Test {
         assertEq(oftEthBefore,     0,        'pre oft native');
         assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
 
-        bytes4[] memory selectors = new bytes4[](2);
-        selectors[0] = FUNDS_OUT_SELECTOR;
-        selectors[1] = sendOutSelector;
         bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, netAmount));
 
         vm.expectEmit(true, false, false, true, address(bridge));
@@ -2063,12 +1957,12 @@ contract MultisigProxyTest is Test {
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
         vm.expectEmit(true, false, false, true, address(proxy));
-        emit BatchExecuted(nonce, bitmap, targets, selectors);
+        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
-        proxy.executeBatch{ value: LZ_NATIVE_FEE }(targets, callDatas, values, nonce, deadline, bitmap, sigs);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.batchNonce(), nonce + 1, 'batch nonce incremented');
+        assertEq(proxy.teeNonce(), nonce + 1, 'tee nonce incremented');
         assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)),  bridgeBefore - AMOUNT,          'bridge gross debit');
         assertEq(token.balanceOf(address(cm)),      cmBefore + tokenCommission,     'cm fee delta');
@@ -2087,9 +1981,10 @@ contract MultisigProxyTest is Test {
         );
     }
 
-    // Batch rollback coverage for Bridge fundsOut followed by an outbound adapter send.
-    // Real UtexoLZAdapter insufficient-fee rollback belongs in a cross-repo integration test.
-    function test_executeBatch_sendOutInsufficientNativeFee_rollsBackBridgeState() public {
+    // Flow-4 rollback coverage: an insufficient LayerZero native fee reverts in
+    // adapter.sendOut, after Bridge.fundsOut ran in the same lzFundsOutCall, so
+    // the whole release rolls back.
+    function test_lzFundsOutCall_sendOutInsufficientNativeFee_rollsBackBridgeState() public {
         uint256 percent = 500; // 5%
         vm.prank(address(proxy));
         cm.setCommissionRule(
@@ -2105,7 +2000,7 @@ contract MultisigProxyTest is Test {
             })
         );
 
-        (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount) =
+        (uint256 tokenCommission, uint256 nativeCommission,) =
             cm.calculateFundsOutCommission(RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token), AMOUNT);
         assertGt(tokenCommission, 0, 'token fee quoted');
         assertEq(nativeCommission, 0, 'native fee is zero');
@@ -2113,36 +2008,12 @@ contract MultisigProxyTest is Test {
         address mockOft = makeAddr('mockOft');
         MockOutboundLZAdapter adapter =
             new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
-        bytes4 sendOutSelector = MockOutboundLZAdapter.sendOut.selector;
-        _allowTeeCall(address(adapter), sendOutSelector);
+        _setLzAdapter(address(adapter));
 
-        bytes memory bridgeCallData = _fundsOutCalldata(address(adapter), AMOUNT, BURN_ID);
-        bytes memory adapterCallData = abi.encodeWithSelector(
-            sendOutSelector,
-            DST_EID,
-            LZ_RECIPIENT,
-            netAmount,
-            netAmount,
-            hex'0003010011010000000000000000000000000000ea60'
-        );
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
 
-        address[] memory targets = new address[](2);
-        bytes[] memory callDatas = new bytes[](2);
-        uint256[] memory values = new uint256[](2);
-        targets[0] = address(bridge);
-        targets[1] = address(adapter);
-        callDatas[0] = bridgeCallData;
-        callDatas[1] = adapterCallData;
-        values[0] = 0;
-        values[1] = LZ_NATIVE_FEE - 1;
-
-        uint256 nonce = proxy.batchNonce();
         uint256 deadline = block.timestamp + 1 hours;
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
-            domainSep, targets, callDatas, values, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
 
         // Snapshot all state touched by the first Bridge leg and the failed adapter leg.
         uint256 bridgeBefore     = token.balanceOf(address(bridge));
@@ -2165,21 +2036,13 @@ contract MultisigProxyTest is Test {
         assertEq(recordBefore,     AMOUNT * 5, 'pre record');
         assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
 
-        // msg.value matches the batch values sum, so the revert happens in sendOut,
-        // after Bridge.fundsOut already ran inside the same batch transaction.
+        // An underfunded native fee reverts in sendOut, after Bridge.fundsOut
+        // already ran inside the same lzFundsOutCall transaction.
         vm.deal(address(this), LZ_NATIVE_FEE - 1);
         vm.expectRevert(bytes('native fee'));
-        proxy.executeBatch{ value: LZ_NATIVE_FEE - 1 }(
-            targets,
-            callDatas,
-            values,
-            nonce,
-            deadline,
-            bitmap,
-            sigs
-        );
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE - 1 }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.batchNonce(),              nonce,            'batch nonce unchanged');
+        assertEq(proxy.teeNonce(),                nonce,            'tee nonce unchanged');
         assertFalse(bridge.consumedBurnIds(BURN_ID),                'burn id unchanged');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter token unchanged');
@@ -2193,9 +2056,9 @@ contract MultisigProxyTest is Test {
         assertEq(mockOft.balance,                   oftEthBefore,      'oft native unchanged');
     }
 
-    // Batch rollback coverage when the Bridge fundsOut leg fails before adapter send.
+    // Flow-4 rollback coverage when the Bridge fundsOut leg fails before adapter send.
     // Real UtexoLZAdapter call-skipping coverage belongs in a cross-repo integration test.
-    function test_executeBatch_bridgeVerifierFailure_doesNotCallAdapter() public {
+    function test_lzFundsOutCall_bridgeVerifierFailure_doesNotCallAdapter() public {
         uint256 percent = 500; // 5%
         vm.prank(address(proxy));
         cm.setCommissionRule(
@@ -2219,50 +2082,17 @@ contract MultisigProxyTest is Test {
         address mockOft = makeAddr('mockOft');
         MockOutboundLZAdapter adapter =
             new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
-        bytes4 sendOutSelector = MockOutboundLZAdapter.sendOut.selector;
-        _allowTeeCall(address(adapter), sendOutSelector);
+        _setLzAdapter(address(adapter));
 
-        bytes memory badProof = abi.encode(uint256(999_999), keccak256('unknown-block'));
-        bytes memory settlementData = abi.encode(_fundsInIds());
-        bytes memory bridgeCallData = abi.encodeWithSelector(
-            FUNDS_OUT_SELECTOR,
-            address(adapter),
-            AMOUNT,
-            BURN_ID,
-            RGB_CHAIN_ID,
-            SOURCE_CHAIN_ID,
-            SRC_ADDR,
-            badProof,
-            settlementData
-        );
-        bytes memory adapterCallData = abi.encodeWithSelector(
-            sendOutSelector,
-            DST_EID,
-            LZ_RECIPIENT,
-            netAmount,
-            netAmount,
-            hex'0003010011010000000000000000000000000000ea60'
-        );
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        // A proof that the verifier rejects, so Bridge.fundsOut reverts before
+        // the adapter send can run.
+        params.proof = abi.encode(uint256(999_999), keccak256('unknown-block'));
 
-        address[] memory targets = new address[](2);
-        bytes[] memory callDatas = new bytes[](2);
-        uint256[] memory values = new uint256[](2);
-        targets[0] = address(bridge);
-        targets[1] = address(adapter);
-        callDatas[0] = bridgeCallData;
-        callDatas[1] = adapterCallData;
-        values[0] = 0;
-        values[1] = LZ_NATIVE_FEE;
-
-        uint256 nonce = proxy.batchNonce();
         uint256 deadline = block.timestamp + 1 hours;
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
-            domainSep, targets, callDatas, values, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
 
-        // The adapter call is valid and funded; only the Bridge verifier failure should stop dispatch.
+        // The adapter is funded; only the Bridge verifier failure should stop dispatch.
         uint256 bridgeBefore     = token.balanceOf(address(bridge));
         uint256 adapterBefore    = token.balanceOf(address(adapter));
         uint256 oftBefore        = token.balanceOf(mockOft);
@@ -2286,17 +2116,9 @@ contract MultisigProxyTest is Test {
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         vm.expectRevert(bytes('verify: block commitment'));
-        proxy.executeBatch{ value: LZ_NATIVE_FEE }(
-            targets,
-            callDatas,
-            values,
-            nonce,
-            deadline,
-            bitmap,
-            sigs
-        );
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.batchNonce(),              nonce,            'batch nonce unchanged');
+        assertEq(proxy.teeNonce(),                nonce,            'tee nonce unchanged');
         assertFalse(bridge.consumedBurnIds(BURN_ID),                'burn id unchanged');
         assertEq(adapter.sendOutCalls(),           0,               'adapter not called');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
@@ -2311,9 +2133,9 @@ contract MultisigProxyTest is Test {
         assertEq(mockOft.balance,                   oftEthBefore,      'oft native unchanged');
     }
 
-    // Batch success coverage for duplicate RGB settlement ids when the first
+    // Flow-4 success coverage for duplicate RGB settlement ids when the first
     // occurrence partially satisfies the Bridge fundsOut amount.
-    function test_executeBatch_duplicateSettlementIdsPartialConsume_succeedsAndIgnoresDuplicate() public {
+    function test_lzFundsOutCall_duplicateSettlementIdsPartialConsume_succeedsAndIgnoresDuplicate() public {
         uint256 percent = 500; // 5%
         vm.prank(address(proxy));
         cm.setCommissionRule(
@@ -2337,52 +2159,16 @@ contract MultisigProxyTest is Test {
         address mockOft = makeAddr('mockOft');
         MockOutboundLZAdapter adapter =
             new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
-        bytes4 sendOutSelector = MockOutboundLZAdapter.sendOut.selector;
-        _allowTeeCall(address(adapter), sendOutSelector);
+        _setLzAdapter(address(adapter));
 
         uint256[] memory duplicateIds = new uint256[](2);
         duplicateIds[0] = TX_ID;
         duplicateIds[1] = TX_ID;
 
-        bytes memory proof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
-        bytes memory settlementData = abi.encode(duplicateIds);
-        bytes memory bridgeCallData = abi.encodeWithSelector(
-            FUNDS_OUT_SELECTOR,
-            address(adapter),
-            AMOUNT,
-            BURN_ID,
-            RGB_CHAIN_ID,
-            SOURCE_CHAIN_ID,
-            SRC_ADDR,
-            proof,
-            settlementData
-        );
-        bytes memory adapterCallData = abi.encodeWithSelector(
-            sendOutSelector,
-            DST_EID,
-            LZ_RECIPIENT,
-            netAmount,
-            netAmount,
-            hex'0003010011010000000000000000000000000000ea60'
-        );
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, duplicateIds);
 
-        address[] memory targets = new address[](2);
-        bytes[] memory callDatas = new bytes[](2);
-        uint256[] memory values = new uint256[](2);
-        targets[0] = address(bridge);
-        targets[1] = address(adapter);
-        callDatas[0] = bridgeCallData;
-        callDatas[1] = adapterCallData;
-        values[0] = 0;
-        values[1] = LZ_NATIVE_FEE;
-
-        uint256 nonce = proxy.batchNonce();
         uint256 deadline = block.timestamp + 1 hours;
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
-            domainSep, targets, callDatas, values, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
 
         // The duplicate id is only safe in this shape because the first entry is
         // partially consumed and the settlement loop breaks before reading it again.
@@ -2407,9 +2193,6 @@ contract MultisigProxyTest is Test {
         assertEq(adapter.sendOutCalls(), 0,    'pre adapter calls');
         assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
 
-        bytes4[] memory selectors = new bytes4[](2);
-        selectors[0] = FUNDS_OUT_SELECTOR;
-        selectors[1] = sendOutSelector;
         bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, netAmount));
 
         vm.expectEmit(true, false, false, true, address(bridge));
@@ -2426,20 +2209,12 @@ contract MultisigProxyTest is Test {
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
         vm.expectEmit(true, false, false, true, address(proxy));
-        emit BatchExecuted(nonce, bitmap, targets, selectors);
+        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
-        proxy.executeBatch{ value: LZ_NATIVE_FEE }(
-            targets,
-            callDatas,
-            values,
-            nonce,
-            deadline,
-            bitmap,
-            sigs
-        );
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.batchNonce(),              nonce + 1,        'batch nonce incremented');
+        assertEq(proxy.teeNonce(),                nonce + 1,        'tee nonce incremented');
         assertTrue(bridge.consumedBurnIds(BURN_ID),                  'burn id consumed');
         assertEq(adapter.sendOutCalls(),           1,               'adapter called once');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge token debit');
@@ -2454,9 +2229,9 @@ contract MultisigProxyTest is Test {
         assertEq(mockOft.balance,                   oftEthBefore + LZ_NATIVE_FEE, 'oft native fee');
     }
 
-    // Batch success coverage for duplicate RGB settlement ids when the first
+    // Flow-4 success coverage for duplicate RGB settlement ids when the first
     // occurrence fully satisfies the Bridge fundsOut amount.
-    function test_executeBatch_duplicateSettlementIdsFullConsume_succeedsAndIgnoresDuplicate() public {
+    function test_lzFundsOutCall_duplicateSettlementIdsFullConsume_succeedsAndIgnoresDuplicate() public {
         uint256 duplicateRecordId = TX_ID + 1;
         uint256 burnId = BURN_ID + 1;
 
@@ -2486,52 +2261,16 @@ contract MultisigProxyTest is Test {
         address mockOft = makeAddr('mockOft');
         MockOutboundLZAdapter adapter =
             new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
-        bytes4 sendOutSelector = MockOutboundLZAdapter.sendOut.selector;
-        _allowTeeCall(address(adapter), sendOutSelector);
+        _setLzAdapter(address(adapter));
 
         uint256[] memory duplicateIds = new uint256[](2);
         duplicateIds[0] = duplicateRecordId;
         duplicateIds[1] = duplicateRecordId;
 
-        bytes memory proof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
-        bytes memory settlementData = abi.encode(duplicateIds);
-        bytes memory bridgeCallData = abi.encodeWithSelector(
-            FUNDS_OUT_SELECTOR,
-            address(adapter),
-            AMOUNT,
-            burnId,
-            RGB_CHAIN_ID,
-            SOURCE_CHAIN_ID,
-            SRC_ADDR,
-            proof,
-            settlementData
-        );
-        bytes memory adapterCallData = abi.encodeWithSelector(
-            sendOutSelector,
-            DST_EID,
-            LZ_RECIPIENT,
-            netAmount,
-            netAmount,
-            hex'0003010011010000000000000000000000000000ea60'
-        );
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, burnId, duplicateIds);
 
-        address[] memory targets = new address[](2);
-        bytes[] memory callDatas = new bytes[](2);
-        uint256[] memory values = new uint256[](2);
-        targets[0] = address(bridge);
-        targets[1] = address(adapter);
-        callDatas[0] = bridgeCallData;
-        callDatas[1] = adapterCallData;
-        values[0] = 0;
-        values[1] = LZ_NATIVE_FEE;
-
-        uint256 nonce = proxy.batchNonce();
         uint256 deadline = block.timestamp + 1 hours;
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
-            domainSep, targets, callDatas, values, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
 
         // Exact full consumption triggers the module's remaining == 0 break.
         // Without that break, the duplicate id would be read after delete.
@@ -2556,9 +2295,6 @@ contract MultisigProxyTest is Test {
         assertEq(adapter.sendOutCalls(),  0,          'pre adapter calls');
         assertFalse(bridge.consumedBurnIds(burnId), 'pre burn id');
 
-        bytes4[] memory selectors = new bytes4[](2);
-        selectors[0] = FUNDS_OUT_SELECTOR;
-        selectors[1] = sendOutSelector;
         bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, netAmount));
 
         vm.expectEmit(true, false, false, true, address(bridge));
@@ -2575,20 +2311,12 @@ contract MultisigProxyTest is Test {
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
         vm.expectEmit(true, false, false, true, address(proxy));
-        emit BatchExecuted(nonce, bitmap, targets, selectors);
+        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
-        proxy.executeBatch{ value: LZ_NATIVE_FEE }(
-            targets,
-            callDatas,
-            values,
-            nonce,
-            deadline,
-            bitmap,
-            sigs
-        );
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.batchNonce(),              nonce + 1,        'batch nonce incremented');
+        assertEq(proxy.teeNonce(),                nonce + 1,        'tee nonce incremented');
         assertTrue(bridge.consumedBurnIds(burnId),                  'burn id consumed');
         assertEq(adapter.sendOutCalls(),           1,               'adapter called once');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge token debit');
@@ -2604,14 +2332,114 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
+    // R-M-03 / UT-FIX-05 — typed enclave methods are the only TEE entry points
+    //
+    // The generic enclave `execute`/`executeBatch` + `teeAllowedCalls` allowlist
+    // were removed. The enclave (TEE) quorum can now only trigger Bridge.fundsOut
+    // via fundsOutCall/lzFundsOutCall. Privileged calldata can still be run, but
+    // exclusively through the FEDERATION-gated, timelocked proposeAdminExecute
+    // path. This proves a compromised enclave quorum cannot reach any privileged
+    // function: enclave signatures over an admin-execute proposal are rejected.
+    // ========================================================================
+
+    function test_enclaveKeysCannotDriveAdminExecute_afterFix() public {
+        // A privileged call the TEE quorum might want to smuggle through.
+        bytes memory callData = abi.encodeWithSignature('pauseInflow()');
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        // Same proposal digest the federation would sign...
+        bytes32 digest = MultisigHelper.digestProposeAdminExecute(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        // ...but signed by the ENCLAVE (TEE) keys instead of the federation.
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        // proposeAdminExecute verifies against the federation signer set, so the
+        // recovered enclave addresses are not authorized: the proposal is never
+        // created and the privileged call never reaches the timelock queue.
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.proposeAdminExecute(callData, nonce, deadline, bitmap, sigs);
+    }
+
+    // ========================================================================
+    // R-W-16 / UT-FIX-18 — lzFundsOutCall binds the release and send-out legs
+    //
+    // Flow-4 release and the cross-chain send are bound on-chain in one signed
+    // operation: the Bridge recipient is forced to the adapter (no params field
+    // for it), and the amount handed to adapter.sendOut is the balance the
+    // adapter ACTUALLY received, measured on-chain — not params.amount. A token
+    // commission makes gross != net, which is what distinguishes the bound
+    // (net delivered) amount from the signed gross amount.
+    // ========================================================================
+
+    function test_lzFundsOutCall_sendsNetDeliveredNotGross_afterFix() public {
+        // 5% FUNDS_OUT token commission so gross (AMOUNT) != net (delivered).
+        vm.prank(address(proxy));
+        cm.setCommissionRule(
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            address(token),
+            CommissionConfig({
+                stablePercent: 500, // 5%
+                multiplier: 100,
+                side: CommissionSide.FUNDS_OUT,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        (uint256 tokenCommission,, uint256 netAmount) =
+            cm.calculateFundsOutCommission(RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token), AMOUNT);
+        assertGt(tokenCommission, 0,                  'fee makes gross != net');
+        assertEq(netAmount, AMOUNT - tokenCommission, 'net = gross - fee');
+
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));
+
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
+
+        // Leg 1: the Bridge recipient is forced to the adapter (not in params).
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit BridgeFundsOut(
+            address(adapter),
+            AMOUNT,
+            netAmount,
+            tokenCommission,
+            BURN_ID,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR
+        );
+        // Leg 2: sendOut carries the NET delivered amount, not the gross AMOUNT.
+        bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, netAmount));
+        vm.expectEmit(true, false, false, true, address(adapter));
+        emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
+
+        // The send-out amount is bound to what the adapter received: it forwarded
+        // exactly the net (leaving no residue) and that net differs from gross.
+        assertEq(token.balanceOf(address(adapter)), 0,         'adapter forwarded everything it received');
+        assertEq(token.balanceOf(mockOft),          netAmount, 'oft received exactly the net delivered');
+        assertTrue(netAmount != AMOUNT,                        'bound amount is distinct from signed gross');
+    }
+
+    // ========================================================================
     // Current behavior reproduction
     // ========================================================================
 
     function test_enclaveSignedFundsOutCanDrainPool_currentBehavior() public {
         address drainRecipient = makeAddr('drainRecipient');
 
-        // The TEE path checks signatures and allowlist membership, but it does
-        // not impose an on-chain amount cap on the signed Bridge fundsOut.
+        // The TEE path checks signatures, but it does not impose an on-chain
+        // amount cap on the signed Bridge fundsOut.
         uint256 bridgeBefore    = token.balanceOf(address(bridge));
         uint256 recipientBefore = token.balanceOf(drainRecipient);
         uint256 recordBefore    = rgbModule.fundsInRecords(TX_ID);
@@ -2623,10 +2451,10 @@ contract MultisigProxyTest is Test {
 
         // Current behavior: if an on-chain amount cap or rate limit is added
         // later, this test should be inverted to expect a revert.
-        bytes memory callData = _fundsOutCalldata(drainRecipient, bridgeBefore, BURN_ID);
-        uint256 nonce = proxy.getNonce(FUNDS_OUT_SELECTOR);
+        IBridge.FundsOutParams memory params = _fundsOutParams(drainRecipient, bridgeBefore, BURN_ID);
+        uint256 nonce = proxy.teeNonce();
         uint256 deadline = block.timestamp + 1 hours;
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, FUNDS_OUT_SELECTOR, callData, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
@@ -2642,11 +2470,11 @@ contract MultisigProxyTest is Test {
             SRC_ADDR
         );
         vm.expectEmit(true, false, false, true, address(proxy));
-        emit Executed(FUNDS_OUT_SELECTOR, nonce, bitmap);
+        emit FundsOutExecuted(nonce, bitmap);
 
-        proxy.execute(callData, nonce, deadline, bitmap, sigs);
+        proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.getNonce(FUNDS_OUT_SELECTOR), nonce + 1, 'nonce incremented');
+        assertEq(proxy.teeNonce(), nonce + 1, 'nonce incremented');
         assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)), 0, 'bridge pool drained');
         assertEq(token.balanceOf(drainRecipient), recipientBefore + bridgeBefore, 'recipient got full pool');
@@ -2698,128 +2526,52 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.enclaveThreshold(), newThreshold, 'post enclave threshold');
     }
 
-    function test_teeAllowlistCanEnablePrivilegedSetter_currentBehavior() public {
-        address newAdapter = makeAddr('teeSetAdapter');
-        bytes4 selector = Bridge.setLZAdapter.selector;
-
-        assertFalse(proxy.teeAllowedCalls(address(bridge), selector), 'pre setter disallowed');
-        assertEq(bridge.lzAdapter(), address(0), 'pre bridge adapter');
-
-        _allowTeeCall(address(bridge), selector);
-        assertTrue(proxy.teeAllowedCalls(address(bridge), selector), 'setter allowed');
-
-        bytes memory callData = abi.encodeWithSelector(selector, newAdapter);
-        uint256 nonce = proxy.getNonce(selector);
-        uint256 deadline = block.timestamp + 1 hours;
-        bytes32 digest = MultisigHelper.digestBridgeOp(domainSep, selector, callData, nonce, deadline);
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
-
-        // Current behavior: federation governance can allowlist an owner-only
-        // Bridge setter, after which the TEE path can execute that setter
-        // directly through the proxy-owned Bridge.
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit LZAdapterUpdated(address(0), newAdapter);
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit Executed(selector, nonce, bitmap);
-
-        proxy.execute(callData, nonce, deadline, bitmap, sigs);
-
-        assertEq(proxy.getNonce(selector), nonce + 1, 'setter nonce incremented');
-        assertEq(bridge.lzAdapter(), newAdapter, 'bridge adapter updated');
-    }
-
-    function test_timelockCanBeSetToZero_currentBehavior() public {
-        uint256 newDuration = 0;
-        uint256 nonce = proxy.proposalNonce();
-        uint256 deadline = block.timestamp + 1 days;
+    function test_proposalUsesSnapshottedTimelock_afterFix() public {
+        uint256 proposedAt  = block.timestamp;
+        address newBridge   = makeAddr('snapshotTimelockBridge');
+        uint256 newDuration = 2 hours;          // raise above the 1h in force at creation
+        uint256 deadline    = proposedAt + 1 days;
 
         assertEq(proxy.timelockDuration(), TIMELOCK, 'pre timelock');
 
-        bytes32 digest = MultisigHelper.digestProposeSetTimelockDuration(
-            domainSep, newDuration, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
-
-        bytes32 id = proxy.proposeSetTimelockDuration(newDuration, nonce, deadline, bitmap, sigs);
-
-        vm.warp(block.timestamp + TIMELOCK + 1);
-
-        // Current behavior: the update path rejects only durations at or above
-        // MAX_PROPOSAL_LIFETIME, so zero removes the governance observation
-        // delay for future proposals.
-        vm.expectEmit(false, false, false, true, address(proxy));
-        emit TimelockDurationUpdated(newDuration);
-        vm.expectEmit(true, true, false, true, address(proxy));
-        emit ProposalExecuted(id, IMultisigProxy.OperationType.SetTimelockDuration);
-
-        proxy.executeProposal(id, abi.encode(newDuration));
-
-        assertEq(proxy.timelockDuration(), 0, 'timelock cleared');
-    }
-
-    // Pending proposals do not snapshot their timelock delay; execution checks
-    // the live timelockDuration, so a later governance update can re-lock an
-    // already mature proposal until the new duration elapses.
-    function test_pendingProposalUsesLiveTimelock_currentBehavior() public {
-        uint256 proposedAt = block.timestamp;
-        address newBridge = makeAddr('liveTimelockBridge');
-        uint256 newDuration = 2 hours;
-        uint256 deadline = proposedAt + 1 days;
-
-        assertEq(proxy.timelockDuration(), TIMELOCK, 'pre timelock');
-
+        // Proposal A — created while timelockDuration == TIMELOCK (1h).
         uint256 bridgeNonce = proxy.proposalNonce();
         bytes32 bridgeDigest = MultisigHelper.digestProposeUpdateBridge(
             domainSep, newBridge, bridgeNonce, deadline
         );
         (uint256[] memory bridgePks, uint256 bridgeBitmap) = _fedSigSet2of3();
         bytes[] memory bridgeSigs = MultisigHelper.signAll(vm, bridgeDigest, bridgePks);
-
         bytes32 bridgeProposalId =
             proxy.proposeUpdateBridge(newBridge, bridgeNonce, deadline, bridgeBitmap, bridgeSigs);
 
+        assertEq(
+            proxy.getProposal(bridgeProposalId).timelockSnapshot,
+            TIMELOCK,
+            'timelock snapshotted at creation'
+        );
+
+        // Raise the live timelock to 2h via its own proposal.
         uint256 timelockNonce = proxy.proposalNonce();
         bytes32 timelockDigest = MultisigHelper.digestProposeSetTimelockDuration(
             domainSep, newDuration, timelockNonce, deadline
         );
         (uint256[] memory timelockPks, uint256 timelockBitmap) = _fedSigSet2of3();
         bytes[] memory timelockSigs = MultisigHelper.signAll(vm, timelockDigest, timelockPks);
-
         bytes32 timelockProposalId = proxy.proposeSetTimelockDuration(
             newDuration, timelockNonce, deadline, timelockBitmap, timelockSigs
         );
 
+        // At proposedAt + 1h + 1: both proposals' creation-time snapshot (1h)
+        // has elapsed. Execute the timelock raise first.
         vm.warp(proposedAt + TIMELOCK + 1);
-
-        vm.expectEmit(false, false, false, true, address(proxy));
-        emit TimelockDurationUpdated(newDuration);
-        vm.expectEmit(true, true, false, true, address(proxy));
-        emit ProposalExecuted(timelockProposalId, IMultisigProxy.OperationType.SetTimelockDuration);
-
         proxy.executeProposal(timelockProposalId, abi.encode(newDuration));
+        assertEq(proxy.timelockDuration(), newDuration, 'live timelock raised to 2h');
 
-        assertEq(proxy.timelockDuration(), newDuration, 'live timelock increased');
-
-        // Current behavior: execution compares the frozen proposedAt against
-        // the live timelockDuration, so raising the timelock re-locks this
-        // already mature bridge proposal.
-        vm.expectRevert(IMultisigProxy.TimelockActive.selector);
+        // Proposal A uses its 1h snapshot, so it is mature now and executes —
+        // the raised live timelock (2h) does NOT re-lock it. Under the pre-fix
+        // live-timelock check this would revert TimelockActive.
         proxy.executeProposal(bridgeProposalId, abi.encode(newBridge));
-
-        assertEq(proxy.bridge(), address(bridge), 'bridge unchanged while re-locked');
-
-        vm.warp(proposedAt + newDuration + 1);
-
-        vm.expectEmit(true, true, false, true, address(proxy));
-        emit BridgeAddressUpdated(address(bridge), newBridge);
-        vm.expectEmit(true, true, false, true, address(proxy));
-        emit ProposalExecuted(bridgeProposalId, IMultisigProxy.OperationType.UpdateBridge);
-
-        proxy.executeProposal(bridgeProposalId, abi.encode(newBridge));
-
-        assertEq(proxy.bridge(), newBridge, 'bridge updated after live timelock');
+        assertEq(proxy.bridge(), newBridge, 'snapshotted proposal executes despite the live timelock raise');
     }
 
     // The typed commission-withdraw path pins the recipient to
@@ -2894,120 +2646,4 @@ contract MultisigProxyTest is Test {
         );
     }
 
-    // executeBatch validates signatures, allowlisted calls, and total native
-    // value, but it does not bind the Bridge payout amount to the adapter send
-    // amount. A smaller send leaves the remainder on the adapter.
-    function test_executeBatchAcceptsUnpairedFundsOutAndSendOut_currentBehavior() public {
-        uint256 percent = 500; // 5%
-        vm.prank(address(proxy));
-        cm.setCommissionRule(
-            RGB_CHAIN_ID,
-            SOURCE_CHAIN_ID,
-            address(token),
-            CommissionConfig({
-                stablePercent: percent,
-                multiplier: 100,
-                side: CommissionSide.FUNDS_OUT,
-                currency: CommissionCurrency.TOKEN,
-                isSet: true
-            })
-        );
-
-        (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount) =
-            cm.calculateFundsOutCommission(RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token), AMOUNT);
-        uint256 adapterSendAmount = netAmount - 1e18;
-        assertGt(tokenCommission, 0, 'token fee quoted');
-        assertEq(nativeCommission, 0, 'native fee is zero');
-        assertLt(adapterSendAmount, netAmount, 'send amount smaller than bridge payout');
-
-        address mockOft = makeAddr('mismatchMockOft');
-        MockOutboundLZAdapter adapter =
-            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
-        bytes4 sendOutSelector = MockOutboundLZAdapter.sendOut.selector;
-        _allowTeeCall(address(adapter), sendOutSelector);
-
-        bytes memory bridgeCallData = _fundsOutCalldata(address(adapter), AMOUNT, BURN_ID + 88);
-        bytes memory adapterCallData = abi.encodeWithSelector(
-            sendOutSelector,
-            DST_EID,
-            LZ_RECIPIENT,
-            adapterSendAmount,
-            adapterSendAmount,
-            bytes('')
-        );
-
-        address[] memory targets = new address[](2);
-        bytes[] memory callDatas = new bytes[](2);
-        uint256[] memory values = new uint256[](2);
-        targets[0] = address(bridge);
-        targets[1] = address(adapter);
-        callDatas[0] = bridgeCallData;
-        callDatas[1] = adapterCallData;
-        values[0] = 0;
-        values[1] = LZ_NATIVE_FEE;
-
-        uint256 nonce = proxy.batchNonce();
-        uint256 deadline = block.timestamp + 1 hours;
-        bytes32 digest = MultisigHelper.digestBridgeBatchOp(
-            domainSep, targets, callDatas, values, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
-
-        uint256 bridgeBefore = token.balanceOf(address(bridge));
-        uint256 adapterBefore = token.balanceOf(address(adapter));
-        uint256 oftBefore = token.balanceOf(mockOft);
-        uint256 cmBefore = token.balanceOf(address(cm));
-        uint256 cmPoolBefore = cm.tokenCommissionPool(address(token));
-        uint256 recordBefore = rgbModule.fundsInRecords(TX_ID);
-
-        assertEq(bridgeBefore, AMOUNT * 5, 'pre bridge pool');
-        assertEq(adapterBefore, 0, 'pre adapter token');
-        assertEq(oftBefore, 0, 'pre oft token');
-        assertEq(recordBefore, AMOUNT * 5, 'pre record');
-
-        bytes4[] memory selectors = new bytes4[](2);
-        selectors[0] = FUNDS_OUT_SELECTOR;
-        selectors[1] = sendOutSelector;
-        bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, adapterSendAmount));
-
-        vm.expectEmit(true, false, false, true, address(bridge));
-        emit BridgeFundsOut(
-            address(adapter),
-            AMOUNT,
-            netAmount,
-            tokenCommission,
-            BURN_ID + 88,
-            RGB_CHAIN_ID,
-            SOURCE_CHAIN_ID,
-            SRC_ADDR
-        );
-        vm.expectEmit(true, false, false, true, address(adapter));
-        emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, adapterSendAmount);
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit BatchExecuted(nonce, bitmap, targets, selectors);
-
-        vm.deal(address(this), LZ_NATIVE_FEE);
-        proxy.executeBatch{ value: LZ_NATIVE_FEE }(targets, callDatas, values, nonce, deadline, bitmap, sigs);
-
-        assertEq(proxy.batchNonce(), nonce + 1, 'batch nonce incremented');
-        assertTrue(bridge.consumedBurnIds(BURN_ID + 88), 'burn id consumed');
-        assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge gross debit');
-        assertEq(token.balanceOf(address(cm)), cmBefore + tokenCommission, 'cm fee delta');
-        assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore + tokenCommission, 'cm pool delta');
-        assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore - AMOUNT, 'record consumed');
-        assertEq(token.balanceOf(mockOft), oftBefore + adapterSendAmount, 'oft receives smaller send');
-        assertEq(
-            token.balanceOf(address(adapter)),
-            adapterBefore + (netAmount - adapterSendAmount),
-            'adapter keeps unpaired remainder'
-        );
-        assertEq(
-            (token.balanceOf(address(cm)) - cmBefore) +
-            (token.balanceOf(mockOft) - oftBefore) +
-            (token.balanceOf(address(adapter)) - adapterBefore),
-            AMOUNT,
-            'gross batch payout conserved'
-        );
-    }
 }

--- a/ethereum/test/RGBVerifier.t.sol
+++ b/ethereum/test/RGBVerifier.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.35;
 
 import { Test } from 'forge-std/Test.sol';
 

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -3,6 +3,9 @@ pragma solidity 0.8.35;
 
 import { Vm } from 'forge-std/Vm.sol';
 
+import { IBridge }        from '../../src/interfaces/IBridge.sol';
+import { IMultisigProxy } from '../../src/interfaces/IMultisigProxy.sol';
+
 /// @title MultisigHelper
 /// @notice EIP-712 digest builders and signature bitmap helpers for MultisigProxy tests.
 library MultisigHelper {
@@ -10,12 +13,12 @@ library MultisigHelper {
         'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'
     );
 
-    bytes32 internal constant BRIDGE_OP_TYPEHASH = keccak256(
-        'BridgeOperation(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
+    bytes32 internal constant TEE_FUNDS_OUT_TYPEHASH = keccak256(
+        'TeeFundsOut(address recipient,uint256 amount,uint256 burnId,uint256 sourceChainId,uint256 destinationChainId,string sourceAddress,bytes proof,bytes settlementData,uint256 nonce,uint256 deadline)'
     );
 
-    bytes32 internal constant BRIDGE_BATCH_OP_TYPEHASH = keccak256(
-        'BridgeBatchOperation(address[] targets,bytes[] callDatas,uint256[] values,uint256 nonce,uint256 deadline)'
+    bytes32 internal constant TEE_LZ_FUNDS_OUT_TYPEHASH = keccak256(
+        'TeeLzFundsOut(uint256 amount,uint256 burnId,uint256 sourceChainId,uint256 destinationChainId,string sourceAddress,bytes proof,bytes settlementData,uint32 dstEid,bytes32 recipient,uint256 minAmountLD,bytes extraOptions,uint256 nonce,uint256 deadline)'
     );
 
     bytes32 internal constant EMERGENCY_PAUSE_TYPEHASH = keccak256(
@@ -52,10 +55,6 @@ library MultisigHelper {
 
     bytes32 internal constant PROPOSE_SET_COMMISSION_RECIPIENT_TYPEHASH = keccak256(
         'ProposeSetCommissionRecipient(address newRecipient,uint256 nonce,uint256 deadline)'
-    );
-
-    bytes32 internal constant PROPOSE_SET_TEE_CALL_TYPEHASH = keccak256(
-        'ProposeSetTeeAllowedCall(address target,bytes4 selector,bool allowed,uint256 nonce,uint256 deadline)'
     );
 
     bytes32 internal constant PROPOSE_SET_TIMELOCK_DURATION_TYPEHASH = keccak256(
@@ -127,37 +126,56 @@ library MultisigHelper {
     // Digest builders
     // ========================================================================
 
-    function digestBridgeOp(
+    /// @dev EIP-712 digest for the typed `fundsOutCall` (TeeFundsOut).
+    function digestTeeFundsOut(
         bytes32 domainSep,
-        bytes4 selector,
-        bytes memory callData,
+        IBridge.FundsOutParams memory p,
         uint256 nonce,
         uint256 deadline
     ) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(
-            BRIDGE_OP_TYPEHASH, selector, keccak256(callData), nonce, deadline
+            TEE_FUNDS_OUT_TYPEHASH,
+            p.recipient,
+            p.amount,
+            p.burnId,
+            p.sourceChainId,
+            p.destinationChainId,
+            keccak256(bytes(p.sourceAddress)),
+            keccak256(p.proof),
+            keccak256(p.settlementData),
+            nonce,
+            deadline
         )));
     }
 
-    function digestBridgeBatchOp(
+    /// @dev EIP-712 digest for the typed `lzFundsOutCall` (TeeLzFundsOut). Built
+    ///      in two `abi.encode` halves joined with `bytes.concat`, matching the
+    ///      contract (byte-identical, and compiles without the optimizer).
+    function digestTeeLzFundsOut(
         bytes32 domainSep,
-        address[] memory targets,
-        bytes[]   memory callDatas,
-        uint256[] memory values,
+        IMultisigProxy.LzFundsOutParams memory p,
         uint256 nonce,
         uint256 deadline
     ) internal pure returns (bytes32) {
-        bytes32[] memory cdHashes = new bytes32[](callDatas.length);
-        for (uint256 i = 0; i < callDatas.length; i++) {
-            cdHashes[i] = keccak256(callDatas[i]);
-        }
-        return toTypedDataHash(domainSep, keccak256(abi.encode(
-            BRIDGE_BATCH_OP_TYPEHASH,
-            keccak256(abi.encodePacked(targets)),
-            keccak256(abi.encodePacked(cdHashes)),
-            keccak256(abi.encodePacked(values)),
-            nonce,
-            deadline
+        return toTypedDataHash(domainSep, keccak256(bytes.concat(
+            abi.encode(
+                TEE_LZ_FUNDS_OUT_TYPEHASH,
+                p.amount,
+                p.burnId,
+                p.sourceChainId,
+                p.destinationChainId,
+                keccak256(bytes(p.sourceAddress)),
+                keccak256(p.proof)
+            ),
+            abi.encode(
+                keccak256(p.settlementData),
+                p.dstEid,
+                p.recipient,
+                p.minAmountLD,
+                keccak256(p.extraOptions),
+                nonce,
+                deadline
+            )
         )));
     }
 
@@ -223,19 +241,6 @@ library MultisigHelper {
     ) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(
             PROPOSE_UPDATE_BRIDGE_TYPEHASH, newBridge, nonce, deadline
-        )));
-    }
-
-    function digestProposeSetTeeAllowedCall(
-        bytes32 domainSep,
-        address target,
-        bytes4 selector,
-        bool allowed,
-        uint256 nonce,
-        uint256 deadline
-    ) internal pure returns (bytes32) {
-        return toTypedDataHash(domainSep, keccak256(abi.encode(
-            PROPOSE_SET_TEE_CALL_TYPEHASH, target, selector, allowed, nonce, deadline
         )));
     }
 


### PR DESCRIPTION
## R-W-18 — proposals use the live timelock instead of a snapshot

`executeProposal` checked `block.timestamp < proposedAt + timelockDuration`
against the **current** `timelockDuration`, which is mutable via a
`SetTimelockDuration` proposal. Reducing it retroactively shortens the delay of
every already-pending proposal and can make several queued proposals executable
at once — for order-sensitive ops (set bridge to A, then to B) the final state
then depends on execution ordering, not the intended schedule.

### Fix
- Add `Proposal.timelockSnapshot`, set to `timelockDuration` at creation in
  `_propose`.
- Enforce `proposedAt + timelockSnapshot` in `executeProposal`.

A later `timelockDuration` change no longer affects proposals that already
exist. Consistent with the R-I-18 deadline lower-bound, which validates against
the same live timelock at creation (snapshot == live value at that moment).