### PR TITLE
fix(R-I-24): cap settlementData length on Bridge fundsIn and fundsOut

### DIFF
--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -57,6 +57,19 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     ///         inclusion proof stays well under this).
     uint256 public constant MAX_PROOF_LENGTH = 1024;
 
+    /// @notice Upper bound on the `settlementData` byte length on both the
+    ///         `fundsIn` and `fundsOut` paths. `settlementData` is forwarded to
+    ///         the route settlement module, which may decode and iterate it
+    ///         (e.g. `RgbSettlementModule.beforeFundsOut` walks the
+    ///         `(operationIds, amounts)` arrays it carries), so an unbounded blob
+    ///         would let that loop inflate until it exceeds the block gas limit
+    ///         and bricks the call. `settlementData` encodes as ~`128 + 64 * n`
+    ///         bytes for `n` records, so 4096 bytes admits ~62 records — ample
+    ///         headroom while keeping any settlement loop bounded. Enforced on
+    ///         `fundsIn` too as defence-in-depth: current inbound modules ignore
+    ///         `settlementData`, but a future module could iterate it.
+    uint256 public constant MAX_SETTLEMENT_DATA_LENGTH = 4096;
+
     /// @notice CommissionManager that receives and custodies protocol fees.
     ICommissionManager public immutable commissionManager;
 
@@ -276,6 +289,9 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             revert AddressTooLong(bytes(fundsOutParams.sourceAddress).length, MAX_ADDRESS_LENGTH);
         }
         if (fundsOutParams.proof.length > MAX_PROOF_LENGTH) revert ProofTooLong(fundsOutParams.proof.length, MAX_PROOF_LENGTH);
+        if (fundsOutParams.settlementData.length > MAX_SETTLEMENT_DATA_LENGTH) {
+            revert SettlementDataTooLong(fundsOutParams.settlementData.length, MAX_SETTLEMENT_DATA_LENGTH);
+        }
         if (fundsOutParams.amount > IERC20(TOKEN).balanceOf(address(this))) revert AmountExceedBridgePool();
 
         // Common replay guard. Set the flag before any external interaction
@@ -405,6 +421,9 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (bytes(destinationAddress).length == 0) revert InvalidDestinationAddress();
         if (bytes(destinationAddress).length > MAX_ADDRESS_LENGTH) {
             revert AddressTooLong(bytes(destinationAddress).length, MAX_ADDRESS_LENGTH);
+        }
+        if (settlementData.length > MAX_SETTLEMENT_DATA_LENGTH) {
+            revert SettlementDataTooLong(settlementData.length, MAX_SETTLEMENT_DATA_LENGTH);
         }
         if (sourceChainId      == 0)               revert InvalidSourceChainId();
         if (destinationChainId == 0)               revert InvalidDestinationChainId();

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -14,6 +14,7 @@ interface IBridge {
     error InvalidMinFundsInAmount();
     error AddressTooLong(uint256 length, uint256 maxLength);
     error ProofTooLong(uint256 length, uint256 maxLength);
+    error SettlementDataTooLong(uint256 length, uint256 maxLength);
     error InsufficientChainLiquidity(uint256 chainId, uint256 requested, uint256 available);    
     error InvalidOutflowLimit();
     error InvalidRouteRegistryAddress();


### PR DESCRIPTION
## Summary
Adds `MAX_SETTLEMENT_DATA_LENGTH = 4096` and error `SettlementDataTooLong`, and
rejects oversized `settlementData` on **both** `Bridge.fundsOut` and the
`_fundsIn` path, next to the existing `proof` / `sourceAddress` caps.

## Fix
`RgbSettlementModule.beforeFundsOut` decodes `settlementData` as
`(uint256[] operationIds, uint256[] amounts)` and loops over it with no length
bound. A redemption spanning very many records can exceed the block gas limit
and brick `fundsOut`. Not an external DoS (`fundsOut` is `onlyOwner`/TEE), but a
self-inflicted availability hazard.

## Scope
- `fundsOut`: primary fix (that's where the unbounded loop is today).
- `fundsIn`: same cap as defence-in-depth. Current inbound modules
  (`RgbSettlementModule`/`Null`) ignore `settlementData`, but a future module
  could iterate it — the cap keeps the invariant symmetric.
- No change to `RgbSettlementModule` or `RGBVerifier`.