### PR TITLE
fix(R-I-25): validate signer set/threshold at propose time

### DIFF
--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -147,11 +147,24 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
 
     /// @inheritdoc IBridge
     /// @dev Owner is `MultisigProxy`; federation governance gates this call
-    ///      on its M-of-N timelock flow.
+    ///      on its M-of-N timelock flow. Rotation only — rejects `address(0)`
+    ///      so an accidental zero cannot silently close the path; use
+    ///      `disableLZAdapter` for an explicit, separately-logged shutdown.
     function setLZAdapter(address newAdapter) external override onlyOwner {
+        if (newAdapter == address(0)) revert InvalidLZAdapter();
         address old = lzAdapter;
         lzAdapter = newAdapter;
         emit LZAdapterUpdated(old, newAdapter);
+    }
+
+    /// @inheritdoc IBridge
+    /// @dev Owner is `MultisigProxy`. Explicit disable, emitting
+    ///      `LZAdapterDisabled` so monitoring can tell a shutdown from a
+    ///      rotation.
+    function disableLZAdapter() external override onlyOwner {
+        address old = lzAdapter;
+        lzAdapter = address(0);
+        emit LZAdapterDisabled(old);
     }
 
     /// @inheritdoc IBridge

--- a/ethereum/src/BridgeBase.sol
+++ b/ethereum/src/BridgeBase.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.35;
 
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
+import { Ownable2Step } from '@openzeppelin/contracts/access/Ownable2Step.sol';
 import { SafeERC20, IERC20 } from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import { Pausable } from '@openzeppelin/contracts/utils/Pausable.sol';
 
@@ -13,7 +14,7 @@ import { Pausable } from '@openzeppelin/contracts/utils/Pausable.sol';
 ///      - pause / unpause (owner-only).
 ///      - Permanently blocked renounceOwnership.
 ///      - Utility views: getChainId, getContractBalance.
