### PR TITLE
test: RgbSettlementModule existence + exact-amount checks

### DIFF
--- a/ethereum/src/libraries/OutflowRateLimiter.sol
+++ b/ethereum/src/libraries/OutflowRateLimiter.sol
@@ -69,10 +69,10 @@ library OutflowRateLimiter {
     }
 
     /// @notice Return bucket state including refill accrued up to this block.
-    function currentState(Bucket memory bucket) internal view returns (Bucket memory) {
-        bucket.tokens = _asUint128(_preview(bucket));
-        bucket.lastUpdated = uint32(block.timestamp);
-        return bucket;
+    function currentState(Bucket memory bucket) internal view returns (Bucket memory updated) {
+        updated = bucket;
+        updated.tokens = _asUint128(_preview(bucket));
+        updated.lastUpdated = uint32(block.timestamp);
     }
 
     /// @notice Apply new settings while carrying over accrued allowance.
@@ -125,7 +125,7 @@ library OutflowRateLimiter {
         return left < right ? left : right;
     }
 
-    function _asUint128(uint256 value) private pure returns (uint128) {
+    function _asUint128(uint256 value) internal pure returns (uint128) {
         if (value > type(uint128).max) revert AmountExceedsUint128(value);
         // forge-lint: disable-next-line(unsafe-typecast)
         return uint128(value);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -160,8 +160,40 @@ contract BridgeTest is Test {
         return abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
     }
 
+    /// @dev Build `settlementData` for the reworked RgbSettlementModule, which
+    ///      expects `(uint256[] operationIds, uint256[] amounts)` and checks
+    ///      each id exists with an EXACTLY matching amount (no consumption).
+    ///
+    ///      This convenience encodes `AMOUNT` for every id — the standard
+    ///      deposit size used across these tests (`TX_ID` is funded with
+    ///      `AMOUNT`). It is intentionally `pure`: it must NOT make an external
+    ///      call, because it is frequently passed inline as a `fundsOut`
+    ///      argument right after `vm.prank`/`vm.expectRevert`, and a staticcall
+    ///      there would consume the cheatcode. Tests whose records differ from
+    ///      `AMOUNT` (seeded liquidity, multi-amount, fuzz, deliberate
+    ///      mismatch) use `_settlementWithAmounts` with explicit values.
     function _settlement(uint256[] memory ids) internal pure returns (bytes memory) {
-        return abi.encode(ids);
+        uint256[] memory amounts = new uint256[](ids.length);
+        for (uint256 i = 0; i < ids.length; i++) {
+            amounts[i] = AMOUNT;
+        }
+        return abi.encode(ids, amounts);
+    }
+
+    /// @dev Explicit `(ids, amounts)` encoding for records that are not `AMOUNT`
+    ///      (seeded liquidity, multi-amount, fuzz) and for mismatch/length tests.
+    function _settlementWithAmounts(uint256[] memory ids, uint256[] memory amounts)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(ids, amounts);
+    }
+
+    /// @dev Single-element `uint256[]` (used for explicit amount arrays).
+    function _one(uint256 value) internal pure returns (uint256[] memory arr) {
+        arr = new uint256[](1);
+        arr[0] = value;
     }
 
     /// @dev Wrap the former 8 positional `fundsOut` args into the typed struct
@@ -744,7 +776,7 @@ contract BridgeTest is Test {
         assertEq(usdt0.balanceOf(address(bridge)), 0);
     }
 
-    function test_fundsOut_consumesRecord() public {
+    function test_fundsOut_keepsRecordAfterRelease() public {
         vm.prank(user);
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
 
@@ -755,7 +787,8 @@ contract BridgeTest is Test {
             _proof(), _settlement(_singleFundsInId())
         );
 
-        assertEq(rgbModule.fundsInRecords(TX_ID), 0);
+        // The mint ledger is permanent (proof-of-mint), not a consumable balance.
+        assertEq(rgbModule.fundsInRecords(TX_ID), AMOUNT, 'record unchanged after release');
     }
 
     function test_fundsOut_multipleFundsInIds() public {
@@ -772,17 +805,21 @@ contract BridgeTest is Test {
         uint256[] memory ids = new uint256[](2);
         ids[0] = txId1;
         ids[1] = txId2;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = amount1;
+        amounts[1] = amount2;
 
         vm.prank(multisig);
         _fundsOut(
             recipient, amount1 + amount2, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(ids)
+            _proof(), _settlementWithAmounts(ids, amounts)
         );
 
         assertEq(usdt0.balanceOf(recipient), amount1 + amount2);
-        assertEq(rgbModule.fundsInRecords(txId1), 0);
-        assertEq(rgbModule.fundsInRecords(txId2), 0);
+        // Records are a permanent proof-of-mint ledger — not consumed on release.
+        assertEq(rgbModule.fundsInRecords(txId1), amount1, 'record 1 unchanged');
+        assertEq(rgbModule.fundsInRecords(txId2), amount2, 'record 2 unchanged');
     }
 
     // ========================================================================
@@ -826,23 +863,25 @@ contract BridgeTest is Test {
         );
     }
 
-    function test_fundsOut_revertsOnAmountExceedsFundsIn() public {
+    function test_fundsOut_revertsOnAmountMismatch() public {
+        // Record a mint of 50e18 under txId1, then claim it for a different
+        // amount in settlementData. The module binds operationId → exact mint
+        // amount, so the mismatch must revert (surfaced through the Bridge).
         uint256 txId1 = 100;
-        uint256 txId2 = 101;
         vm.prank(user);
         bridge.fundsIn(50e18, RGB_CHAIN_ID, DST_ADDR, txId1, '');
-        vm.prank(user);
-        bridge.fundsIn(50e18, RGB_CHAIN_ID, DST_ADDR, txId2, '');
 
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = txId1;
+        uint256[] memory ids     = new uint256[](1); ids[0] = txId1;
+        uint256[] memory amounts = new uint256[](1); amounts[0] = 60e18; // != recorded 50e18
 
-        vm.expectRevert(RgbSettlementModule.FundsOutAmountExceedsFundsIn.selector);
+        vm.expectRevert(abi.encodeWithSelector(
+            RgbSettlementModule.AmountMismatch.selector, txId1, uint256(60e18), uint256(50e18)
+        ));
         vm.prank(multisig);
         _fundsOut(
-            recipient, 60e18, BURN_ID,
+            recipient, 50e18, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(ids)
+            _proof(), _settlementWithAmounts(ids, amounts)
         );
     }
 
@@ -894,8 +933,9 @@ contract BridgeTest is Test {
 
         // Isolated liquidity (R-C-01 level 1): the first release drained the RGB
         // bucket to zero, and a direct mint does not credit it (only fundsIn
-        // does). So the liquidity guard rejects the double-spend before the
-        // settlement module's FundsInNotFound — an earlier, stronger backstop.
+        // does). The settlement module no longer consumes records (the mint
+        // proof is permanent and would still pass), so the liquidity guard is
+        // now the sole backstop against re-releasing a spent deposit.
         vm.expectRevert(abi.encodeWithSelector(
             IBridge.InsufficientChainLiquidity.selector, RGB_CHAIN_ID, AMOUNT, uint256(0)
         ));
@@ -1015,7 +1055,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, amount + 1, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlementWithAmounts(_singleFundsInId(), _one(amount))
         );
 
         // Exactly the locked amount succeeds and zeroes the bucket.
@@ -1023,7 +1063,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, amount, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlementWithAmounts(_singleFundsInId(), _one(amount))
         );
         assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), 0, 'fully debited');
     }
