### PR TITLE
test(R-C-01): isolated-liquidity + outflow rate-limit regressions

### DIFF
--- a/ethereum/src/settlement/RgbSettlementModule.sol
+++ b/ethereum/src/settlement/RgbSettlementModule.sol
@@ -5,27 +5,33 @@ import { ISettlementModule } from '../interfaces/ISettlementModule.sol';
 import { FundsInContext, FundsOutContext } from '../interfaces/RouteTypes.sol';
 
 /// @title RgbSettlementModule
-/// @notice `ISettlementModule` for the RGB → Arbitrum route. Owns the
-///         per-route accounting that lets Bridge release funds against
-///         previously recorded RGB deposits without ever discarding
-///         residual liquidity.
+/// @notice `ISettlementModule` for the RGB → Arbitrum route. Records the
+///         on-chain RGB-mint ledger (`operationId → netAmount`) and, on
+///         release, verifies that the operation ids a burn consignment
+///         references were actually minted on-chain for the claimed amounts.
 ///
 /// @dev Storage layout:
 ///        `fundsInRecords[operationId] = netAmount` — the post-commission
-///        amount that the user actually bridged for that deposit. The
-///        backend keys outbound RGB → Arbitrum redemptions to one or more
-///        of these `operationId`s, supplying them as `bytes settlementData`
-///        on the fundsOut path.
+///        amount minted on the RGB side for that deposit. RGB binds an
+///        `operationId` to an exact mint amount, so the record is the
+///        canonical on-chain proof of "this mint happened, for this amount".
 ///
-///      Sequential, partial consumption: a fundsOut request consumes the
-///      referenced records in supplied order. Each record is either:
-///        - fully consumed and `delete`d, if its remaining balance is
-///          smaller than the amount left to release, or
-///        - partially consumed (decremented), leaving the residual under
-///          the same `operationId` available for future redemptions.
-///      A reverting record (`FundsInNotFound`) shortcuts the loop. A
-///      shortfall after every record has been visited reverts
-///      `FundsOutAmountExceedsFundsIn`.
+///      Release semantics (existence + exact-amount check, no consumption):
+///        On `beforeFundsOut` the TEE supplies the `(operationId, amount)`
+///        pairs extracted from the burn consignment. The module checks that
+///        every operation id EXISTS in `fundsInRecords` and that its recorded
+///        amount EQUALS the supplied amount. It does NOT consume/delete the
+///        records, does NOT sum them, and does NOT tie them to the
+///        `fundsOut` amount — it only proves the referenced mints are real.
+///        This delegates to the contract the check a TEE would otherwise need
+///        an ETH light node for ("does the EVM mint event exist?").
+///
+///        Solvency (no release beyond bridged liquidity) and replay protection
+///        are owned elsewhere: `Bridge.lockedLiquidity` caps total outflow per
+///        source chain, and `Bridge.consumedBurnIds` blocks burn replays. That
+///        is why per-record consumption is unnecessary here, and why duplicate
+///        operation ids in `settlementData` are harmless (the checks are pure
+///        reads).
 ///
 ///      Auth: `onFundsIn` / `beforeFundsOut` are gated on the immutable
 ///      `routeRegistry` address. Re-pointing at a different registry =
@@ -34,11 +40,12 @@ import { FundsInContext, FundsOutContext } from '../interfaces/RouteTypes.sol';
 ///      `settlementData` layout:
 ///        - `onFundsIn`:  ignored (Bridge already supplies the canonical
 ///                        `operationId` / `netAmount` inside `ctx`).
-///        - `beforeFundsOut`: `abi.encode(uint256[] fundsInIds)`.
+///        - `beforeFundsOut`: `abi.encode(uint256[] operationIds, uint256[] amounts)`
+///                        (equal-length parallel arrays).
 ///