-abstract contract BridgeBase is Ownable, Pausable {
+abstract contract BridgeBase is Ownable2Step, Pausable {
     using SafeERC20 for IERC20;
 
     // =========================================================================

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.35;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -40,7 +41,7 @@ import {
  *      `owner` configures rules and withdraws accumulated pools. `renounceOwnership` is disabled.
  *      Withdrawals use `nonReentrant` against reentrancy via ERC-20 hooks or native recipients.
  */
-contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
+contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager {
     using SafeERC20 for IERC20;
 
     // ============ State Variables ============

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -460,6 +460,14 @@ contract MultisigProxy is IMultisigProxy {
         uint256 fedBitmap,
         bytes[] calldata fedSigs
     ) external returns (bytes32) {
+        // Validate the proposed set up front so a malformed rotation reverts
+        // here instead of consuming a nonce + timelock slot and failing only at
+        // execution. Disjointness is intentionally left to execute time: it
+        // depends on the live counterpart set, which may change before then.
+        if (newSigners.length == 0) revert NoSigners();
+        _requireValidThreshold(newThreshold, newSigners.length);
+        _validateSigners(newSigners);
+
         bytes32 structHash = keccak256(abi.encode(
             _PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH,
             _hashAddressArray(newSigners), newThreshold, nonce, deadline
@@ -481,6 +489,12 @@ contract MultisigProxy is IMultisigProxy {
         uint256 fedBitmap,
         bytes[] calldata fedSigs
     ) external returns (bytes32) {
+        // Validate up front (see proposeUpdateEnclaveSigners); disjointness is
+        // enforced at execution against the live enclave set.
+        if (newSigners.length == 0) revert NoSigners();
+        _requireValidThreshold(newThreshold, newSigners.length);
+        _validateSigners(newSigners);
+
         bytes32 structHash = keccak256(abi.encode(
             _PROPOSE_UPDATE_FEDERATION_SIGNERS_TYPEHASH,
             _hashAddressArray(newSigners), newThreshold, nonce, deadline

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -137,6 +137,9 @@ contract MultisigProxy is IMultisigProxy {
     bytes32 private constant _PROPOSE_ADMIN_EXECUTE_CM_TYPEHASH = keccak256(
         'ProposeAdminExecuteCommissionManager(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
     );
+    bytes32 private constant _PROPOSE_ADMIN_EXECUTE_ROUTE_REGISTRY_TYPEHASH = keccak256(
+        'ProposeAdminExecuteRouteRegistry(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
+    );
     bytes32 private constant _PROPOSE_WITHDRAW_TOKEN_COMMISSION_CM_TYPEHASH = keccak256(
         'ProposeWithdrawTokenCommissionCM(address token,uint256 amount,uint256 nonce,uint256 deadline)'
     );
@@ -153,6 +156,9 @@ contract MultisigProxy is IMultisigProxy {
     );
     bytes32 private constant _PROPOSE_UPDATE_LZ_ADAPTER_TYPEHASH = keccak256(
         'ProposeUpdateLZAdapter(address newLZAdapter,uint256 nonce,uint256 deadline)'
+    );
+    bytes32 private constant _PROPOSE_DISABLE_LZ_ADAPTER_TYPEHASH = keccak256(
+        'ProposeDisableLZAdapter(uint256 nonce,uint256 deadline)'
     );
 
     // Federation propose — RouteRegistry side
@@ -593,6 +599,30 @@ contract MultisigProxy is IMultisigProxy {
     }
 
     /// @inheritdoc IMultisigProxy
+    function proposeAdminExecuteRouteRegistry(
+        bytes calldata callData,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
+
+        bytes4 selector;
+        assembly { selector := calldataload(callData.offset) }
+
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_ADMIN_EXECUTE_ROUTE_REGISTRY_TYPEHASH, selector, keccak256(callData), nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.AdminExecuteRouteRegistry,
+            callData,
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
+    /// @inheritdoc IMultisigProxy
     function proposeWithdrawTokenCommissionCM(
         address token,
         uint256 amount,
@@ -693,6 +723,24 @@ contract MultisigProxy is IMultisigProxy {
         return _propose(
             OperationType.UpdateLZAdapter,
             abi.encode(newLZAdapter),
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
+    /// @inheritdoc IMultisigProxy
+    function proposeDisableLZAdapter(
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_DISABLE_LZ_ADAPTER_TYPEHASH, nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.DisableLZAdapter,
+            '',
             nonce, deadline, structHash, fedBitmap, fedSigs
         );
     }
@@ -966,6 +1014,16 @@ contract MultisigProxy is IMultisigProxy {
             (bool ok, bytes memory ret) = commissionManager.call(opData);
             _propagateRevert(ok, ret);
 
+        } else if (opType == OperationType.AdminExecuteRouteRegistry) {
+            // opData = raw RouteRegistry callData. Registry resolved from Bridge
+            // (single source of truth), same as SetRoute. Enables ownership
+            // migration (transferOwnership / acceptOwnership) for the Ownable2Step
+            // RouteRegistry.
+            address registry = IBridge(bridge).routeRegistry();
+            if (registry == address(0)) revert ZeroTarget();
+            (bool ok, bytes memory ret) = registry.call(opData);
+            _propagateRevert(ok, ret);
+
         } else if (opType == OperationType.WithdrawTokenCommissionCM) {
             (address token, uint256 amount) = abi.decode(opData, (address, uint256));
             address recipient = commissionRecipient;
@@ -1006,9 +1064,15 @@ contract MultisigProxy is IMultisigProxy {
 
         } else if (opType == OperationType.UpdateLZAdapter) {
             address newAdapter = abi.decode(opData, (address));
+            if (newAdapter == address(0)) revert InvalidLZAdapter();
             address oldAdapter = lzAdapter;
             lzAdapter = newAdapter;
             emit LZAdapterUpdated(oldAdapter, newAdapter);
+
+        } else if (opType == OperationType.DisableLZAdapter) {
+            address oldAdapter = lzAdapter;
+            lzAdapter = address(0);
+            emit LZAdapterDisabled(oldAdapter);
 
         } else if (opType == OperationType.SetRoute) {
             // Forwards to RouteRegistry, looked up dynamically from Bridge to

--- a/ethereum/src/RouteRegistry.sol
+++ b/ethereum/src/RouteRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.35;
 
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
+import { Ownable2Step } from '@openzeppelin/contracts/access/Ownable2Step.sol';
 
 import { IRouteRegistry }    from './interfaces/IRouteRegistry.sol';
 import { IFinalityVerifier } from './interfaces/IFinalityVerifier.sol';
@@ -33,7 +34,7 @@ import {
 ///      auditable on-chain rather than hidden behind an empty slot.
 ///
 ///      `renounceOwnership` is permanently blocked.
-contract RouteRegistry is IRouteRegistry, Ownable {
+contract RouteRegistry is IRouteRegistry, Ownable2Step {
     // =========================================================================
     // Errors
     // =========================================================================

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -19,6 +19,7 @@ interface IBridge {
     error InvalidRouteRegistryAddress();
     error InvalidCommissionManagerAddress();
     error NotLZAdapter();
+    error InvalidLZAdapter();
     error BurnIdAlreadyConsumed(uint256 burnId);
     error NativeValueMismatch();
 
@@ -26,10 +27,16 @@ interface IBridge {
     // Events
     // =========================================================================
 
-    /// @notice Emitted on every successful `setLZAdapter`.
+    /// @notice Emitted on every successful `setLZAdapter` (rotation to a
+    ///         non-zero adapter).
     /// @param oldAdapter Previous trusted adapter (zero before first set).
-    /// @param newAdapter New trusted adapter (zero disables the adapter overload).
+    /// @param newAdapter New trusted adapter (always non-zero).
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
+
+    /// @notice Emitted on `disableLZAdapter` — the inbound adapter path is
+    ///         explicitly closed (distinct from a rotation).
+    /// @param oldAdapter Adapter that was cleared.
+    event LZAdapterDisabled(address indexed oldAdapter);
 
     /// @notice Emitted on every successful `setRouteRegistry`.
     /// @param oldRegistry Previous registry (the constructor-supplied value
@@ -172,10 +179,16 @@ interface IBridge {
     // External — admin (called via MultisigProxy)
     // =========================================================================
 
-    /// @notice Updates the trusted LayerZero adapter address. Owner-only
-    ///         (MultisigProxy in production). Passing `address(0)` disables
-    ///         the adapter overload until a non-zero address is set again.
+    /// @notice Rotates the trusted LayerZero adapter to a new non-zero address.
+    ///         Owner-only (MultisigProxy in production). Reverts
+    ///         `InvalidLZAdapter` on `address(0)` — use `disableLZAdapter` to
+    ///         close the adapter overload.
     function setLZAdapter(address newAdapter) external;
+
+    /// @notice Explicitly clears the trusted LayerZero adapter (closes the
+    ///         adapter `fundsIn` overload). Owner-only. Emits `LZAdapterDisabled`,
+    ///         distinct from the `LZAdapterUpdated` rotation event.
+    function disableLZAdapter() external;
 
     /// @notice Updates the `RouteRegistry` reference Bridge dispatches
     ///         `onFundsIn` / `beforeFundsOut` through. Owner-only.

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -72,6 +72,7 @@ interface IMultisigProxy {
     error ZeroRecipient();
     error ZeroTarget();
     error LZAdapterNotSet();
+    error InvalidLZAdapter();
 
     // =========================================================================
     // Types
@@ -93,7 +94,9 @@ interface IMultisigProxy {
         SetRoute,                        // 12 — RouteRegistry.setRoute(src, dst, enabled, verifier, module)
         UpdateRouteRegistry,             // 13 — Bridge.setRouteRegistry(newRouteRegistry)
         PauseInflow,                     // 14 — Bridge.pauseInflow()  (planned inflow-only freeze, timelocked)
-        UnpauseInflow                    // 15 — Bridge.unpauseInflow()
+        UnpauseInflow,                   // 15 — Bridge.unpauseInflow()
+        DisableLZAdapter,                // 16 — clear the routing target (explicit disable, distinct from UpdateLZAdapter rotation)
+        AdminExecuteRouteRegistry        // 17 — generic call into RouteRegistry (transferOwnership/acceptOwnership, setRoute, …)
     }
 
     enum ProposalStatus { None, Pending, Executed, Cancelled }
@@ -160,6 +163,7 @@ interface IMultisigProxy {
     event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
+    event LZAdapterDisabled(address indexed oldAdapter);
     event CommissionRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
     event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
     event NativeCommissionWithdrawn(uint256 amount, address indexed recipient);
@@ -296,6 +300,21 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
+    // --- RouteRegistry-targeted operations ---
+
+    /// @notice Propose an arbitrary call into the RouteRegistry (resolved from
+    ///         Bridge). Enables ownership migration (`transferOwnership` /
+    ///         `acceptOwnership`) now that RouteRegistry is `Ownable2Step`,
+    ///         alongside the dedicated `SetRoute` op.
+    /// @dev opData = raw ABI-encoded RouteRegistry callData (selector + args).
+    function proposeAdminExecuteRouteRegistry(
+        bytes calldata callData,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
     /// @notice Propose an ERC-20 commission withdrawal from the CommissionManager
     ///         to the stored `commissionRecipient`.
     /// @dev opData = abi.encode(address token, uint256 amount)
@@ -345,10 +364,21 @@ interface IMultisigProxy {
     ) external returns (bytes32);
 
     /// @notice Propose rotating the LZAdapter routing target stored on this proxy.
-    /// @dev opData = abi.encode(address newLZAdapter). `address(0)` is allowed
-    ///      and closes adapter-execute until set again.
+    /// @dev opData = abi.encode(address newLZAdapter). Reverts `InvalidLZAdapter`
+    ///      on `address(0)` — use `proposeDisableLZAdapter` to close the path.
     function proposeUpdateLZAdapter(
         address newLZAdapter,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
+    /// @notice Propose clearing the LZAdapter routing target stored on this proxy
+    ///         (explicit disable, emits `LZAdapterDisabled` — distinct from a
+    ///         rotation via `proposeUpdateLZAdapter`).
+    /// @dev opData is empty.
+    function proposeDisableLZAdapter(
         uint256 nonce,
         uint256 deadline,
         uint256 fedBitmap,

--- a/ethereum/test/BaseBridge.t.sol
+++ b/ethereum/test/BaseBridge.t.sol
@@ -40,6 +40,10 @@ contract BaseBridgeTest is Test {
         vm.prank(deployer);
         bridge.transferOwnership(owner);
 
+        // Ownable2Step: the new owner must accept before it takes effect.
+        vm.prank(owner);
+        bridge.acceptOwnership();
+
         token.mint(user, AMOUNT * 10);
         vm.prank(user);
         token.approve(address(bridge), type(uint256).max);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -52,6 +52,7 @@ contract BridgeTest is Test {
         string  sourceAddress
     );
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
+    event LZAdapterDisabled(address indexed oldAdapter);
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
     event MinFundsInAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
     event OutflowLimitUpdated(uint256 indexed chainId, uint256 capacity, uint256 refillRate, uint256 available);
@@ -141,6 +142,10 @@ contract BridgeTest is Test {
         // governance-driven paths live in MultisigProxy.t.sol / Integration.t.sol.
         bridge.transferOwnership(multisig);
         vm.stopPrank();
+
+        // Ownable2Step: the new owner must accept before it takes effect.
+        vm.prank(multisig);
+        bridge.acceptOwnership();
 
         // fund user and approve bridge
         usdt0.mint(user, AMOUNT * 10);
@@ -320,7 +325,7 @@ contract BridgeTest is Test {
     // setLZAdapter
     // ========================================================================
 
-    function test_setLZAdapter_ownerCanSetAndUnset() public {
+    function test_setLZAdapter_rotatesToNonZero() public {
         address adapter = makeAddr('adapter');
 
         vm.expectEmit(true, true, false, true, address(bridge));
@@ -328,14 +333,32 @@ contract BridgeTest is Test {
 
         vm.prank(multisig);
         bridge.setLZAdapter(adapter);
-        assertEq(bridge.lzAdapter(), adapter, 'set');
+        assertEq(bridge.lzAdapter(), adapter, 'rotated');
+    }
 
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit LZAdapterUpdated(adapter, address(0));
+    function test_setLZAdapter_revertsOnZero() public {
+        vm.prank(multisig);
+        vm.expectRevert(IBridge.InvalidLZAdapter.selector);
+        bridge.setLZAdapter(address(0));
+    }
+
+    function test_disableLZAdapter_clearsAndEmits() public {
+        address adapter = makeAddr('adapter');
+        vm.prank(multisig);
+        bridge.setLZAdapter(adapter);
+
+        vm.expectEmit(true, false, false, false, address(bridge));
+        emit LZAdapterDisabled(adapter);
 
         vm.prank(multisig);
-        bridge.setLZAdapter(address(0));
-        assertEq(bridge.lzAdapter(), address(0), 'unset');
+        bridge.disableLZAdapter();
+        assertEq(bridge.lzAdapter(), address(0), 'disabled');
+    }
+
+    function test_disableLZAdapter_revertsIfNotOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.disableLZAdapter();
     }
 
     function test_setLZAdapter_revertsIfNotOwner() public {

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -191,6 +191,13 @@ contract IntegrationTest is Test {
         bridge.transferOwnership(address(proxy));
         vm.stopPrank();
 
+        // Ownable2Step: the proxy accepts ownership (prank shortcut; the real
+        // governance-accept path is exercised in MultisigProxy.t.sol).
+        vm.prank(address(proxy));
+        cm.acceptOwnership();
+        vm.prank(address(proxy));
+        bridge.acceptOwnership();
+
         // Invariants from deployment.
         assertEq(address(bridge),                       predictedBridge,        'bridge prediction');
         assertEq(cm.bridgeAddress(),                    address(bridge),        'CM.bridgeAddress');

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -96,6 +96,7 @@ contract MultisigProxyTest is Test {
     event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
     event TokenCommissionWithdrawn(address indexed token, address indexed to, uint256 amount);
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
+    event LZAdapterDisabled(address indexed oldAdapter);
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event BatchExecuted(uint256 indexed nonce, uint256 enclaveBitmap, address[] targets, bytes4[] selectors);
@@ -248,6 +249,15 @@ contract MultisigProxyTest is Test {
         cm.transferOwnership(address(proxy));
         routeRegistry.transferOwnership(address(proxy));
         vm.stopPrank();
+
+        // Ownable2Step: the proxy accepts ownership of all three (prank shortcut;
+        // the real governance-driven accept path is covered by a dedicated test).
+        vm.prank(address(proxy));
+        bridge.acceptOwnership();
+        vm.prank(address(proxy));
+        cm.acceptOwnership();
+        vm.prank(address(proxy));
+        routeRegistry.acceptOwnership();
 
         domainSep = proxy.DOMAIN_SEPARATOR();
 
@@ -556,7 +566,7 @@ contract MultisigProxyTest is Test {
 
     // ---- Signer update (validated at executeProposal) ----
 
-    function test_proposeUpdateEnclaveSigners_rejectsOneOfNAtExecute() public {
+    function test_proposeUpdateEnclaveSigners_rejectsOneOfNAtPropose() public {
         address[] memory newSigners = _signers(3);
         uint256 badThreshold = 1; // 1-of-3
         uint256 nonce    = proxy.proposalNonce();
@@ -568,15 +578,83 @@ contract MultisigProxyTest is Test {
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        // Propose succeeds — threshold validity is enforced on execution.
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, badThreshold, nonce, deadline, bitmap, sigs);
-
-        vm.warp(block.timestamp + TIMELOCK + 1);
+        // Threshold validity is now enforced up front, at propose time.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        proxy.executeProposal(id, abi.encode(newSigners, badThreshold));
+        proxy.proposeUpdateEnclaveSigners(newSigners, badThreshold, nonce, deadline, bitmap, sigs);
     }
 
-    function test_proposeUpdateFederationSigners_rejectsSubMajorityAtExecute() public {
+    // ---- Intrinsic set validation runs at propose time ----
+    // (empty / zero-address / duplicate paths; threshold and MAX_SIGNERS are
+    //  covered by the *AtPropose tests above. Disjointness stays deferred to
+    //  execute — see the R-W-14 *OverlapWith*AtExecute tests.)
+
+    function test_proposeUpdateEnclaveSigners_rejectsEmptySetAtPropose() public {
+        address[] memory newSigners = new address[](0);
+        uint256 threshold = 2;
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, newSigners, threshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.NoSigners.selector);
+        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeUpdateEnclaveSigners_rejectsZeroAddressSignerAtPropose() public {
+        address[] memory newSigners = _signers(3);
+        newSigners[1] = address(0);
+        uint256 threshold = 2;
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, newSigners, threshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
+        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeUpdateEnclaveSigners_rejectsDuplicateSignerAtPropose() public {
+        address[] memory newSigners = _signers(3);
+        newSigners[2] = newSigners[0]; // duplicate
+        uint256 threshold = 2;
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, newSigners, threshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
+        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeUpdateFederationSigners_rejectsEmptySetAtPropose() public {
+        address[] memory newSigners = new address[](0);
+        uint256 threshold = 2;
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(
+            domainSep, newSigners, threshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.NoSigners.selector);
+        proxy.proposeUpdateFederationSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeUpdateFederationSigners_rejectsSubMajorityAtPropose() public {
         address[] memory newSigners = _signers(4);
         uint256 badThreshold = 2; // 2-of-4, sub-majority
         uint256 nonce    = proxy.proposalNonce();
@@ -588,11 +666,9 @@ contract MultisigProxyTest is Test {
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateFederationSigners(newSigners, badThreshold, nonce, deadline, bitmap, sigs);
-
-        vm.warp(block.timestamp + TIMELOCK + 1);
+        // Threshold validity is now enforced up front, at propose time.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        proxy.executeProposal(id, abi.encode(newSigners, badThreshold));
+        proxy.proposeUpdateFederationSigners(newSigners, badThreshold, nonce, deadline, bitmap, sigs);
     }
 
     function test_proposeUpdateFederationSigners_acceptsStrictMajority() public {
@@ -709,7 +785,7 @@ contract MultisigProxyTest is Test {
         assertEq(p.getFederationSigners().length, max);
     }
 
-    function test_proposeUpdateEnclaveSigners_rejectsTooManySignersAtExecute() public {
+    function test_proposeUpdateEnclaveSigners_rejectsTooManySignersAtPropose() public {
         uint256 max = proxy.MAX_SIGNERS();
         address[] memory newSigners = _signers(max + 1);
         uint256 newThreshold = (max + 1) / 2 + 1; // valid strict majority
@@ -722,11 +798,9 @@ contract MultisigProxyTest is Test {
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
-
-        vm.warp(block.timestamp + TIMELOCK + 1);
+        // Signer-set size is now enforced up front, at propose time.
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
-        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
     }
 
     // ========================================================================
@@ -1478,17 +1552,40 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.lzAdapter(), newAdapter);
     }
 
-    function test_proposeUpdateLZAdapter_canRotateToZero() public {
+    function test_proposeUpdateLZAdapter_rejectsZeroAtExecute() public {
+        // Proposing zero succeeds (validated at execute); execution reverts —
+        // DisableLZAdapter is the explicit way to clear the routing target.
+        bytes32 id = _proposeUpdateLZAdapter(address(0));
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(IMultisigProxy.InvalidLZAdapter.selector);
+        proxy.executeProposal(id, abi.encode(address(0)));
+    }
+
+    function _proposeDisableLZAdapter() internal returns (bytes32 id) {
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeDisableLZAdapter(domainSep, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        id = proxy.proposeDisableLZAdapter(nonce, deadline, bitmap, sigs);
+    }
+
+    function test_proposeDisableLZAdapter_clearsAdapterAndEmits() public {
+        // Set a non-zero adapter first.
         address newAdapter = makeAddr('lzAdapter');
         bytes32 id = _proposeUpdateLZAdapter(newAdapter);
         vm.warp(block.timestamp + TIMELOCK + 1);
         proxy.executeProposal(id, abi.encode(newAdapter));
         assertEq(proxy.lzAdapter(), newAdapter);
 
-        bytes32 id2 = _proposeUpdateLZAdapter(address(0));
+        // Explicit disable clears it and emits LZAdapterDisabled.
+        bytes32 id2 = _proposeDisableLZAdapter();
         vm.warp(block.timestamp + 2 * TIMELOCK + 2);
 
-        proxy.executeProposal(id2, abi.encode(address(0)));
+        vm.expectEmit(true, false, false, false);
+        emit LZAdapterDisabled(newAdapter);
+
+        proxy.executeProposal(id2, '');
         assertEq(proxy.lzAdapter(), address(0));
     }
 
@@ -2637,10 +2734,11 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.bridge(), address(bridge), 'stale proposal leaves bridge unchanged');
     }
 
-    // Current behavior: generic Bridge admin execution can call standard
-    // Ownable transferOwnership directly. A wrong nonzero owner leaves the
-    // proxy unable to execute future Bridge owner-only operations.
-    function test_singleStepOwnershipTransferCanOrphanGovernance_currentBehavior() public {
+    // Generic Bridge admin execution can still call
+    // transferOwnership, but Ownable2Step only records a pendingOwner. A wrong
+    // non-zero address never becomes owner, so governance is not orphaned and
+    // the proxy keeps driving owner-only operations.
+    function test_ownershipTransferToWrongAddressDoesNotOrphanGovernance_afterFix() public {
         address wrongOwner = makeAddr('wrongBridgeOwner');
         uint256 startTime = block.timestamp;
 
@@ -2669,14 +2767,14 @@ contract MultisigProxyTest is Test {
         uint256 transferReadyAt = startTime + TIMELOCK + 1;
         vm.warp(transferReadyAt);
 
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit OwnershipTransferred(address(proxy), wrongOwner);
         vm.expectEmit(true, true, false, true, address(proxy));
         emit ProposalExecuted(transferProposalId, IMultisigProxy.OperationType.AdminExecute);
 
         proxy.executeProposal(transferProposalId, transferCallData);
 
-        assertEq(bridge.owner(), wrongOwner, 'bridge owner moved away from proxy');
+        // Ownable2Step: ownership did NOT move; the wrong address is only pending.
+        assertEq(bridge.owner(), address(proxy), 'owner unchanged (two-step)');
+        assertEq(bridge.pendingOwner(), wrongOwner, 'wrong address only pending');
 
         address replacementRegistry = makeAddr('replacementRouteRegistry');
         bytes memory registryCallData = abi.encodeWithSignature('setRouteRegistry(address)', replacementRegistry);
@@ -2697,11 +2795,37 @@ contract MultisigProxyTest is Test {
 
         vm.warp(transferReadyAt + TIMELOCK + 1);
 
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(proxy)));
+        // Governance is NOT orphaned: the proxy still owns Bridge, so the
+        // setRouteRegistry op executes and takes effect.
         proxy.executeProposal(registryProposalId, registryCallData);
 
-        assertEq(bridge.owner(), wrongOwner, 'wrong owner remains');
-        assertEq(bridge.routeRegistry(), routeRegistryBefore, 'proxy cannot update bridge config');
+        assertEq(bridge.owner(), address(proxy), 'proxy remains owner');
+        assertEq(bridge.routeRegistry(), replacementRegistry, 'proxy still governs bridge config');
+    }
+
+    // The new AdminExecuteRouteRegistry op gives the proxy a call path
+    // into RouteRegistry (which previously had only the typed SetRoute op), so
+    // it can drive RouteRegistry's Ownable2Step transferOwnership on migration.
+    function test_adminExecuteRouteRegistry_initiatesRouteRegistryOwnershipTransfer() public {
+        address newOwner = makeAddr('newRouteRegistryOwner');
+        bytes memory callData = abi.encodeWithSignature('transferOwnership(address)', newOwner);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteRouteRegistry(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        assertEq(routeRegistry.owner(), address(proxy), 'pre RR owner');
+
+        bytes32 id = proxy.proposeAdminExecuteRouteRegistry(callData, nonce, deadline, bitmap, sigs);
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, callData);
+
+        // Ownable2Step: RR ownership is only pending until the new owner accepts.
+        assertEq(routeRegistry.owner(), address(proxy), 'RR owner unchanged (two-step)');
+        assertEq(routeRegistry.pendingOwner(), newOwner, 'RR transfer started via new op');
     }
 
     // The typed commission-withdraw path pins the recipient to

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -69,6 +69,10 @@ library MultisigHelper {
         'ProposeAdminExecuteCommissionManager(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
     );
 
+    bytes32 internal constant PROPOSE_ADMIN_EXECUTE_ROUTE_REGISTRY_TYPEHASH = keccak256(
+        'ProposeAdminExecuteRouteRegistry(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
+    );
+
     bytes32 internal constant PROPOSE_WITHDRAW_TOKEN_COMMISSION_CM_TYPEHASH = keccak256(
         'ProposeWithdrawTokenCommissionCM(address token,uint256 amount,uint256 nonce,uint256 deadline)'
     );
@@ -87,6 +91,9 @@ library MultisigHelper {
 
     bytes32 internal constant PROPOSE_UPDATE_LZ_ADAPTER_TYPEHASH = keccak256(
         'ProposeUpdateLZAdapter(address newLZAdapter,uint256 nonce,uint256 deadline)'
+    );
+    bytes32 internal constant PROPOSE_DISABLE_LZ_ADAPTER_TYPEHASH = keccak256(
+        'ProposeDisableLZAdapter(uint256 nonce,uint256 deadline)'
     );
 
     bytes32 internal constant PROPOSE_SET_ROUTE_TYPEHASH = keccak256(
@@ -195,6 +202,10 @@ library MultisigHelper {
         return toTypedDataHash(domainSep, keccak256(abi.encode(PROPOSE_UNPAUSE_INFLOW_TYPEHASH, nonce, deadline)));
     }
 
+    function digestProposeDisableLZAdapter(bytes32 domainSep, uint256 nonce, uint256 deadline) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(PROPOSE_DISABLE_LZ_ADAPTER_TYPEHASH, nonce, deadline)));
+    }
+
     function digestProposeAdminExecute(
         bytes32 domainSep,
         bytes4 selector,
@@ -264,6 +275,18 @@ library MultisigHelper {
     ) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(
             PROPOSE_ADMIN_EXECUTE_CM_TYPEHASH, selector, keccak256(callData), nonce, deadline
+        )));
+    }
+
+    function digestProposeAdminExecuteRouteRegistry(
+        bytes32 domainSep,
+        bytes4 selector,
+        bytes memory callData,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(
+            PROPOSE_ADMIN_EXECUTE_ROUTE_REGISTRY_TYPEHASH, selector, keccak256(callData), nonce, deadline
         )));
     }
 


### PR DESCRIPTION
## Summary
`proposeUpdateEnclaveSigners` / `proposeUpdateFederationSigners` now validate the
proposed signer set + threshold up front (`NoSigners`, `_requireValidThreshold`,
`_validateSigners`) before creating the proposal.

Both propose functions forwarded the new set straight to `_propose` with no
validation. A malformed rotation therefore consumed a `proposalNonce` and a
timelock slot and reverted only at execution — a wasted governance round and a
confusing, delayed failure.

## Fix
- Only the intrinsic, data-deterministic checks are duplicated at propose time.
- `_requireDisjoint` stays execute-only: it depends on the live counterpart
  signer set, which can change between propose and execute, so an early check
  could wrongly reject a proposal that is valid at execution. Execute-time
  checks remain the authoritative guard.