@@ -1035,14 +1075,21 @@ contract BridgeTest is Test {
     // global bucket (aggregate-scoped errors). setUp configures both RGB and
     // global to 1_000_000 ether and primes them full; tests reconfigure RGB down
     // (clamp makes available == new capacity) to exercise tight limits. SEED_TX
-    // seeds ample isolated liquidity + a consumable settlement record, so the
-    // token bucket is the only limiter. Rate-limit reverts are matched by
+    // seeds ample isolated liquidity + a settlement record (proof-of-mint), so
+    // the token bucket is the only limiter. Rate-limit reverts are matched by
     // selector (the library's minWait is an implementation detail).
     // ========================================================================
 
     uint256 constant SEED_TX = 5_000;
 
+    /// @dev The net amount recorded under `SEED_TX` by the last `_seedRGB`, so
+    ///      `_releaseRGB` can build a settlement whose amount matches the record
+    ///      (the reworked module requires an exact match). Read internally only
+    ///      — no external call — so inline use after a cheatcode is safe.
+    uint256 _seedAmt;
+
     function _seedRGB(uint256 amount) internal {
+        _seedAmt = amount; // no fundsIn commission in this suite → net == gross
         vm.prank(user);
         bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, SEED_TX, '');
     }
@@ -1051,7 +1098,10 @@ contract BridgeTest is Test {
         uint256[] memory ids = new uint256[](1);
         ids[0] = SEED_TX;
         vm.prank(multisig);
-        _fundsOut(recipient, amount, burnId, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, _proof(), abi.encode(ids));
+        _fundsOut(
+            recipient, amount, burnId, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlementWithAmounts(ids, _one(_seedAmt))
+        );
     }
 
     function _setRGBBucket(uint256 cap, uint256 rate) internal {
@@ -1174,7 +1224,7 @@ contract BridgeTest is Test {
         ids[0] = SEED_TX;
         vm.expectRevert(OutflowRateLimiter.LimitNotConfigured.selector);
         vm.prank(multisig);
-        _fundsOut(recipient, 100 ether, BURN_ID, unconfigured, SOURCE_CHAIN_ID, SRC_ADDR, _proof(), abi.encode(ids));
+        _fundsOut(recipient, 100 ether, BURN_ID, unconfigured, SOURCE_CHAIN_ID, SRC_ADDR, _proof(), _settlementWithAmounts(ids, _one(100 ether)));
     }
 
     function test_outflow_downstreamRevertRestoresBuckets() public {
@@ -1188,7 +1238,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert();
         vm.prank(multisig);
-        _fundsOut(recipient, 50 ether, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, badProof, abi.encode(ids));
+        _fundsOut(recipient, 50 ether, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, badProof, _settlementWithAmounts(ids, _one(_seedAmt)));
 
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 100 ether, 'per-chain restored');
         assertEq(bridge.availableGlobalOutflow(), globalBefore, 'global restored');
@@ -1606,7 +1656,7 @@ contract BridgeTest is Test {
     // fundsOut — full-flow state snapshots
     // ========================================================================
 
-    function test_fundsOut_snapshot_tokenCommission_partialConsume() public {
+    function test_fundsOut_snapshot_tokenCommission_partialRelease() public {
         uint256 releaseAmount = 60e18;
         uint256 percent = 500; // 5%
 
@@ -1651,7 +1701,10 @@ contract BridgeTest is Test {
             SRC_ADDR
         );
 
-        // Release only part of the RGB record; the module should preserve the residual.
+        // Release less than the recorded mint. The settlement module no longer
+        // consumes records (the proof-of-mint ledger is permanent), so the
+        // record is left intact regardless of the release amount; solvency for
+        // the partial release is enforced by Bridge.lockedLiquidity.
         vm.prank(multisig);
         _fundsOut(
             recipient,
@@ -1674,7 +1727,7 @@ contract BridgeTest is Test {
             'cm pool delta'
         );
         assertEq(cm.nativeCommissionPool(),        nativePoolBefore,             'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore - releaseAmount, 'record residual');
+        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore, 'record unchanged (proof-of-mint permanent)');
 
         // The gross Bridge debit splits into recipient net payout and CM token commission.
         assertEq(
@@ -1827,15 +1880,18 @@ contract BridgeTest is Test {
         uint256 txId2 = 101;
         uint256 amount1 = 50e18;
         uint256 amount2 = 50e18;
-        uint256 releaseAmount = 60e18;
+        uint256 releaseAmount = 50e18;
 
         vm.prank(user);
         bridge.fundsIn(amount1, RGB_CHAIN_ID, DST_ADDR, txId1, '');
         vm.prank(user);
         bridge.fundsIn(amount2, RGB_CHAIN_ID, DST_ADDR, txId2, '');
 
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = txId1;
+        // Reference txId1 with a deliberately wrong amount so the settlement
+        // module reverts (AmountMismatch) after the Bridge has already marked
+        // the burn id and debited liquidity — exercising the rollback.
+        uint256[] memory ids        = new uint256[](1); ids[0] = txId1;
+        uint256[] memory badAmounts = new uint256[](1); badAmounts[0] = amount1 + 1;
 
         uint256 bridgeBefore     = usdt0.balanceOf(address(bridge));
         uint256 recipientBefore  = usdt0.balanceOf(recipient);
@@ -1854,9 +1910,12 @@ contract BridgeTest is Test {
         assertEq(record1Before, amount1, 'pre record 1');
         assertEq(record2Before, amount2, 'pre record 2');
 
-        // The first record is deleted before the module discovers the release
-        // is underfunded; the revert must restore that consumed record too.
-        vm.expectRevert(RgbSettlementModule.FundsOutAmountExceedsFundsIn.selector);
+        // The module reverts on the amount mismatch; the surrounding fundsOut
+        // must atomically roll back the burn-id mark and the liquidity debit.
+        // (Records are view-only now, so they are trivially unchanged.)
+        vm.expectRevert(abi.encodeWithSelector(
+            RgbSettlementModule.AmountMismatch.selector, txId1, amount1 + 1, amount1
+        ));
         vm.prank(multisig);
         _fundsOut(
             recipient,
@@ -1866,7 +1925,7 @@ contract BridgeTest is Test {
             SOURCE_CHAIN_ID,
             SRC_ADDR,
             _proof(),
-            _settlement(ids)
+            _settlementWithAmounts(ids, badAmounts)
         );
 
         assertFalse(bridge.consumedBurnIds(BURN_ID), 'burn id unchanged');
@@ -1875,7 +1934,7 @@ contract BridgeTest is Test {
         assertEq(usdt0.balanceOf(address(cm)),     cmBefore, 'cm token unchanged');
         assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
         assertEq(cm.nativeCommissionPool(),        nativePoolBefore, 'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(txId1),  record1Before, 'record 1 rolled back');
+        assertEq(rgbModule.fundsInRecords(txId1),  record1Before, 'record 1 unchanged');
         assertEq(rgbModule.fundsInRecords(txId2),  record2Before, 'record 2 unchanged');
     }
 
@@ -1918,8 +1977,8 @@ contract BridgeTest is Test {
 
         // Current behavior: this is still an authorized fundsOut call, but the
         // RGBVerifier checks only the encoded BTC block commitment proof. The
-        // record was created on the default route and is consumed on this
-        // alternate enabled route because the proof is not bound to release
+        // record was created on the default route and the release is accepted on
+        // this alternate enabled route because the proof is not bound to release
         // context on-chain. If that binding is enforced later, invert this to
         // expect a revert.
         vm.expectEmit(true, false, false, true, address(bridge));
@@ -1949,7 +2008,7 @@ contract BridgeTest is Test {
         assertTrue(bridge.consumedBurnIds(alternateBurnId), 'burn id consumed');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore - releaseAmount, 'bridge debit');
         assertEq(usdt0.balanceOf(alternateRecipient), recipientBefore + releaseAmount, 'recipient credited');
-        assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore - releaseAmount, 'record residual');
+        assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore, 'record unchanged (proof-of-mint permanent)');
     }
 
     function test_operationIdPreemptionBlocksVictimRgbDeposit_currentBehavior() public {

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -282,15 +282,17 @@ contract IntegrationTest is Test {
 
         // -------------------------------------------------------------------------
         // 3. TEE-signed fundsOut — RGBVerifier checks the BtcRelay header, the
-        //    settlement module consumes the recorded deposit, Bridge releases
-        //    `netBridgedIn` from the pool. 1% outbound commission to CM, the
-        //    rest to recipient.
+        //    settlement module verifies the referenced mint exists for the exact
+        //    amount (no consumption), Bridge releases `netBridgedIn` from the
+        //    pool. 1% outbound commission to CM, the rest to recipient.
         // -------------------------------------------------------------------------
-        uint256[] memory fundsInIds = new uint256[](1);
-        fundsInIds[0] = TX_ID_IN;
+        uint256[] memory fundsInIds     = new uint256[](1);
+        fundsInIds[0]     = TX_ID_IN;
+        uint256[] memory fundsInAmounts = new uint256[](1);
+        fundsInAmounts[0] = netBridgedIn;   // must equal the recorded mint amount
 
         bytes memory proof          = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
-        bytes memory settlementData = abi.encode(fundsInIds);
+        bytes memory settlementData = abi.encode(fundsInIds, fundsInAmounts);
 
         IBridge.FundsOutParams memory params = IBridge.FundsOutParams(
             recipient,
@@ -331,7 +333,7 @@ contract IntegrationTest is Test {
         assertEq(token.balanceOf(recipient),             netOut,                                 'recipient got net');
         assertEq(token.balanceOf(address(cm)),           tokenCommissionIn + tokenCommissionOut, 'cm accrued both fees');
         assertEq(cm.tokenCommissionPool(address(token)), tokenCommissionIn + tokenCommissionOut, 'cm pool mirrors');
-        assertEq(rgbModule.fundsInRecords(TX_ID_IN),     0,                                      'fundsIn record consumed');
+        assertEq(rgbModule.fundsInRecords(TX_ID_IN),     netBridgedIn,                           'fundsIn record unchanged (permanent)');
         assertTrue(bridge.consumedBurnIds(BURN_ID),                                              'burnId recorded');
 
         // -------------------------------------------------------------------------

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -279,6 +279,20 @@ contract MultisigProxyTest is Test {
         ids[0] = TX_ID;
     }
 
+    /// @dev Build `settlementData` for the reworked RgbSettlementModule, which
+    ///      expects `(uint256[] operationIds, uint256[] amounts)` and checks
+    ///      each id exists with an EXACTLY matching amount (no consumption).
+    ///      The amount is derived from the on-chain mint record so an exact
+    ///      match is guaranteed for the common path; ids with no record resolve
+    ///      to amount 0 (the module then reverts FundsInNotFound first).
+    function _settlement(uint256[] memory ids) internal view returns (bytes memory) {
+        uint256[] memory amounts = new uint256[](ids.length);
+        for (uint256 i = 0; i < ids.length; i++) {
+            amounts[i] = rgbModule.fundsInRecords(ids[i]);
+        }
+        return abi.encode(ids, amounts);
+    }
+
     /// @dev Valid strict-majority signer sets (2-of-2) used as filler in
     ///      constructor-revert tests that target a non-threshold revert.
     function _validEnc() internal view returns (address[] memory a) {
@@ -311,7 +325,7 @@ contract MultisigProxyTest is Test {
             destinationChainId: SOURCE_CHAIN_ID,
             sourceAddress:      SRC_ADDR,
             proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH),
-            settlementData:     abi.encode(_fundsInIds())
+            settlementData:     _settlement(_fundsInIds())
         });
     }
 
@@ -330,7 +344,7 @@ contract MultisigProxyTest is Test {
             destinationChainId: SOURCE_CHAIN_ID,
             sourceAddress:      SRC_ADDR,
             proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH),
-            settlementData:     abi.encode(ids),
+            settlementData:     _settlement(ids),
             dstEid:             DST_EID,
             recipient:          LZ_RECIPIENT,
             minAmountLD:        0,
@@ -1881,7 +1895,7 @@ contract MultisigProxyTest is Test {
             'cm pool delta'
         );
         assertEq(cm.nativeCommissionPool(),        nativePoolBefore,             'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore - AMOUNT,        'record consumed');
+        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore,                 'record unchanged (proof-of-mint permanent)');
 
         // The signed Bridge gross debit splits into recipient net payout and CM token commission.
         assertEq(
@@ -1973,7 +1987,7 @@ contract MultisigProxyTest is Test {
         assertEq(token.balanceOf(address(bridge)),  bridgeBefore - AMOUNT,          'bridge gross debit');
         assertEq(token.balanceOf(address(cm)),      cmBefore + tokenCommission,     'cm fee delta');
         assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore + tokenCommission, 'cm pool delta');
-        assertEq(rgbModule.fundsInRecords(TX_ID),   recordBefore - AMOUNT,          'record consumed');
+        assertEq(rgbModule.fundsInRecords(TX_ID),   recordBefore,                   'record unchanged (proof-of-mint permanent)');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,                  'adapter no residue');
         assertEq(token.balanceOf(mockOft),          oftBefore + netAmount,          'oft receives net');
         assertEq(address(proxy).balance,            proxyEthBefore,                 'proxy native no residue');
@@ -2176,8 +2190,10 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 hours;
         (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
 
-        // The duplicate id is only safe in this shape because the first entry is
-        // partially consumed and the settlement loop breaks before reading it again.
+        // Duplicate ids are harmless under the reworked module: the check is a
+        // pure read, so referencing the same id twice with its (correct) amount
+        // simply passes both times. Solvency is the Bridge's concern, not the
+        // module's.
         uint256 bridgeBefore     = token.balanceOf(address(bridge));
         uint256 adapterBefore    = token.balanceOf(address(adapter));
         uint256 oftBefore        = token.balanceOf(mockOft);
@@ -2195,7 +2211,7 @@ contract MultisigProxyTest is Test {
         assertEq(cmBefore,         0,          'pre cm token');
         assertEq(cmPoolBefore,     0,          'pre cm pool');
         assertEq(nativePoolBefore, 0,          'pre native pool');
-        assertEq(recordBefore,     AMOUNT * 5, 'pre record allows partial consume');
+        assertEq(recordBefore,     AMOUNT * 5, 'pre record');
         assertEq(adapter.sendOutCalls(), 0,    'pre adapter calls');
         assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
 
@@ -2229,14 +2245,14 @@ contract MultisigProxyTest is Test {
         assertEq(token.balanceOf(address(cm)),      cmBefore + tokenCommission, 'cm token delta');
         assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore + tokenCommission, 'cm pool delta');
         assertEq(cm.nativeCommissionPool(),         nativePoolBefore,  'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID),   recordBefore - AMOUNT, 'record consumed once');
+        assertEq(rgbModule.fundsInRecords(TX_ID),   recordBefore, 'record unchanged (proof-of-mint permanent)');
         assertEq(address(proxy).balance,            proxyEthBefore,  'proxy native unchanged');
         assertEq(address(adapter).balance,          adapterEthBefore, 'adapter native unchanged');
         assertEq(mockOft.balance,                   oftEthBefore + LZ_NATIVE_FEE, 'oft native fee');
     }
 
-    // Flow-4 success coverage for duplicate RGB settlement ids when the first
-    // occurrence fully satisfies the Bridge fundsOut amount.
+    // Flow-4 success coverage for duplicate RGB settlement ids: the reworked
+    // module verifies each (id, amount) pair by pure read, so duplicates pass.
     function test_lzFundsOutCall_duplicateSettlementIdsFullConsume_succeedsAndIgnoresDuplicate() public {
         uint256 duplicateRecordId = TX_ID + 1;
         uint256 burnId = BURN_ID + 1;
@@ -2278,8 +2294,8 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 hours;
         (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
 
-        // Exact full consumption triggers the module's remaining == 0 break.
-        // Without that break, the duplicate id would be read after delete.
+        // The reworked module never consumes records, so a duplicated id is just
+        // verified twice against the same (intact) record and passes.
         uint256 bridgeBefore     = token.balanceOf(address(bridge));
         uint256 adapterBefore    = token.balanceOf(address(adapter));
         uint256 oftBefore        = token.balanceOf(mockOft);
@@ -2331,7 +2347,7 @@ contract MultisigProxyTest is Test {
         assertEq(token.balanceOf(address(cm)),      cmBefore + tokenCommission, 'cm token delta');
         assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore + tokenCommission, 'cm pool delta');
         assertEq(rgbModule.fundsInRecords(TX_ID),   originalRecordBefore, 'original record untouched');
-        assertEq(rgbModule.fundsInRecords(duplicateRecordId), 0,     'duplicate record consumed once');
+        assertEq(rgbModule.fundsInRecords(duplicateRecordId), duplicateRecordBefore, 'duplicate record unchanged');
         assertEq(address(proxy).balance,            proxyEthBefore,  'proxy native unchanged');
         assertEq(address(adapter).balance,          adapterEthBefore, 'adapter native unchanged');
         assertEq(mockOft.balance,                   oftEthBefore + LZ_NATIVE_FEE, 'oft native fee');
@@ -2484,7 +2500,7 @@ contract MultisigProxyTest is Test {
         assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)), 0, 'bridge pool drained');
         assertEq(token.balanceOf(drainRecipient), recipientBefore + bridgeBefore, 'recipient got full pool');
-        assertEq(rgbModule.fundsInRecords(TX_ID), 0, 'record fully consumed');
+        assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore, 'record unchanged (proof-of-mint permanent)');
     }
 
     function test_governanceCanRotateEnclaveToUnattestedEOA_currentBehavior() public {

--- a/ethereum/test/OutflowRateLimiter.t.sol
+++ b/ethereum/test/OutflowRateLimiter.t.sol
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import { Test }                       from 'forge-std/Test.sol';
+import { Vm }                         from 'forge-std/Vm.sol';
+import { OutflowRateLimiter }         from '../src/libraries/OutflowRateLimiter.sol';
+import { OutflowRateLimiterHarness }  from './mocks/OutflowRateLimiterHarness.sol';
+
+/// @title OutflowRateLimiterTest
+/// @notice Standalone unit tests for the `OutflowRateLimiter` token-bucket
+///         library, driven through `OutflowRateLimiterHarness` — no `Bridge`.
+///
+/// @dev    Bridge integration tests prove the limiter is wired correctly; these
+///         tests prove the library's own arithmetic in isolation: refill
+///         accrual, capacity clamping, throttle `retryAfter`, the config
+///         validation rules, and the defensive narrowing/stored-state guards.
+contract OutflowRateLimiterTest is Test {
+    OutflowRateLimiterHarness harness;
+
+    address constant TOKEN     = address(0xBEEF);
+    address constant AGGREGATE = address(0); // sentinel selecting aggregate-scope errors
+
+    uint128 constant CAP  = 1_000;
+    uint128 constant RATE = 10;
+
+    function setUp() public {
+        harness = new OutflowRateLimiterHarness();
+        // Start at a non-zero timestamp so `lastUpdated` casts are meaningful.
+        vm.warp(1_000_000);
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    function _enabled(uint128 capacity, uint128 rate)
+        internal
+        pure
+        returns (OutflowRateLimiter.Settings memory)
+    {
+        return OutflowRateLimiter.Settings({ isEnabled: true, capacity: capacity, rate: rate });
+    }
+
+    function _disabled() internal pure returns (OutflowRateLimiter.Settings memory) {
+        return OutflowRateLimiter.Settings({ isEnabled: false, capacity: 0, rate: 0 });
+    }
+
+    function _prime(uint128 capacity, uint128 rate) internal {
+        harness.configurePrimed(_enabled(capacity, rate));
+    }
+
+    // =========================================================================
+    // validate
+    // =========================================================================
+
+    function test_validate_enabled_validConfig_passes() public view {
+        harness.validate(_enabled(CAP, RATE), false); // no revert
+    }
+
+    function test_validate_enabled_zeroCapacity_reverts() public {
+        OutflowRateLimiter.Settings memory s = _enabled(0, RATE);
+        vm.expectRevert(abi.encodeWithSelector(OutflowRateLimiter.InvalidLimitConfig.selector, s));
+        harness.validate(s, false);
+    }
+
+    function test_validate_enabled_zeroRate_reverts() public {
+        OutflowRateLimiter.Settings memory s = _enabled(CAP, 0);
+        vm.expectRevert(abi.encodeWithSelector(OutflowRateLimiter.InvalidLimitConfig.selector, s));
+        harness.validate(s, false);
+    }
+
+    function test_validate_enabled_rateGteCapacity_reverts() public {
+        OutflowRateLimiter.Settings memory s = _enabled(CAP, CAP); // rate >= capacity
+        vm.expectRevert(abi.encodeWithSelector(OutflowRateLimiter.InvalidLimitConfig.selector, s));
+        harness.validate(s, false);
+    }
+
+    function test_validate_disabled_clean_passes() public view {
+        harness.validate(_disabled(), false); // no revert
+    }
+
+    /// @dev Covers `DisabledLimitHasValues`: disabled flag but non-zero fields.
+    function test_validate_disabled_withValues_reverts() public {
+        OutflowRateLimiter.Settings memory s =
+            OutflowRateLimiter.Settings({ isEnabled: false, capacity: 5, rate: 0 });
+        vm.expectRevert(abi.encodeWithSelector(OutflowRateLimiter.DisabledLimitHasValues.selector, s));
+        harness.validate(s, false);
+    }
+
+    /// @dev Covers `LimitMustStayDisabled`: `mustBeDisabled` set while enabled.
+    function test_validate_mustBeDisabled_butEnabled_reverts() public {
+        vm.expectRevert(OutflowRateLimiter.LimitMustStayDisabled.selector);
+        harness.validate(_enabled(CAP, RATE), true);
+    }
+
+    function test_validate_mustBeDisabled_andDisabled_passes() public view {
+        harness.validate(_disabled(), true); // no revert
+    }
+
+    // =========================================================================
+    // configurePrimed / configure
+    // =========================================================================
+
+    function test_configurePrimed_firstEnable_fillsToCapacity() public {
+        _prime(CAP, RATE);
+        assertEq(harness.read().tokens, CAP, 'first enable should fill to capacity');
+        assertTrue(harness.read().isEnabled);
+    }
+
+    /// @dev Re-priming an already-enabled bucket must NOT refill to capacity.
+    function test_configurePrimed_alreadyEnabled_doesNotRefill() public {
+        _prime(CAP, RATE);
+        harness.spend(400, TOKEN); // tokens -> 600
+        harness.configurePrimed(_enabled(CAP, RATE)); // already enabled -> no refill
+        assertEq(harness.read().tokens, 600, 'second prime must carry over, not refill');
+    }
+
+    /// @dev Lowering capacity clamps carried allowance (covers the `_min` clamp).
+    function test_configure_clampsCarriedAllowanceToNewCapacity() public {
+        _prime(CAP, RATE);
+        harness.spend(400, TOKEN); // tokens -> 600
+        harness.configure(_enabled(500, RATE)); // new cap 500 < carried 600
+        assertEq(harness.read().tokens, 500, 'carried allowance clamped to new capacity');
+        assertEq(harness.read().capacity, 500);
+    }
+
+    /// @dev Raising capacity keeps carried allowance unchanged (other `_min` arm).
+    function test_configure_keepsCarriedWhenBelowNewCapacity() public {
+        _prime(CAP, RATE);
+        harness.spend(400, TOKEN); // tokens -> 600
+        harness.configure(_enabled(2_000, RATE)); // new cap 2000 > carried 600
+        assertEq(harness.read().tokens, 600, 'carried allowance preserved below new capacity');
+        assertEq(harness.read().capacity, 2_000);
+    }
+
+    function test_configure_emitsSettingsChanged() public {
+        OutflowRateLimiter.Settings memory s = _enabled(CAP, RATE);
+        vm.expectEmit(false, false, false, true, address(harness));
+        emit OutflowRateLimiter.LimitSettingsChanged(s);
+        harness.configure(s);
+    }
+
+    // =========================================================================
+    // spend — guards
+    // =========================================================================
+
+    function test_spend_disabledBucket_reverts() public {
+        vm.expectRevert(OutflowRateLimiter.LimitNotConfigured.selector);
+        harness.spend(1, TOKEN);
+    }
+
+    /// @dev Covers the `amount == 0` early return: no state change, no event.
+    function test_spend_zeroAmount_isNoop() public {
+        _prime(CAP, RATE);
+        uint32 lastUpdatedBefore = harness.read().lastUpdated;
+
+        vm.recordLogs();
+        harness.spend(0, TOKEN);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, 'zero-amount spend must emit nothing');
+        assertEq(harness.read().tokens, CAP, 'tokens unchanged');
+        assertEq(harness.read().lastUpdated, lastUpdatedBefore, 'lastUpdated unchanged');
+    }
+
+    function test_spend_amountAboveCapacity_token_reverts() public {
+        _prime(CAP, RATE);
+        vm.expectRevert(
+            abi.encodeWithSelector(OutflowRateLimiter.TokenRequestAboveCapacity.selector, CAP, CAP + 1, TOKEN)
+        );
+        harness.spend(CAP + 1, TOKEN);
+    }
+
+    /// @dev Covers the aggregate-scope (`token == address(0)`) above-capacity arm.
+    function test_spend_amountAboveCapacity_aggregate_reverts() public {
+        _prime(CAP, RATE);
+        vm.expectRevert(
+            abi.encodeWithSelector(OutflowRateLimiter.AggregateRequestAboveCapacity.selector, CAP, CAP + 1)
+        );
+        harness.spend(CAP + 1, AGGREGATE);
+    }
+
+    function test_spend_throttled_token_reportsRetryAfter() public {
+        _prime(CAP, RATE);
+        harness.spend(400, TOKEN); // available -> 600, same block (no refill)
+
+        // request 800 > available 600; retryAfter = ceil((800-600)/10) = 20
+        vm.expectRevert(
+            abi.encodeWithSelector(OutflowRateLimiter.TokenOutflowThrottled.selector, 20, 600, TOKEN)
+        );
+        harness.spend(800, TOKEN);
+    }
+
+    function test_spend_throttled_aggregate_reportsRetryAfter() public {
+        _prime(CAP, RATE);
+        harness.spend(400, AGGREGATE); // available -> 600
+
+        vm.expectRevert(
+            abi.encodeWithSelector(OutflowRateLimiter.AggregateOutflowThrottled.selector, 20, 600)
+        );
+        harness.spend(800, AGGREGATE);
+    }
+
+    // =========================================================================
+    // spend — happy path & refill
+    // =========================================================================
+
+    function test_spend_happyPath_debitsAndEmits() public {
+        _prime(CAP, RATE);
+
+        vm.expectEmit(false, false, false, true, address(harness));
+        emit OutflowRateLimiter.AllowanceSpent(400);
+        harness.spend(400, TOKEN);
+
+        assertEq(harness.read().tokens, 600, 'debited');
+        assertEq(harness.read().lastUpdated, uint32(block.timestamp), 'timestamp persisted');
+    }
+
+    /// @dev Partial refill: available grows by `elapsed * rate` below capacity.
+    function test_spend_usesPartialRefill() public {
+        _prime(CAP, RATE);
+        harness.spend(CAP, TOKEN); // drain to 0
+        assertEq(harness.read().tokens, 0);
+
+        vm.warp(block.timestamp + 50); // +50s -> +500 available (still < capacity)
+        harness.spend(500, TOKEN);     // exactly the refilled amount
+        assertEq(harness.read().tokens, 0, 'spent all refilled allowance');
+    }
+
+    /// @dev Refill caps at capacity once enough time elapses.
+    function test_refill_capsAtCapacity() public {
+        _prime(CAP, RATE);
+        harness.spend(CAP, TOKEN); // drain to 0
+
+        vm.warp(block.timestamp + 10_000); // far beyond full-refill horizon
+        assertEq(harness.currentState().tokens, CAP, 'refill must cap at capacity');
+        harness.spend(CAP, TOKEN); // a full-capacity spend now succeeds
+        assertEq(harness.read().tokens, 0);
+    }
+
+    // =========================================================================
+    // currentState / _preview
+    // =========================================================================
+
+    /// @dev `currentState` returns the refill-adjusted view WITHOUT persisting,
+    ///      and exercises the explicit `return` of the view helper.
+    function test_currentState_returnsPreviewWithoutPersisting() public {
+        _prime(CAP, RATE);
+        harness.spend(400, TOKEN); // tokens -> 600
+        uint32 persistedTs = harness.read().lastUpdated;
+
+        vm.warp(block.timestamp + 5); // +5s -> +50 available
+        OutflowRateLimiter.Bucket memory preview = harness.currentState();
+
+        assertEq(preview.tokens, 650, 'preview reflects accrued refill');
+        assertEq(preview.lastUpdated, uint32(block.timestamp), 'preview stamps now');
+        // storage is untouched by the view call
+        assertEq(harness.read().tokens, 600, 'storage tokens not mutated');
+        assertEq(harness.read().lastUpdated, persistedTs, 'storage timestamp not mutated');
+    }
+
+    function test_preview_elapsedZero_returnsAvailable() public {
+        _prime(CAP, RATE);
+        harness.spend(400, TOKEN); // tokens -> 600, same block
+        assertEq(harness.currentState().tokens, 600, 'no elapsed time -> no refill');
+    }
+
+    function test_preview_atCapacity_noRefill() public {
+        _prime(CAP, RATE); // full at capacity
+        vm.warp(block.timestamp + 100);
+        assertEq(harness.currentState().tokens, CAP, 'already full stays at capacity');
+    }
+
+    /// @dev Covers `StoredAllowanceAboveCapacity`: a persisted allowance above
+    ///      capacity (only constructable via raw setup) must revert on read.
+    function test_preview_storedAllowanceAboveCapacity_reverts() public {
+        harness.setRaw(2_000, uint32(block.timestamp), true, CAP, RATE); // tokens 2000 > cap 1000
+        vm.expectRevert(
+            abi.encodeWithSelector(OutflowRateLimiter.StoredAllowanceAboveCapacity.selector, 2_000, CAP)
+        );
+        harness.currentState();
+    }
+
+    // =========================================================================
+    // _asUint128 narrowing guard
+    // =========================================================================
+
+    function test_asUint128_atMax_passes() public view {
+        assertEq(harness.asUint128(uint256(type(uint128).max)), type(uint128).max);
+    }
+
+    /// @dev Covers the defensive `AmountExceedsUint128` guard. Unreachable via
+    ///      the public API (all inputs are `uint128`-bounded); driven directly.
+    function test_asUint128_aboveMax_reverts() public {
+        uint256 tooBig = uint256(type(uint128).max) + 1;
+        vm.expectRevert(abi.encodeWithSelector(OutflowRateLimiter.AmountExceedsUint128.selector, tooBig));
+        harness.asUint128(tooBig);
+    }
+
+    // =========================================================================
+    // fuzz invariants
+    // =========================================================================
+
+    /// @dev A successful spend never pushes stored tokens above capacity and
+    ///      never debits more than was available.
+    function testFuzz_spend_withinBounds(uint128 capacity, uint128 rate, uint256 amount) public {
+        capacity = uint128(bound(capacity, 2, type(uint128).max));
+        rate     = uint128(bound(rate, 1, capacity - 1)); // satisfy validate(): 0 < rate < capacity
+        amount   = bound(amount, 1, capacity);            // within capacity so it cannot exceed-capacity revert
+
+        _prime(capacity, rate); // primed full -> available == capacity >= amount
+        harness.spend(amount, TOKEN);
+
+        OutflowRateLimiter.Bucket memory b = harness.read();
+        assertLe(b.tokens, capacity, 'tokens never exceed capacity');
+        assertEq(b.tokens, capacity - uint128(amount), 'debit is exact');
+    }
+
+    /// @dev Refill is monotonic in elapsed time and clamps at capacity.
+    function testFuzz_refill_monotonicAndCapped(uint32 elapsed) public {
+        _prime(CAP, RATE);
+        harness.spend(CAP, TOKEN); // drain to 0
+        uint256 ts = block.timestamp;
+        vm.warp(ts + uint256(elapsed));
+
+        uint256 available = harness.currentState().tokens;
+        assertLe(available, CAP, 'refill capped at capacity');
+        // expected = min(elapsed * rate, capacity)
+        uint256 expected = uint256(elapsed) * RATE;
+        if (expected > CAP) expected = CAP;
+        assertEq(available, expected, 'refill equals elapsed * rate, capped');
+    }
+}

--- a/ethereum/test/RgbSettlementModule.t.sol
+++ b/ethereum/test/RgbSettlementModule.t.sol
@@ -7,7 +7,15 @@ import { FundsInContext, FundsOutContext } from '../src/interfaces/RouteTypes.so
 
 /// @title RgbSettlementModuleTest
 /// @notice Unit tests for the standalone settlement module. The module is
-///         driven via `vm.prank(routeRegistry)` — no actual `RouteRegistry`
+///         driven via `vm.prank(routeRegistry)` — no actual `RouteRegistry`.
+///
+/// @dev    Release semantics under test (post R-C-01 rework): `beforeFundsOut`
+///         is a pure (view) proof-of-mint check. It decodes
+///         `(uint256[] operationIds, uint256[] amounts)` and asserts every id
+///         EXISTS in `fundsInRecords` with an EXACTLY matching amount. It does
+///         NOT consume/delete records, does NOT sum them, and does NOT compare
+///         against `ctx.amount` — solvency and replay are owned by the Bridge
+///         (`lockedLiquidity` / `consumedBurnIds`).
 contract RgbSettlementModuleTest is Test {
     RgbSettlementModule module;
 
@@ -52,11 +60,14 @@ contract RgbSettlementModuleTest is Test {
         });
     }
 
-    function _fundsOutCtx(uint256 amount) internal view returns (FundsOutContext memory) {
+    /// @dev `ctx.amount` is irrelevant to the reworked module — it never
+    ///      compares the release amount against the mint records. We still
+    ///      supply a context so the signature matches.
+    function _fundsOutCtx() internal view returns (FundsOutContext memory) {
         return FundsOutContext({
             token:         token,
             recipient:     recipient,
-            amount:        amount,
+            amount:        AMOUNT,
             burnId:        BURN_ID,
             sourceChainId: SOURCE_CHAIN_ID,
             destChainId:   DEST_CHAIN_ID,
@@ -64,13 +75,24 @@ contract RgbSettlementModuleTest is Test {
         });
     }
 
-    function _settlementData(uint256[] memory ids) internal pure returns (bytes memory) {
-        return abi.encode(ids);
+    /// @dev Encodes the two parallel arrays the reworked module expects.
+    function _settlementData(uint256[] memory ids, uint256[] memory amounts)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(ids, amounts);
     }
 
-    function _single(uint256 id) internal pure returns (uint256[] memory ids) {
-        ids = new uint256[](1);
-        ids[0] = id;
+    function _single(uint256 value) internal pure returns (uint256[] memory arr) {
+        arr = new uint256[](1);
+        arr[0] = value;
+    }
+
+    function _pair(uint256 a, uint256 b) internal pure returns (uint256[] memory arr) {
+        arr = new uint256[](2);
+        arr[0] = a;
+        arr[1] = b;
     }
 
     function _record(uint256 operationId, uint256 netAmount) internal {
@@ -115,87 +137,69 @@ contract RgbSettlementModuleTest is Test {
     }
 
     // ========================================================================
-    // beforeFundsOut — happy paths
+    // beforeFundsOut — happy paths (existence + exact-amount, no consumption)
     // ========================================================================
 
-    function test_beforeFundsOut_consumesFullSingleRecord() public {
+    function test_beforeFundsOut_passesOnSingleExactMatch() public {
         _record(TX_ID_1, AMOUNT);
 
         vm.prank(routeRegistry);
-        module.beforeFundsOut(_fundsOutCtx(AMOUNT), _settlementData(_single(TX_ID_1)));
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT)));
 
-        assertEq(module.fundsInRecords(TX_ID_1), 0, 'record fully consumed');
+        // Proof-of-mint ledger is permanent: the check must not mutate it.
+        assertEq(module.fundsInRecords(TX_ID_1), AMOUNT, 'record left intact (no consumption)');
     }
 
-    function test_beforeFundsOut_consumesSequentiallyMultipleIds() public {
+    function test_beforeFundsOut_passesOnMultipleExactMatches() public {
         uint256 amount1 = 60e18;
         uint256 amount2 = 40e18;
         _record(TX_ID_1, amount1);
         _record(TX_ID_2, amount2);
 
-        uint256[] memory ids = new uint256[](2);
-        ids[0] = TX_ID_1;
-        ids[1] = TX_ID_2;
-
         vm.prank(routeRegistry);
-        module.beforeFundsOut(_fundsOutCtx(amount1 + amount2), _settlementData(ids));
+        module.beforeFundsOut(
+            _fundsOutCtx(),
+            _settlementData(_pair(TX_ID_1, TX_ID_2), _pair(amount1, amount2))
+        );
 
-        assertEq(module.fundsInRecords(TX_ID_1), 0);
-        assertEq(module.fundsInRecords(TX_ID_2), 0);
+        assertEq(module.fundsInRecords(TX_ID_1), amount1, 'record 1 intact');
+        assertEq(module.fundsInRecords(TX_ID_2), amount2, 'record 2 intact');
     }
 
-    function test_beforeFundsOut_partialConsume_preservesResidual() public {
+    function test_beforeFundsOut_passesOnEmptyArrays() public {
+        // Degenerate input: nothing to verify, nothing to revert on.
+        vm.prank(routeRegistry);
+        module.beforeFundsOut(
+            _fundsOutCtx(),
+            _settlementData(new uint256[](0), new uint256[](0))
+        );
+    }
+
+    function test_beforeFundsOut_duplicateIdsAreHarmless() public {
+        // The check is a pure read, so referencing the same id twice with the
+        // same (correct) amount simply passes both times — no double-spend
+        // here; solvency is the Bridge's concern.
         _record(TX_ID_1, AMOUNT);
-        uint256 partialAmount = 60e18;
 
         vm.prank(routeRegistry);
         module.beforeFundsOut(
-            _fundsOutCtx(partialAmount),
-            _settlementData(_single(TX_ID_1))
+            _fundsOutCtx(),
+            _settlementData(_pair(TX_ID_1, TX_ID_1), _pair(AMOUNT, AMOUNT))
         );
 
-        assertEq(
-            module.fundsInRecords(TX_ID_1),
-            AMOUNT - partialAmount,
-            'residual preserved on same operationId'
-        );
+        assertEq(module.fundsInRecords(TX_ID_1), AMOUNT, 'record intact');
     }
 
-    function test_beforeFundsOut_consumesPartiallyAcrossIds() public {
-        // Two records of 100 each. fundsOut for 150 fully consumes the
-        // first and partially consumes the second (leaving 50).
+    function test_beforeFundsOut_isViewAcrossManyCalls() public {
+        // Repeated verification of the same record never depletes it.
         _record(TX_ID_1, AMOUNT);
-        _record(TX_ID_2, AMOUNT);
 
-        uint256[] memory ids = new uint256[](2);
-        ids[0] = TX_ID_1;
-        ids[1] = TX_ID_2;
+        for (uint256 i = 0; i < 3; i++) {
+            vm.prank(routeRegistry);
+            module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT)));
+        }
 
-        vm.prank(routeRegistry);
-        module.beforeFundsOut(_fundsOutCtx(150e18), _settlementData(ids));
-
-        assertEq(module.fundsInRecords(TX_ID_1), 0,    'first fully consumed');
-        assertEq(module.fundsInRecords(TX_ID_2), 50e18, 'second partially consumed');
-    }
-
-    function test_beforeFundsOut_breaksAfterAmountSatisfied() public {
-        // Three records, but the request is satisfied by the first one. The
-        // remaining two records must remain untouched (loop early-terminates).
-        _record(TX_ID_1, AMOUNT);
-        _record(TX_ID_2, AMOUNT);
-        _record(TX_ID_3, AMOUNT);
-
-        uint256[] memory ids = new uint256[](3);
-        ids[0] = TX_ID_1;
-        ids[1] = TX_ID_2;
-        ids[2] = TX_ID_3;
-
-        vm.prank(routeRegistry);
-        module.beforeFundsOut(_fundsOutCtx(AMOUNT), _settlementData(ids));
-
-        assertEq(module.fundsInRecords(TX_ID_1), 0);
-        assertEq(module.fundsInRecords(TX_ID_2), AMOUNT, 'second untouched');
-        assertEq(module.fundsInRecords(TX_ID_3), AMOUNT, 'third untouched');
+        assertEq(module.fundsInRecords(TX_ID_1), AMOUNT, 'record never consumed');
     }
 
     // ========================================================================
@@ -208,34 +212,62 @@ contract RgbSettlementModuleTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, TX_ID_1)
         );
-        module.beforeFundsOut(_fundsOutCtx(AMOUNT), _settlementData(_single(TX_ID_1)));
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT)));
     }
 
-    function test_beforeFundsOut_revertsOnAmountExceedsFundsIn() public {
+    function test_beforeFundsOut_revertsWhenAmountAboveRecord() public {
         _record(TX_ID_1, AMOUNT);
 
-        vm.prank(routeRegistry);
-        vm.expectRevert(RgbSettlementModule.FundsOutAmountExceedsFundsIn.selector);
-        module.beforeFundsOut(
-            _fundsOutCtx(AMOUNT + 1),
-            _settlementData(_single(TX_ID_1))
-        );
-    }
-
-    function test_beforeFundsOut_revertsOnDoubleSpendConsumedRecord() public {
-        // Record + fully consume + try to consume the same id again.
-        _record(TX_ID_1, AMOUNT);
-
-        vm.prank(routeRegistry);
-        module.beforeFundsOut(_fundsOutCtx(AMOUNT), _settlementData(_single(TX_ID_1)));
-
-        // Second redemption against the same id reverts with FundsInNotFound
-        // (slot is back to 0 after `delete`).
         vm.prank(routeRegistry);
         vm.expectRevert(
-            abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, TX_ID_1)
+            abi.encodeWithSelector(
+                RgbSettlementModule.AmountMismatch.selector, TX_ID_1, AMOUNT + 1, AMOUNT
+            )
         );
-        module.beforeFundsOut(_fundsOutCtx(AMOUNT), _settlementData(_single(TX_ID_1)));
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT + 1)));
+    }
+
+    function test_beforeFundsOut_revertsWhenAmountBelowRecord() public {
+        // RGB binds an operationId to an EXACT mint amount, so even an
+        // under-claim is rejected — the supplied amount must equal the record.
+        _record(TX_ID_1, AMOUNT);
+
+        vm.prank(routeRegistry);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RgbSettlementModule.AmountMismatch.selector, TX_ID_1, AMOUNT - 1, AMOUNT
+            )
+        );
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT - 1)));
+    }
+
+    function test_beforeFundsOut_revertsOnLengthMismatch() public {
+        _record(TX_ID_1, AMOUNT);
+
+        // Two ids but one amount.
+        vm.prank(routeRegistry);
+        vm.expectRevert(RgbSettlementModule.SettlementDataLengthMismatch.selector);
+        module.beforeFundsOut(
+            _fundsOutCtx(),
+            _settlementData(_pair(TX_ID_1, TX_ID_2), _single(AMOUNT))
+        );
+    }
+
+    function test_beforeFundsOut_revertsOnSecondIdMismatch() public {
+        // First id matches, second does not — the loop must still catch it.
+        _record(TX_ID_1, AMOUNT);
+        _record(TX_ID_2, AMOUNT);
+
+        vm.prank(routeRegistry);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RgbSettlementModule.AmountMismatch.selector, TX_ID_2, AMOUNT + 5, AMOUNT
+            )
+        );
+        module.beforeFundsOut(
+            _fundsOutCtx(),
+            _settlementData(_pair(TX_ID_1, TX_ID_2), _pair(AMOUNT, AMOUNT + 5))
+        );
     }
 
     function test_beforeFundsOut_revertsIfNotRouteRegistry() public {
@@ -243,25 +275,33 @@ contract RgbSettlementModuleTest is Test {
 
         vm.prank(attacker);
         vm.expectRevert(RgbSettlementModule.NotRouteRegistry.selector);
-        module.beforeFundsOut(_fundsOutCtx(AMOUNT), _settlementData(_single(TX_ID_1)));
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT)));
     }
 