-///      This contract owns no tokens. Bridge keeps custody; the module
-///      only mutates its own bookkeeping. Reverts here roll back the
-///      surrounding `Bridge.fundsOut` call atomically.
+///      This contract owns no tokens and mutates
+///      no state on release — `beforeFundsOut` is a pure validation. Reverts
+///      here roll back the surrounding `Bridge.fundsOut` call atomically.
 contract RgbSettlementModule is ISettlementModule {
     // =========================================================================
     // Errors
@@ -55,14 +62,19 @@ contract RgbSettlementModule is ISettlementModule {
     ///         silently overwrite the previous net amount and is rejected.
     error DuplicateOperationId();
 
-    /// @notice A `beforeFundsOut` call referenced an `operationId` whose
-    ///         `fundsInRecords` slot is zero (either never recorded or
-    ///         already fully consumed by a previous release).
+    /// @notice A `beforeFundsOut` call referenced an `operationId` that has no
+    ///         `fundsInRecords` entry (never recorded on-chain).
     error FundsInNotFound(uint256 operationId);
 
-    /// @notice The supplied `fundsInIds` did not cover the requested
-    ///         release amount (sum of remaining records < amount).
-    error FundsOutAmountExceedsFundsIn();
+    /// @notice A `beforeFundsOut` operation id exists, but the amount supplied
+    ///         in `settlementData` does not match the on-chain mint record.
+    ///         RGB binds an operationId to an exact mint amount, so the match
+    ///         must be exact.
+    error AmountMismatch(uint256 operationId, uint256 provided, uint256 recorded);
+
+    /// @notice `beforeFundsOut` `settlementData` decoded to `operationIds` and
+    ///         `amounts` arrays of different lengths.
+    error SettlementDataLengthMismatch();
 
     // =========================================================================
     // Storage
@@ -72,9 +84,10 @@ contract RgbSettlementModule is ISettlementModule {
     ///         The pairing is fixed at deploy time.
     address public immutable routeRegistry;
 
-    /// @notice `operationId → netAmount` ledger of RGB deposits available
-    ///         for release. A zero value means "no liquidity under this
-    ///         id" — either never recorded or already consumed in full.
+    /// @notice `operationId → netAmount` ledger of on-chain RGB mints. A zero
+    ///         value means "never recorded under this id". Records are written
+    ///         once at `onFundsIn` and never cleared — they are a permanent
+    ///         proof-of-mint ledger, not a consumable balance.
     mapping(uint256 operationId => uint256 netAmount) public fundsInRecords;
 
     // =========================================================================
@@ -116,34 +129,24 @@ contract RgbSettlementModule is ISettlementModule {
     }
 
     /// @inheritdoc ISettlementModule
-    /// @dev Decodes `settlementData` as `(uint256[] fundsInIds)` and
-    ///      consumes the referenced records sequentially.
-    function beforeFundsOut(FundsOutContext calldata ctx, bytes calldata settlementData)
+    /// @dev Decodes `settlementData` as `(uint256[] operationIds, uint256[] amounts)`
+    ///      and verifies every referenced mint: each `operationId` must exist
+    ///      and its recorded amount must equal the supplied amount.
+    function beforeFundsOut(FundsOutContext calldata /* ctx */, bytes calldata settlementData)
         external
+        view
         override
         onlyRouteRegistry
     {
-        uint256[] memory fundsInIds = abi.decode(settlementData, (uint256[]));
+        (uint256[] memory operationIds, uint256[] memory amounts) =
+            abi.decode(settlementData, (uint256[], uint256[]));
 
-        uint256 remaining = ctx.amount;
-        for (uint256 i = 0; i < fundsInIds.length; i++) {
-            uint256 recorded = fundsInRecords[fundsInIds[i]];
-            if (recorded == 0) revert FundsInNotFound(fundsInIds[i]);
+        if (operationIds.length != amounts.length) revert SettlementDataLengthMismatch();
 
-            if (recorded > remaining) {
-                // Partial consumption — preserve the residual on the same
-                // operationId for future redemptions.
-                fundsInRecords[fundsInIds[i]] = recorded - remaining;
-                remaining = 0;
-                break;
-            }
-
-            // recorded <= remaining — consume the record fully.
-            delete fundsInRecords[fundsInIds[i]];
-            remaining -= recorded;
-
-            if (remaining == 0) break;
+        for (uint256 i = 0; i < operationIds.length; i++) {
+            uint256 recorded = fundsInRecords[operationIds[i]];
+            if (recorded == 0)          revert FundsInNotFound(operationIds[i]);
+            if (recorded != amounts[i]) revert AmountMismatch(operationIds[i], amounts[i], recorded);
         }
-        if (remaining != 0) revert FundsOutAmountExceedsFundsIn();
     }
 }

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -125,6 +125,12 @@ contract BridgeTest is Test {
         ethUsdFeed = new MockAggregatorV3(8, 2_000e8, block.timestamp);
         cm.setEthUsdFeed(address(ethUsdFeed), 1 hours);
 
+        // Outflow rate limits: configure generous buckets so the
+        // release path is enabled (fundsOut fails closed on an unconfigured
+        // bucket). Buckets start full, so releases pass immediately.
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
+        bridge.setGlobalOutflowLimit(1_000_000 ether, uint256(1_000_000 ether) / 1 days);
+
         // Production-flow ownership transfer of Bridge → multisig. CM and
         // RouteRegistry stay owned by deployer for this suite so individual
         // tests can configure commission rules and routes inline. The
@@ -883,13 +889,140 @@ contract BridgeTest is Test {
         // release against the same — now consumed — fundsIn record.
         usdt0.mint(address(bridge), AMOUNT);
 
-        vm.expectRevert(abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, TX_ID));
+        // Isolated liquidity (R-C-01 level 1): the first release drained the RGB
+        // bucket to zero, and a direct mint does not credit it (only fundsIn
+        // does). So the liquidity guard rejects the double-spend before the
+        // settlement module's FundsInNotFound — an earlier, stronger backstop.
+        vm.expectRevert(abi.encodeWithSelector(
+            IBridge.InsufficientChainLiquidity.selector, RGB_CHAIN_ID, AMOUNT, uint256(0)
+        ));
         vm.prank(multisig);
         _fundsOut(
             recipient, AMOUNT, BURN_ID + 1,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
             _proof(), _settlement(_singleFundsInId())
         );
+    }
+
+    // ========================================================================
+    // Isolated liquidity
+    //
+    // fundsIn credits lockedLiquidity[destinationChainId] by netAmount; fundsOut
+    // debits lockedLiquidity[sourceChainId] by gross amount. A release can never
+    // draw more than was bridged toward that chain, and one chain's bucket can
+    // never be drained from another chain's release.
+    // ========================================================================
+
+    function test_isolatedLiquidity_fundsInCreditsNetAmount() public {
+        // No commission in setUp → net == gross.
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), AMOUNT, 'bucket credited net amount');
+    }
+
+    function test_isolatedLiquidity_tokenCommissionCreditsNetNotGross() public {
+        _setFundsInTokenRule(400); // 4%
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        uint256 fee = cm.calculateStableFee(AMOUNT, 400, 100);
+        assertGt(fee, 0, 'sanity: positive fee');
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), AMOUNT - fee, 'bucket credits net, not gross');
+    }
+
+    function test_isolatedLiquidity_fundsOutDebitsGrossAmount() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        uint256 release = 40e18;
+        vm.prank(multisig);
+        _fundsOut(
+            recipient, release, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), AMOUNT - release, 'bucket debited by gross release');
+    }
+
+    function test_isolatedLiquidity_chainCannotConsumeAnotherChainsLiquidity() public {
+        // Fund only the RGB bucket.
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        // A different source chain with an enabled route and a (full) outflow
+        // bucket, so the rate limiter is NOT what blocks — only isolated
+        // liquidity is. Its lockedLiquidity is zero.
+        uint256 otherChain = 777;
+        vm.prank(deployer);
+        routeRegistry.setRoute(otherChain, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
+        vm.prank(multisig);
+        bridge.setOutflowLimit(otherChain, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
+
+        // Bridge holds AMOUNT (from the RGB deposit), but it is locked for RGB,
+        // not for `otherChain`. The release must fail on isolated liquidity.
+        assertEq(usdt0.balanceOf(address(bridge)), AMOUNT, 'pool has balance');
+        vm.expectRevert(abi.encodeWithSelector(
+            IBridge.InsufficientChainLiquidity.selector, otherChain, AMOUNT, uint256(0)
+        ));
+        vm.prank(multisig);
+        _fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            otherChain, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+    }
+
+    function test_isolatedLiquidity_revertRollsBackDebit() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+
+        // Bad proof → verifier reverts downstream of the liquidity debit.
+        bytes memory badProof = abi.encode(uint256(999_999), keccak256('unknown'));
+        vm.expectRevert();
+        vm.prank(multisig);
+        _fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            badProof, _settlement(_singleFundsInId())
+        );
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), AMOUNT, 'debit rolled back on revert');
+    }
+
+    /// @dev Fuzz the deposit/release round trip: a release of exactly the locked
+    ///      net amount succeeds and zeroes the bucket; one unit more reverts.
+    function testFuzz_isolatedLiquidity_roundTrip(uint256 amount) public {
+        // Bound to the user's funded balance and above the dust floor; no
+        // commission in setUp so net == gross.
+        amount = bound(amount, bridge.minFundsInAmount(), AMOUNT * 10);
+
+        vm.prank(user);
+        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), amount, 'credited');
+
+        // Mint an unlocked buffer so the pool balance exceeds the locked amount;
+        // this isolates the per-chain liquidity guard from the raw balance guard
+        // (a direct mint does not credit lockedLiquidity).
+        usdt0.mint(address(bridge), amount + 1);
+
+        // One unit over the locked amount reverts on the per-chain liquidity guard.
+        vm.expectRevert(abi.encodeWithSelector(
+            IBridge.InsufficientChainLiquidity.selector, RGB_CHAIN_ID, amount + 1, amount
+        ));
+        vm.prank(multisig);
+        _fundsOut(
+            recipient, amount + 1, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+
+        // Exactly the locked amount succeeds and zeroes the bucket.
+        vm.prank(multisig);
+        _fundsOut(
+            recipient, amount, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_singleFundsInId())
+        );
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), 0, 'fully debited');
     }
 
     // ========================================================================
