### PR TITLE
fix(R-I-15): Ownable2Step for Bridge/CommissionManager/RouteRegistry

### DIFF
--- a/ethereum/src/BridgeBase.sol
+++ b/ethereum/src/BridgeBase.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.35;
 
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
+import { Ownable2Step } from '@openzeppelin/contracts/access/Ownable2Step.sol';
 import { SafeERC20, IERC20 } from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import { Pausable } from '@openzeppelin/contracts/utils/Pausable.sol';
 
@@ -13,7 +14,7 @@ import { Pausable } from '@openzeppelin/contracts/utils/Pausable.sol';
 ///      - pause / unpause (owner-only).
 ///      - Permanently blocked renounceOwnership.
 ///      - Utility views: getChainId, getContractBalance.
-abstract contract BridgeBase is Ownable, Pausable {
+abstract contract BridgeBase is Ownable2Step, Pausable {
     using SafeERC20 for IERC20;
 
     // =========================================================================

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.35;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -40,7 +41,7 @@ import {
  *      `owner` configures rules and withdraws accumulated pools. `renounceOwnership` is disabled.
  *      Withdrawals use `nonReentrant` against reentrancy via ERC-20 hooks or native recipients.
  */
-contract CommissionManager is Ownable, ReentrancyGuard, ICommissionManager {
+contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager {
     using SafeERC20 for IERC20;
 
     // ============ State Variables ============

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -137,6 +137,9 @@ contract MultisigProxy is IMultisigProxy {
     bytes32 private constant _PROPOSE_ADMIN_EXECUTE_CM_TYPEHASH = keccak256(
         'ProposeAdminExecuteCommissionManager(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
     );
+    bytes32 private constant _PROPOSE_ADMIN_EXECUTE_ROUTE_REGISTRY_TYPEHASH = keccak256(
+        'ProposeAdminExecuteRouteRegistry(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
+    );
     bytes32 private constant _PROPOSE_WITHDRAW_TOKEN_COMMISSION_CM_TYPEHASH = keccak256(
         'ProposeWithdrawTokenCommissionCM(address token,uint256 amount,uint256 nonce,uint256 deadline)'
     );
@@ -596,6 +599,30 @@ contract MultisigProxy is IMultisigProxy {
     }
 
     /// @inheritdoc IMultisigProxy
+    function proposeAdminExecuteRouteRegistry(
+        bytes calldata callData,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        if (callData.length < SELECTOR_LENGTH) revert CallDataTooShort();
+
+        bytes4 selector;
+        assembly { selector := calldataload(callData.offset) }
+
+        bytes32 structHash = keccak256(abi.encode(
+            _PROPOSE_ADMIN_EXECUTE_ROUTE_REGISTRY_TYPEHASH, selector, keccak256(callData), nonce, deadline
+        ));
+
+        return _propose(
+            OperationType.AdminExecuteRouteRegistry,
+            callData,
+            nonce, deadline, structHash, fedBitmap, fedSigs
+        );
+    }
+
+    /// @inheritdoc IMultisigProxy
     function proposeWithdrawTokenCommissionCM(
         address token,
         uint256 amount,
@@ -985,6 +1012,16 @@ contract MultisigProxy is IMultisigProxy {
         } else if (opType == OperationType.AdminExecuteCommissionManager) {
             // opData = raw CommissionManager callData
             (bool ok, bytes memory ret) = commissionManager.call(opData);
+            _propagateRevert(ok, ret);
+
+        } else if (opType == OperationType.AdminExecuteRouteRegistry) {
+            // opData = raw RouteRegistry callData. Registry resolved from Bridge
+            // (single source of truth), same as SetRoute. Enables ownership
+            // migration (transferOwnership / acceptOwnership) for the Ownable2Step
+            // RouteRegistry.
+            address registry = IBridge(bridge).routeRegistry();
+            if (registry == address(0)) revert ZeroTarget();
+            (bool ok, bytes memory ret) = registry.call(opData);
             _propagateRevert(ok, ret);
 
         } else if (opType == OperationType.WithdrawTokenCommissionCM) {

--- a/ethereum/src/RouteRegistry.sol
+++ b/ethereum/src/RouteRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.35;
 
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
+import { Ownable2Step } from '@openzeppelin/contracts/access/Ownable2Step.sol';
 
 import { IRouteRegistry }    from './interfaces/IRouteRegistry.sol';
 import { IFinalityVerifier } from './interfaces/IFinalityVerifier.sol';
@@ -33,7 +34,7 @@ import {
 ///      auditable on-chain rather than hidden behind an empty slot.
 ///
 ///      `renounceOwnership` is permanently blocked.
-contract RouteRegistry is IRouteRegistry, Ownable {
+contract RouteRegistry is IRouteRegistry, Ownable2Step {
     // =========================================================================
     // Errors
     // =========================================================================

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -95,7 +95,8 @@ interface IMultisigProxy {
         UpdateRouteRegistry,             // 13 — Bridge.setRouteRegistry(newRouteRegistry)
         PauseInflow,                     // 14 — Bridge.pauseInflow()  (planned inflow-only freeze, timelocked)
         UnpauseInflow,                   // 15 — Bridge.unpauseInflow()
-        DisableLZAdapter                 // 16 — clear the routing target (explicit disable, distinct from UpdateLZAdapter rotation)
+        DisableLZAdapter,                // 16 — clear the routing target (explicit disable, distinct from UpdateLZAdapter rotation)
+        AdminExecuteRouteRegistry        // 17 — generic call into RouteRegistry (transferOwnership/acceptOwnership, setRoute, …)
     }
 
     enum ProposalStatus { None, Pending, Executed, Cancelled }
@@ -292,6 +293,21 @@ interface IMultisigProxy {
     ///      setMockTokenToNativeRate, setBridgeAddress, transferOwnership, …
     /// @dev opData = raw ABI-encoded CommissionManager callData (selector + args).
     function proposeAdminExecuteCommissionManager(
+        bytes calldata callData,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
+    // --- RouteRegistry-targeted operations ---
+
+    /// @notice Propose an arbitrary call into the RouteRegistry (resolved from
+    ///         Bridge). Enables ownership migration (`transferOwnership` /
+    ///         `acceptOwnership`) now that RouteRegistry is `Ownable2Step`,
+    ///         alongside the dedicated `SetRoute` op.
+    /// @dev opData = raw ABI-encoded RouteRegistry callData (selector + args).
+    function proposeAdminExecuteRouteRegistry(
         bytes calldata callData,
         uint256 nonce,
         uint256 deadline,

--- a/ethereum/test/BaseBridge.t.sol
+++ b/ethereum/test/BaseBridge.t.sol
@@ -40,6 +40,10 @@ contract BaseBridgeTest is Test {
         vm.prank(deployer);
         bridge.transferOwnership(owner);
 
+        // Ownable2Step: the new owner must accept before it takes effect.
+        vm.prank(owner);
+        bridge.acceptOwnership();
+
         token.mint(user, AMOUNT * 10);
         vm.prank(user);
         token.approve(address(bridge), type(uint256).max);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -143,6 +143,10 @@ contract BridgeTest is Test {
         bridge.transferOwnership(multisig);
         vm.stopPrank();
 
+        // Ownable2Step: the new owner must accept before it takes effect.
+        vm.prank(multisig);
+        bridge.acceptOwnership();
+
         // fund user and approve bridge
         usdt0.mint(user, AMOUNT * 10);
         vm.prank(user);

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -191,6 +191,13 @@ contract IntegrationTest is Test {
         bridge.transferOwnership(address(proxy));
         vm.stopPrank();
 
+        // Ownable2Step: the proxy accepts ownership (prank shortcut; the real
+        // governance-accept path is exercised in MultisigProxy.t.sol).
+        vm.prank(address(proxy));
+        cm.acceptOwnership();
+        vm.prank(address(proxy));
+        bridge.acceptOwnership();
+
         // Invariants from deployment.
         assertEq(address(bridge),                       predictedBridge,        'bridge prediction');
         assertEq(cm.bridgeAddress(),                    address(bridge),        'CM.bridgeAddress');

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -250,6 +250,15 @@ contract MultisigProxyTest is Test {
         routeRegistry.transferOwnership(address(proxy));
         vm.stopPrank();
 
+        // Ownable2Step: the proxy accepts ownership of all three (prank shortcut;
+        // the real governance-driven accept path is covered by a dedicated test).
+        vm.prank(address(proxy));
+        bridge.acceptOwnership();
+        vm.prank(address(proxy));
+        cm.acceptOwnership();
+        vm.prank(address(proxy));
+        routeRegistry.acceptOwnership();
+
         domainSep = proxy.DOMAIN_SEPARATOR();
 
         // Fund user, lock tokens into the bridge so fundsOut has a pool.
@@ -2725,10 +2734,11 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.bridge(), address(bridge), 'stale proposal leaves bridge unchanged');
     }
 
-    // Current behavior: generic Bridge admin execution can call standard
-    // Ownable transferOwnership directly. A wrong nonzero owner leaves the
-    // proxy unable to execute future Bridge owner-only operations.
-    function test_singleStepOwnershipTransferCanOrphanGovernance_currentBehavior() public {
+    // Generic Bridge admin execution can still call
+    // transferOwnership, but Ownable2Step only records a pendingOwner. A wrong
+    // non-zero address never becomes owner, so governance is not orphaned and
+    // the proxy keeps driving owner-only operations.
+    function test_ownershipTransferToWrongAddressDoesNotOrphanGovernance_afterFix() public {
         address wrongOwner = makeAddr('wrongBridgeOwner');
         uint256 startTime = block.timestamp;
 
@@ -2757,14 +2767,14 @@ contract MultisigProxyTest is Test {
         uint256 transferReadyAt = startTime + TIMELOCK + 1;
         vm.warp(transferReadyAt);
 
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit OwnershipTransferred(address(proxy), wrongOwner);
         vm.expectEmit(true, true, false, true, address(proxy));
         emit ProposalExecuted(transferProposalId, IMultisigProxy.OperationType.AdminExecute);
 
         proxy.executeProposal(transferProposalId, transferCallData);
 
-        assertEq(bridge.owner(), wrongOwner, 'bridge owner moved away from proxy');
+        // Ownable2Step: ownership did NOT move; the wrong address is only pending.
+        assertEq(bridge.owner(), address(proxy), 'owner unchanged (two-step)');
+        assertEq(bridge.pendingOwner(), wrongOwner, 'wrong address only pending');
 
         address replacementRegistry = makeAddr('replacementRouteRegistry');
         bytes memory registryCallData = abi.encodeWithSignature('setRouteRegistry(address)', replacementRegistry);
@@ -2785,11 +2795,37 @@ contract MultisigProxyTest is Test {
 
         vm.warp(transferReadyAt + TIMELOCK + 1);
 
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(proxy)));
+        // Governance is NOT orphaned: the proxy still owns Bridge, so the
+        // setRouteRegistry op executes and takes effect.
         proxy.executeProposal(registryProposalId, registryCallData);
 
-        assertEq(bridge.owner(), wrongOwner, 'wrong owner remains');
-        assertEq(bridge.routeRegistry(), routeRegistryBefore, 'proxy cannot update bridge config');
+        assertEq(bridge.owner(), address(proxy), 'proxy remains owner');
+        assertEq(bridge.routeRegistry(), replacementRegistry, 'proxy still governs bridge config');
+    }
+
+    // The new AdminExecuteRouteRegistry op gives the proxy a call path
+    // into RouteRegistry (which previously had only the typed SetRoute op), so
+    // it can drive RouteRegistry's Ownable2Step transferOwnership on migration.
+    function test_adminExecuteRouteRegistry_initiatesRouteRegistryOwnershipTransfer() public {
+        address newOwner = makeAddr('newRouteRegistryOwner');
+        bytes memory callData = abi.encodeWithSignature('transferOwnership(address)', newOwner);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteRouteRegistry(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        assertEq(routeRegistry.owner(), address(proxy), 'pre RR owner');
+
+        bytes32 id = proxy.proposeAdminExecuteRouteRegistry(callData, nonce, deadline, bitmap, sigs);
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, callData);
+
+        // Ownable2Step: RR ownership is only pending until the new owner accepts.
+        assertEq(routeRegistry.owner(), address(proxy), 'RR owner unchanged (two-step)');
+        assertEq(routeRegistry.pendingOwner(), newOwner, 'RR transfer started via new op');
     }
 
     // The typed commission-withdraw path pins the recipient to

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -69,6 +69,10 @@ library MultisigHelper {
         'ProposeAdminExecuteCommissionManager(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
     );
 
+    bytes32 internal constant PROPOSE_ADMIN_EXECUTE_ROUTE_REGISTRY_TYPEHASH = keccak256(
+        'ProposeAdminExecuteRouteRegistry(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
+    );
+
     bytes32 internal constant PROPOSE_WITHDRAW_TOKEN_COMMISSION_CM_TYPEHASH = keccak256(
         'ProposeWithdrawTokenCommissionCM(address token,uint256 amount,uint256 nonce,uint256 deadline)'
     );
@@ -271,6 +275,18 @@ library MultisigHelper {
     ) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(
             PROPOSE_ADMIN_EXECUTE_CM_TYPEHASH, selector, keccak256(callData), nonce, deadline
+        )));
+    }
+
+    function digestProposeAdminExecuteRouteRegistry(
+        bytes32 domainSep,
+        bytes4 selector,
+        bytes memory callData,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(
+            PROPOSE_ADMIN_EXECUTE_ROUTE_REGISTRY_TYPEHASH, selector, keccak256(callData), nonce, deadline
         )));
     }
 


### PR DESCRIPTION
## Summary
- `BridgeBase` (Bridge), `CommissionManager`, `RouteRegistry`: `Ownable` → `Ownable2Step`.
- New `AdminExecuteRouteRegistry` governance op in `MultisigProxy` so the proxy
  can call `transferOwnership` / `acceptOwnership` on RouteRegistry (it had no
  generic call path before — only typed `SetRoute`). Bridge/CM already have
  generic exec.

## Fix
Single-step `transferOwnership` on an owned contract could orphan governance
(wrong non-zero owner, `renounceOwnership` blocked). Two-step means ownership
only changes after `acceptOwnership`.

Redeploying MultisigProxy → old proxy `transferOwnership(newProxy)` + new proxy
`acceptOwnership()` on all three contracts (Bridge/CM via their generic exec,
RouteRegistry via the new op).