### PR TITLE
test(R-I-15): two-step ownership handoff + AdminExecuteRouteRegistry

### DIFF
--- a/ethereum/test/BaseBridge.t.sol
+++ b/ethereum/test/BaseBridge.t.sol
@@ -40,6 +40,10 @@ contract BaseBridgeTest is Test {
         vm.prank(deployer);
         bridge.transferOwnership(owner);
 
+        // Ownable2Step: the new owner must accept before it takes effect.
+        vm.prank(owner);
+        bridge.acceptOwnership();
+
         token.mint(user, AMOUNT * 10);
         vm.prank(user);
         token.approve(address(bridge), type(uint256).max);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -143,6 +143,10 @@ contract BridgeTest is Test {
         bridge.transferOwnership(multisig);
         vm.stopPrank();
 
+        // Ownable2Step: the new owner must accept before it takes effect.
+        vm.prank(multisig);
+        bridge.acceptOwnership();
+
         // fund user and approve bridge
         usdt0.mint(user, AMOUNT * 10);
         vm.prank(user);

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -191,6 +191,13 @@ contract IntegrationTest is Test {
         bridge.transferOwnership(address(proxy));
         vm.stopPrank();
 
+        // Ownable2Step: the proxy accepts ownership (prank shortcut; the real
+        // governance-accept path is exercised in MultisigProxy.t.sol).
+        vm.prank(address(proxy));
+        cm.acceptOwnership();
+        vm.prank(address(proxy));
+        bridge.acceptOwnership();
+
         // Invariants from deployment.
         assertEq(address(bridge),                       predictedBridge,        'bridge prediction');
         assertEq(cm.bridgeAddress(),                    address(bridge),        'CM.bridgeAddress');

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -250,6 +250,15 @@ contract MultisigProxyTest is Test {
         routeRegistry.transferOwnership(address(proxy));
         vm.stopPrank();
 
+        // Ownable2Step: the proxy accepts ownership of all three (prank shortcut;
+        // the real governance-driven accept path is covered by a dedicated test).
+        vm.prank(address(proxy));
+        bridge.acceptOwnership();
+        vm.prank(address(proxy));
+        cm.acceptOwnership();
+        vm.prank(address(proxy));
+        routeRegistry.acceptOwnership();
+
         domainSep = proxy.DOMAIN_SEPARATOR();
 
         // Fund user, lock tokens into the bridge so fundsOut has a pool.
@@ -2725,10 +2734,11 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.bridge(), address(bridge), 'stale proposal leaves bridge unchanged');
     }
 
-    // Current behavior: generic Bridge admin execution can call standard
-    // Ownable transferOwnership directly. A wrong nonzero owner leaves the
-    // proxy unable to execute future Bridge owner-only operations.
-    function test_singleStepOwnershipTransferCanOrphanGovernance_currentBehavior() public {
+    // Generic Bridge admin execution can still call
+    // transferOwnership, but Ownable2Step only records a pendingOwner. A wrong
+    // non-zero address never becomes owner, so governance is not orphaned and
+    // the proxy keeps driving owner-only operations.
+    function test_ownershipTransferToWrongAddressDoesNotOrphanGovernance_afterFix() public {
         address wrongOwner = makeAddr('wrongBridgeOwner');
         uint256 startTime = block.timestamp;
 
@@ -2757,14 +2767,14 @@ contract MultisigProxyTest is Test {
         uint256 transferReadyAt = startTime + TIMELOCK + 1;
         vm.warp(transferReadyAt);
 
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit OwnershipTransferred(address(proxy), wrongOwner);
         vm.expectEmit(true, true, false, true, address(proxy));
         emit ProposalExecuted(transferProposalId, IMultisigProxy.OperationType.AdminExecute);
 
         proxy.executeProposal(transferProposalId, transferCallData);
 
-        assertEq(bridge.owner(), wrongOwner, 'bridge owner moved away from proxy');
+        // Ownable2Step: ownership did NOT move; the wrong address is only pending.
+        assertEq(bridge.owner(), address(proxy), 'owner unchanged (two-step)');
+        assertEq(bridge.pendingOwner(), wrongOwner, 'wrong address only pending');
 
         address replacementRegistry = makeAddr('replacementRouteRegistry');
         bytes memory registryCallData = abi.encodeWithSignature('setRouteRegistry(address)', replacementRegistry);
@@ -2785,11 +2795,37 @@ contract MultisigProxyTest is Test {
 
         vm.warp(transferReadyAt + TIMELOCK + 1);
 
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(proxy)));
+        // Governance is NOT orphaned: the proxy still owns Bridge, so the
+        // setRouteRegistry op executes and takes effect.
         proxy.executeProposal(registryProposalId, registryCallData);
 
-        assertEq(bridge.owner(), wrongOwner, 'wrong owner remains');
-        assertEq(bridge.routeRegistry(), routeRegistryBefore, 'proxy cannot update bridge config');
+        assertEq(bridge.owner(), address(proxy), 'proxy remains owner');
+        assertEq(bridge.routeRegistry(), replacementRegistry, 'proxy still governs bridge config');
+    }
+
+    // The new AdminExecuteRouteRegistry op gives the proxy a call path
+    // into RouteRegistry (which previously had only the typed SetRoute op), so
+    // it can drive RouteRegistry's Ownable2Step transferOwnership on migration.
+    function test_adminExecuteRouteRegistry_initiatesRouteRegistryOwnershipTransfer() public {
+        address newOwner = makeAddr('newRouteRegistryOwner');
+        bytes memory callData = abi.encodeWithSignature('transferOwnership(address)', newOwner);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeAdminExecuteRouteRegistry(
+            domainSep, bytes4(callData), callData, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        assertEq(routeRegistry.owner(), address(proxy), 'pre RR owner');
+
+        bytes32 id = proxy.proposeAdminExecuteRouteRegistry(callData, nonce, deadline, bitmap, sigs);
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, callData);
+
+        // Ownable2Step: RR ownership is only pending until the new owner accepts.
+        assertEq(routeRegistry.owner(), address(proxy), 'RR owner unchanged (two-step)');
+        assertEq(routeRegistry.pendingOwner(), newOwner, 'RR transfer started via new op');
     }
 
     // The typed commission-withdraw path pins the recipient to

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -69,6 +69,10 @@ library MultisigHelper {
         'ProposeAdminExecuteCommissionManager(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
     );
 
+    bytes32 internal constant PROPOSE_ADMIN_EXECUTE_ROUTE_REGISTRY_TYPEHASH = keccak256(
+        'ProposeAdminExecuteRouteRegistry(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
+    );
+
     bytes32 internal constant PROPOSE_WITHDRAW_TOKEN_COMMISSION_CM_TYPEHASH = keccak256(
         'ProposeWithdrawTokenCommissionCM(address token,uint256 amount,uint256 nonce,uint256 deadline)'
     );
@@ -271,6 +275,18 @@ library MultisigHelper {
     ) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(
             PROPOSE_ADMIN_EXECUTE_CM_TYPEHASH, selector, keccak256(callData), nonce, deadline
+        )));
+    }
+
+    function digestProposeAdminExecuteRouteRegistry(
+        bytes32 domainSep,
+        bytes4 selector,
+        bytes memory callData,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return toTypedDataHash(domainSep, keccak256(abi.encode(
+            PROPOSE_ADMIN_EXECUTE_ROUTE_REGISTRY_TYPEHASH, selector, keccak256(callData), nonce, deadline
         )));
     }
 


### PR DESCRIPTION
## Summary
Tests for the R-I-15 fix (Ownable2Step on Bridge/CM/RouteRegistry + the new
AdminExecuteRouteRegistry op).

- setUp handoff made two-step in every suite that transfers owned contracts to
  the proxy/EOA: `transferOwnership` followed by `acceptOwnership` (impersonated
  via prank in setUp). This clears the ~96 cascading failures the fix caused.
- Rewrote the R-I-15 orphan reproduction as an after-fix test: a mis-addressed
  `transferOwnership` via `AdminExecute` only records `pendingOwner`; ownership
  stays with the proxy and governance keeps working (not orphaned).
- New `AdminExecuteRouteRegistry` op coverage: the proxy initiates
  `RouteRegistry.transferOwnership` (two-step). Added the matching
  `MultisigHelper.digestProposeAdminExecuteRouteRegistry`.