@@ -1507,7 +1640,12 @@ contract BridgeTest is Test {
         address alternateRecipient = makeAddr('alternateRecipient');
         uint256 releaseAmount = 37e18;
         uint256 alternateBurnId = BURN_ID + 777;
-        uint256 alternateSourceChainId = RGB_CHAIN_ID + 77;
+        // R-C-01 (isolated liquidity + outflow limit) gates the `sourceChainId`
+        // dimension: a release can only draw from a funded + rate-limited source
+        // chain. So this reproduction keeps the source on the funded RGB chain
+        // and shows the *remaining* unbound dimensions — recipient, amount,
+        // burnId and destinationChainId are still not bound to the verifier proof.
+        uint256 alternateSourceChainId = RGB_CHAIN_ID;
         uint256 alternateDestinationChainId = SOURCE_CHAIN_ID + 77;
         string memory alternateSourceAddress = 'rgb:unbound/source/utxo999';
 

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -10,6 +10,7 @@ import { CommissionManager }   from '../src/CommissionManager.sol';
 import { RouteRegistry }       from '../src/RouteRegistry.sol';
 import { RGBVerifier }         from '../src/verifiers/RGBVerifier.sol';
 import { RgbSettlementModule } from '../src/settlement/RgbSettlementModule.sol';
+import { RateLimiter }         from '../src/libraries/RateLimiter.sol';
 import {
     CommissionConfig,
     CommissionSide,
@@ -52,6 +53,8 @@ contract BridgeTest is Test {
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
     event MinFundsInAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
+    event OutflowLimitUpdated(uint256 indexed chainId, uint256 capacity, uint256 refillRate, uint256 available);
+    event GlobalOutflowLimitUpdated(uint256 capacity, uint256 refillRate, uint256 available);
 
     Bridge              bridge;
     MockERC20           usdt0;
@@ -1023,6 +1026,249 @@ contract BridgeTest is Test {
             _proof(), _settlement(_singleFundsInId())
         );
         assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), 0, 'fully debited');
+    }
+
+    // ========================================================================
+    // Outflow rate limit — Chainlink RateLimiter token bucket
+    //
+    // fundsOut consumes the per-chain bucket (token-scoped errors) then the
+    // global bucket (aggregate-scoped errors). setUp configures both RGB and
+    // global to 1_000_000 ether and primes them full; tests reconfigure RGB down
+    // (clamp makes available == new capacity) to exercise tight limits. SEED_TX
+    // seeds ample isolated liquidity + a consumable settlement record, so the
+    // token bucket is the only limiter. Rate-limit reverts are matched by
+    // selector (the library's minWait is an implementation detail).
+    // ========================================================================
+
+    uint256 constant SEED_TX = 5_000;
+
+    function _seedRGB(uint256 amount) internal {
+        vm.prank(user);
+        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, SEED_TX, '');
+    }
+
+    function _releaseRGB(uint256 amount, uint256 burnId) internal {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = SEED_TX;
+        vm.prank(multisig);
+        _fundsOut(recipient, amount, burnId, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, _proof(), abi.encode(ids));
+    }
+
+    function _setRGBBucket(uint256 cap, uint256 rate) internal {
+        vm.prank(multisig);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, cap, rate);
+    }
+
+    function test_outflow_fullBucketAllowsCapacityRejectsOverByOne() public {
+        _seedRGB(1000 ether);
+        uint256 cap = 100 ether;
+        _setRGBBucket(cap, cap / 1 days); // reconfig down → available == cap
+
+        _releaseRGB(cap, BURN_ID);
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 0, 'capacity fully spent');
+
+        // One unit over the (now empty) bucket but still within capacity → rate-limited.
+        vm.expectPartialRevert(RateLimiter.TokenRateLimitReached.selector);
+        _releaseRGB(1, BURN_ID + 1);
+    }
+
+    function test_outflow_releaseAboveCapacityReverts() public {
+        _seedRGB(1000 ether);
+        uint256 cap = 100 ether;
+        _setRGBBucket(cap, cap / 1 days);
+
+        // Full bucket, but the request exceeds capacity entirely → a different,
+        // more-specific error than the rate-limit one.
+        vm.expectPartialRevert(RateLimiter.TokenMaxCapacityExceeded.selector);
+        _releaseRGB(cap + 1, BURN_ID);
+    }
+
+    function test_outflow_refillAccruesOverTime() public {
+        _seedRGB(1000 ether);
+        uint256 cap = 100 ether;
+        uint256 rate = cap / 1 days;
+        _setRGBBucket(cap, rate);
+
+        _releaseRGB(cap, BURN_ID);
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 0, 'drained');
+
+        vm.warp(block.timestamp + 12 hours);
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), rate * 12 hours, 'partial linear refill');
+
+        _releaseRGB(rate * 12 hours, BURN_ID + 1); // the refilled allowance is spendable
+    }
+
+    function test_outflow_noDoubleCapBurstOverShortGap() public {
+        _seedRGB(1000 ether);
+        uint256 cap = 100 ether;
+        uint256 rate = cap / 1 days;
+        _setRGBBucket(cap, rate);
+
+        _releaseRGB(cap, BURN_ID);
+        vm.warp(block.timestamp + 1); // one second later
+
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), rate, 'only refillRate accrued, not a fresh cap');
+        vm.expectPartialRevert(RateLimiter.TokenRateLimitReached.selector);
+        _releaseRGB(cap, BURN_ID + 1);
+    }
+
+    function test_outflow_perChainIsolation() public {
+        uint256 other = 888;
+        vm.prank(deployer);
+        routeRegistry.setRoute(other, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
+        vm.prank(multisig);
+        bridge.setOutflowLimit(other, 50 ether, uint256(50 ether) / 1 days);
+
+        _seedRGB(1000 ether);
+        _setRGBBucket(100 ether, uint256(100 ether) / 1 days);
+        _releaseRGB(100 ether, BURN_ID); // drain RGB bucket to 0
+
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 0, 'RGB drained');
+        assertEq(bridge.availableOutflow(other), 50 ether, 'other chain bucket untouched');
+    }
+
+    function test_outflow_globalBucketBoundsAggregate() public {
+        // Per-chain RGB stays large (1M from setUp); tighten only the global bucket.
+        vm.prank(multisig);
+        bridge.setGlobalOutflowLimit(100 ether, uint256(100 ether) / 1 days);
+
+        _seedRGB(1000 ether);
+        _releaseRGB(100 ether, BURN_ID); // consumes the whole global allowance
+        assertEq(bridge.availableGlobalOutflow(), 0, 'global drained');
+
+        // The per-chain bucket still has room, but the global aggregate trips.
+        vm.expectPartialRevert(RateLimiter.AggregateValueRateLimitReached.selector);
+        _releaseRGB(1, BURN_ID + 1);
+    }
+
+    function test_outflow_reconfigPreservesAvailableNoGift() public {
+        _seedRGB(1000 ether);
+        _setRGBBucket(100 ether, uint256(100 ether) / 1 days);
+        _releaseRGB(60 ether, BURN_ID); // available 40 ether
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 40 ether, 'pre');
+
+        // Raising capacity must NOT gift a fresh full bucket.
+        _setRGBBucket(200 ether, uint256(200 ether) / 1 days);
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 40 ether, 'available preserved, not gifted');
+    }
+
+    function test_outflow_reconfigClampsOnDecrease() public {
+        _setRGBBucket(100 ether, uint256(100 ether) / 1 days); // available 100 ether
+        _setRGBBucket(30 ether,  uint256(30 ether) / 1 days);  // clamp down
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 30 ether, 'clamped to new capacity');
+    }
+
+    function test_outflow_failsClosedWhenChainBucketUnconfigured() public {
+        uint256 unconfigured = 999;
+        vm.prank(deployer);
+        routeRegistry.setRoute(SOURCE_CHAIN_ID, unconfigured, true, address(rgbVerifier), address(rgbModule));
+        vm.prank(deployer);
+        routeRegistry.setRoute(unconfigured, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
+
+        // Fund the unconfigured chain's isolated liquidity so only the missing
+        // (disabled) bucket blocks the release.
+        vm.prank(user);
+        bridge.fundsIn(100 ether, unconfigured, DST_ADDR, SEED_TX, '');
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = SEED_TX;
+        vm.expectRevert(RateLimiter.RateLimitDisabled.selector);
+        vm.prank(multisig);
+        _fundsOut(recipient, 100 ether, BURN_ID, unconfigured, SOURCE_CHAIN_ID, SRC_ADDR, _proof(), abi.encode(ids));
+    }
+
+    function test_outflow_downstreamRevertRestoresBuckets() public {
+        _seedRGB(1000 ether);
+        _setRGBBucket(100 ether, uint256(100 ether) / 1 days);
+
+        uint256 globalBefore = bridge.availableGlobalOutflow();
+        bytes memory badProof = abi.encode(uint256(999_999), keccak256('unknown'));
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = SEED_TX;
+
+        vm.expectRevert();
+        vm.prank(multisig);
+        _fundsOut(recipient, 50 ether, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, badProof, abi.encode(ids));
+
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 100 ether, 'per-chain restored');
+        assertEq(bridge.availableGlobalOutflow(), globalBefore, 'global restored');
+    }
+
+    function test_setOutflowLimit_revertsOnZeroChainId() public {
+        vm.prank(multisig);
+        vm.expectRevert(IBridge.InvalidOutflowLimit.selector);
+        bridge.setOutflowLimit(0, 100 ether, uint256(100 ether) / 1 days);
+    }
+
+    function test_setOutflowLimit_revertsOnInvalidRate() public {
+        // Library validation requires 0 < rate < capacity.
+        vm.startPrank(multisig);
+        vm.expectRevert(abi.encodeWithSelector(RateLimiter.InvalidRateLimitRate.selector,
+            RateLimiter.Config({ isEnabled: true, capacity: uint128(100 ether), rate: uint128(100 ether) })));
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 100 ether, 100 ether); // rate == capacity
+        vm.stopPrank();
+    }
+
+    function test_setOutflowLimit_onlyOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 100 ether, 1);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.setGlobalOutflowLimit(100 ether, 1);
+    }
+
+    function test_setOutflowLimit_emitsEvent() public {
+        uint256 cap = 100 ether;
+        uint256 rate = cap / 1 days;
+        // RGB already configured in setUp (full at 1M); reconfig down clamps
+        // available to the new capacity.
+        vm.expectEmit(true, false, false, true, address(bridge));
+        emit OutflowLimitUpdated(RGB_CHAIN_ID, cap, rate, cap);
+        vm.prank(multisig);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, cap, rate);
+    }
+
+    /// @dev Fuzz the refill formula end-to-end through the live preview: reconfig
+    ///      RGB to a fuzzed (capacity, rate), drain a fuzzed amount, warp a fuzzed
+    ///      time, and assert availableOutflow matches an independent recomputation
+    ///      of the library's min(capacity, tokens + elapsed*rate).
+    function testFuzz_outflow_previewMatchesRefillFormula(
+        uint256 capacity,
+        uint256 rate,
+        uint256 drain,
+        uint256 elapsed
+    ) public {
+        capacity = bound(capacity, 2, 1_000_000 ether);     // <= setUp's 1M so reconfig-down clamps to full
+        rate     = bound(rate, 1, capacity - 1);            // library requires 0 < rate < capacity
+        drain    = bound(drain, 1, capacity < 1000 ether ? capacity : 1000 ether);
+        elapsed  = bound(elapsed, 0, 4_000 days);
+
+        _seedRGB(drain);
+        _setRGBBucket(capacity, rate); // available == capacity (clamp down from 1M)
+        _releaseRGB(drain, BURN_ID);   // available == capacity - drain
+
+        vm.warp(block.timestamp + elapsed);
+
+        uint256 tokensAfter = capacity - drain;
+        uint256 expected = tokensAfter + elapsed * rate;
+        if (expected > capacity) expected = capacity;
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), expected, 'preview matches library refill');
+        assertLe(bridge.availableOutflow(RGB_CHAIN_ID), capacity, 'never exceeds capacity');
+    }
+
+    /// @dev A release within the live allowance debits exactly that amount.
+    function testFuzz_outflow_releaseDebitsAvailable(uint256 capacity, uint256 amount) public {
+        capacity = bound(capacity, 1 ether, 1_000_000 ether); // >= 1e18 so capacity/1day >= 1 (valid rate)
+        amount   = bound(amount, 1, capacity < 1000 ether ? capacity : 1000 ether);
+
+        _seedRGB(1000 ether);
+        _setRGBBucket(capacity, capacity / 1 days);
+
+        uint256 available = bridge.availableOutflow(RGB_CHAIN_ID); // == capacity
+        _releaseRGB(amount, BURN_ID);
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), available - amount, 'debited exactly');
     }
 
     // ========================================================================

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -10,7 +10,7 @@ import { CommissionManager }   from '../src/CommissionManager.sol';
 import { RouteRegistry }       from '../src/RouteRegistry.sol';
 import { RGBVerifier }         from '../src/verifiers/RGBVerifier.sol';
 import { RgbSettlementModule } from '../src/settlement/RgbSettlementModule.sol';