-    function test_beforeFundsOut_duplicateIdsFullyConsumedReverts() public {
-        _record(TX_ID_1, AMOUNT);
+    // ========================================================================
+    // beforeFundsOut — fuzz
+    // ========================================================================
 
-        uint256[] memory ids = new uint256[](2);
-        ids[0] = TX_ID_1;
-        ids[1] = TX_ID_1;
+    /// @dev Any amount that differs from the record must revert; the exact
+    ///      record amount must pass. Record is never mutated either way.
+    function testFuzz_beforeFundsOut_exactMatchOnly(uint256 recorded, uint256 provided) public {
+        recorded = bound(recorded, 1, type(uint128).max);
+        provided = bound(provided, 0, type(uint128).max);
+        _record(TX_ID_1, recorded);
 
-        // The first entry fully consumes and deletes the record. The duplicate
-        // entry must not count the same record again.
-        vm.prank(routeRegistry);
-        vm.expectRevert(
-            abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, TX_ID_1)
-        );
-        // +1 forces a second loop iteration; exact AMOUNT would break before the duplicate is read.
-        module.beforeFundsOut(_fundsOutCtx(AMOUNT + 1), _settlementData(ids));
+        if (provided == recorded) {
+            vm.prank(routeRegistry);
+            module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(provided)));
+        } else {
+            vm.prank(routeRegistry);
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    RgbSettlementModule.AmountMismatch.selector, TX_ID_1, provided, recorded
+                )
+            );
+            module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(provided)));
+        }
 