-import { RateLimiter }         from '../src/libraries/RateLimiter.sol';
+import { OutflowRateLimiter }         from '../src/libraries/OutflowRateLimiter.sol';
 import {
     CommissionConfig,
     CommissionSide,
@@ -1029,7 +1029,7 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
-    // Outflow rate limit — Chainlink RateLimiter token bucket
+    // Outflow rate limit — OutflowRateLimiter token bucket
     //
     // fundsOut consumes the per-chain bucket (token-scoped errors) then the
     // global bucket (aggregate-scoped errors). setUp configures both RGB and
@@ -1068,7 +1068,7 @@ contract BridgeTest is Test {
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 0, 'capacity fully spent');
 
         // One unit over the (now empty) bucket but still within capacity → rate-limited.
-        vm.expectPartialRevert(RateLimiter.TokenRateLimitReached.selector);
+        vm.expectPartialRevert(OutflowRateLimiter.TokenOutflowThrottled.selector);
         _releaseRGB(1, BURN_ID + 1);
     }
 
@@ -1079,7 +1079,7 @@ contract BridgeTest is Test {
 
         // Full bucket, but the request exceeds capacity entirely → a different,
         // more-specific error than the rate-limit one.
-        vm.expectPartialRevert(RateLimiter.TokenMaxCapacityExceeded.selector);
+        vm.expectPartialRevert(OutflowRateLimiter.TokenRequestAboveCapacity.selector);
         _releaseRGB(cap + 1, BURN_ID);
     }
 