-        assertEq(module.fundsInRecords(TX_ID_1), AMOUNT, 'record restored on revert');
+        assertEq(module.fundsInRecords(TX_ID_1), recorded, 'record never mutated');
     }
 }

--- a/ethereum/test/mocks/OutflowRateLimiterHarness.sol
+++ b/ethereum/test/mocks/OutflowRateLimiterHarness.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import { OutflowRateLimiter } from '../../src/libraries/OutflowRateLimiter.sol';
+
+/// @title OutflowRateLimiterHarness
+/// @notice Thin external wrapper around the `OutflowRateLimiter` library so its
+///         `internal` functions can be unit-tested in isolation, without the
+///         `Bridge` contract.
+/// @dev    Holds a single `Bucket` in storage. Storage-mutating library calls
+///         (`spend` / `configure` / `configurePrimed`) act on it; `read`
+///         exposes the raw persisted state and `currentState` exposes the
+///         refill-adjusted view. `setRaw` lets tests construct otherwise
+///         unreachable states (e.g. a stored allowance above capacity) to drive
+///         the library's defensive branches.
+contract OutflowRateLimiterHarness {
+    using OutflowRateLimiter for OutflowRateLimiter.Bucket;
+
+    OutflowRateLimiter.Bucket internal bucket;
+
+    // ----- storage-mutating wrappers -----
+
+    function spend(uint256 amount, address token) external {
+        bucket.spend(amount, token);
+    }
+
+    function configure(OutflowRateLimiter.Settings memory settings) external {
+        bucket.configure(settings);
+    }
+
+    function configurePrimed(OutflowRateLimiter.Settings memory settings) external {
+        bucket.configurePrimed(settings);
+    }
+
+    // ----- view wrappers -----
+
+    function currentState() external view returns (OutflowRateLimiter.Bucket memory) {
+        return bucket.currentState();
+    }
+
+    function read() external view returns (OutflowRateLimiter.Bucket memory) {
+        return bucket;
+    }
+
+    // ----- pure wrappers -----
+
+    function validate(OutflowRateLimiter.Settings memory settings, bool mustBeDisabled) external pure {
+        OutflowRateLimiter.validate(settings, mustBeDisabled);
+    }
+
+    /// @dev Drives the `uint256 -> uint128` narrowing guard directly; this path
+    ///      is unreachable through the public API because all inputs are bounded
+    ///      by the `uint128` capacity/token fields.
+    function asUint128(uint256 value) external pure returns (uint128) {
+        return OutflowRateLimiter._asUint128(value);
+    }
+
+    // ----- test setup helper -----
+
+    function setRaw(
+        uint128 tokens,
+        uint32 lastUpdated,
+        bool isEnabled,
+        uint128 capacity,
+        uint128 rate
+    ) external {
+        bucket = OutflowRateLimiter.Bucket({
+            tokens: tokens,
+            lastUpdated: lastUpdated,
+            isEnabled: isEnabled,
+            capacity: capacity,
+            rate: rate
+        });
+    }
+}


### PR DESCRIPTION
## Summary
Test branch for the RgbSettlementModule beforeFundsOut rework (fix PR:
rgb-opid-amount-binding). beforeFundsOut is now a view proof-of-mint check
that decodes (uint256[] operationIds, uint256[] amounts) and asserts every
id exists in fundsInRecords with an exactly matching amount — no
consumption, no tie to fundsOut.amount. Solvency/replay remain owned by
Bridge.lockedLiquidity + consumedBurnIds.

## Changes
- RgbSettlementModule.t.sol fully rewritten: existence + exact-amount happy
  paths (records left intact), reverts for AmountMismatch (over/under),
  SettlementDataLengthMismatch, mid-array mismatch; empty-array, duplicate-id
  (harmless), repeated-call view stability; exact-match-only fuzz.
- Bridge / Integration / MultisigProxy: switched settlementData to the
  two-array encoding, replaced FundsOutAmountExceedsFundsIn assertions with
  AmountMismatch, and replaced all "record consumed/residual" assertions with
  "record unchanged" (permanent proof-of-mint ledger).
- Bridge settlement builders are pure (encode AMOUNT, or explicit amounts for
  seeded/fuzz/mismatch records) so they don't consume vm.prank/vm.expectRevert
  when passed inline.