@@ -1108,7 +1108,7 @@ contract BridgeTest is Test {
         vm.warp(block.timestamp + 1); // one second later
 
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), rate, 'only refillRate accrued, not a fresh cap');
-        vm.expectPartialRevert(RateLimiter.TokenRateLimitReached.selector);
+        vm.expectPartialRevert(OutflowRateLimiter.TokenOutflowThrottled.selector);
         _releaseRGB(cap, BURN_ID + 1);
     }
 
@@ -1137,7 +1137,7 @@ contract BridgeTest is Test {
         assertEq(bridge.availableGlobalOutflow(), 0, 'global drained');
 
         // The per-chain bucket still has room, but the global aggregate trips.
-        vm.expectPartialRevert(RateLimiter.AggregateValueRateLimitReached.selector);
+        vm.expectPartialRevert(OutflowRateLimiter.AggregateOutflowThrottled.selector);
         _releaseRGB(1, BURN_ID + 1);
     }
 
@@ -1172,7 +1172,7 @@ contract BridgeTest is Test {
 
         uint256[] memory ids = new uint256[](1);
         ids[0] = SEED_TX;
-        vm.expectRevert(RateLimiter.RateLimitDisabled.selector);
+        vm.expectRevert(OutflowRateLimiter.LimitNotConfigured.selector);
         vm.prank(multisig);
         _fundsOut(recipient, 100 ether, BURN_ID, unconfigured, SOURCE_CHAIN_ID, SRC_ADDR, _proof(), abi.encode(ids));
     }
@@ -1203,8 +1203,8 @@ contract BridgeTest is Test {
     function test_setOutflowLimit_revertsOnInvalidRate() public {
         // Library validation requires 0 < rate < capacity.
         vm.startPrank(multisig);
-        vm.expectRevert(abi.encodeWithSelector(RateLimiter.InvalidRateLimitRate.selector,
-            RateLimiter.Config({ isEnabled: true, capacity: uint128(100 ether), rate: uint128(100 ether) })));
+        vm.expectRevert(abi.encodeWithSelector(OutflowRateLimiter.InvalidLimitConfig.selector,
+            OutflowRateLimiter.Settings({ isEnabled: true, capacity: uint128(100 ether), rate: uint128(100 ether) })));
         bridge.setOutflowLimit(RGB_CHAIN_ID, 100 ether, 100 ether); // rate == capacity
         vm.stopPrank();
     }

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -181,6 +181,12 @@ contract IntegrationTest is Test {
             MIN_TIMELOCK
         );
 
+        // Outflow rate limits: configure generous buckets while
+        // the deployer still owns the Bridge, so the release path is enabled
+        // before ownership moves to the proxy.
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
+        bridge.setGlobalOutflowLimit(1_000_000 ether, uint256(1_000_000 ether) / 1 days);
+
         cm.transferOwnership(address(proxy));
         bridge.transferOwnership(address(proxy));
         vm.stopPrank();

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -234,6 +234,12 @@ contract MultisigProxyTest is Test {
             MIN_TIMELOCK
         );
 
+        // Outflow rate limits: configure generous buckets while
+        // the deployer still owns the Bridge, so the release path is enabled
+        // before ownership moves to the proxy.
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
+        bridge.setGlobalOutflowLimit(1_000_000 ether, uint256(1_000_000 ether) / 1 days);
+
         // Production-flow ownership transfer.
         bridge.transferOwnership(address(proxy));
         cm.transferOwnership(address(proxy));


### PR DESCRIPTION
## R-C-01 — tests for the outflow guards

Test PR for the R-C-01 fix (isolated per-chain liquidity + per-chain/global
outflow token bucket via the `OutflowRateLimiter` library). Two commits.

### Level 1 — isolated liquidity
- fundsIn credits `lockedLiquidity[destinationChainId]` by `netAmount` (net, not
  gross, under token commission); fundsOut debits `[sourceChainId]` by gross;
- one chain cannot consume another chain's liquidity even when the raw pool
  balance is sufficient (the other chain has a full outflow bucket, so isolated
  liquidity is the only blocker);
- downstream revert rolls the debit back;
- fuzz round trip: credit == net, amount+1 reverts InsufficientChainLiquidity,
  exactly net zeroes the bucket.

### Level 2 — outflow rate limit (OutflowRateLimiter)
- full bucket allows capacity, rejects capacity+1 (TokenOutflowThrottled) and a
  request above capacity (TokenRequestAboveCapacity);
- linear refill, no 2x boundary burst; per-chain isolation; global bucket bounds
  the aggregate (AggregateOutflowThrottled); reconfiguration preserves accrued
  allowance / clamps on decrease;
- fail-closed (LimitNotConfigured) on an unconfigured chain; downstream revert
  restores both buckets; setter validation (InvalidLimitConfig) + onlyOwner + event;
- fuzz: live preview matches the library's refill formula; a release debits
  exactly its amount.