### PR TITLE
test(R-W-06): two-pair proof + confirmation-depth coverage for RGBVerifier

### DIFF
--- a/ethereum/.env.deploy.example
+++ b/ethereum/.env.deploy.example
@@ -68,6 +68,25 @@ ETH_USD_FEED=
 # 87000 leaves ~10 min slack).
 ETH_USD_HEARTBEAT=87000
 
+# --- Arbitrum Chainlink robustness (optional) ---
+
+# Chainlink L2 Sequencer Uptime feed. When set, NATIVE quotes are rejected while
+# the sequencer is down and for the 3600 s grace period after a restart. Set on
+# Arbitrum whenever NATIVE commission is used; leave blank on non-L2 / tests.
+#   Arbitrum One  Sequencer Uptime  0xFdB631F5EE196F0ed6FAa767959853A9F217697D
+SEQUENCER_UPTIME_FEED=
+
+# Optional ETH/USD sanity band (circuit breaker), in the feed's decimals
+# (ETH/USD = 8). Set BOTH or NEITHER (else the deploy reverts); 0 < min < max.
+# Example for an 8-decimal feed: $100 = 10000000000, $100k = 10000000000000.
+ETH_USD_MIN_PRICE=
+ETH_USD_MAX_PRICE=
+
+# When true, the deploy reverts unless ETH_USD_FEED, SEQUENCER_UPTIME_FEED, and
+# the price band are ALL set. Recommend =true for Arbitrum production so the
+# R-I-14 guards can never be silently absent; leave false for non-L2 / tests.
+REQUIRE_CHAINLINK_HARDENING=false
+
 # -----------------------------------------------------------------------------
 # MultisigProxy
 # -----------------------------------------------------------------------------

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -24,10 +24,13 @@ import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.so
 ///   n + 3  → RGBVerifier        (wraps the BtcRelay)
 ///   n + 4  → RgbSettlementModule (paired with RouteRegistry)
 ///   n + 5  → MultisigProxy
-///   n + 6  → (optional) CommissionManager.setEthUsdFeed
-///   n + 7  → CommissionManager.transferOwnership (starts two-step handoff)
-///   n + 8  → Bridge.transferOwnership (starts two-step handoff)
-///   n + 9  → RouteRegistry.transferOwnership (starts two-step handoff)
+///          → (optional) CommissionManager config txs, each present only when
+///            its env is set: setEthUsdFeed, setSequencerUptimeFeed,
+///            setEthUsdPriceBounds. These shift the transferOwnership nonces
+///            below by however many are emitted (0–3).
+///          → CommissionManager.transferOwnership (starts two-step handoff)
+///          → Bridge.transferOwnership (starts two-step handoff)
+///          → RouteRegistry.transferOwnership (starts two-step handoff)
 ///
 /// Ownership is Ownable2Step: the transferOwnership calls only set
 /// pendingOwner = MultisigProxy. The federation MUST accept post-deploy via
@@ -40,7 +43,7 @@ import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.so
 ///
 /// Env (required):
 ///   PRIVATE_KEY, USDT0_ADDRESS, BTC_RELAY_ADDRESS,
-///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD,
+///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD, INITIAL_ENCLAVE_SOURCE_CHAIN_ID,
 ///   FEDERATION_SIGNERS, FEDERATION_THRESHOLD,
 ///   COMMISSION_RECIPIENT, TIMELOCK_DURATION, MIN_TIMELOCK,
 ///   MIN_FUNDS_IN_AMOUNT
@@ -51,6 +54,23 @@ import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.so
 ///                       are live the moment the proxy takes over).
 ///   ETH_USD_HEARTBEAT — Seconds before the feed answer is considered stale.
 ///                       Required when ETH_USD_FEED is provided.
+///   MIN_SOURCE_CONFIRMATIONS (6) — RGBVerifier: min depth of the source
+///                       (RGB burn/lock) block.
+///   MAX_LATEST_CONFIRMATIONS (1) — RGBVerifier: max depth of the latest
+///                       (freshness) block; must be >= 1.
+///   MIN_CONFIRMATION_GAP     (5) — RGBVerifier: min depth gap between the
+///                       source and latest blocks.
+///   SEQUENCER_UPTIME_FEED — (Arbitrum, R-I-14) Chainlink L2 Sequencer Uptime
+///                       feed. When set, NATIVE quotes reject prices during
+///                       sequencer downtime and the post-restart grace period.
+///                       SHOULD be set on Arbitrum when NATIVE commission is used.
+///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — (R-I-14) optional ETH/USD sanity
+///                       band in feed decimals (e.g. 100e8 / 100000e8). Set both
+///                       or neither; else 0 < min < max.
+///   REQUIRE_CHAINLINK_HARDENING (false) — when true, the deploy reverts unless
+///                       ETH_USD_FEED, SEQUENCER_UPTIME_FEED, and the price band
+///                       are all set. Recommended for Arbitrum production so the
+///                       R-I-14 guards can never be silently absent.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployAll.s.sol \
@@ -73,6 +93,7 @@ contract DeployAll is Script {
         address btcRelay       = vm.envAddress('BTC_RELAY_ADDRESS');
         address[] memory enc   = vm.envAddress('ENCLAVE_SIGNERS', ',');
         uint256 encThr         = vm.envUint('ENCLAVE_THRESHOLD');
+        uint256 initialSrcChain = vm.envUint('INITIAL_ENCLAVE_SOURCE_CHAIN_ID');
         address[] memory fed   = vm.envAddress('FEDERATION_SIGNERS', ',');
         uint256 fedThr         = vm.envUint('FEDERATION_THRESHOLD');
         address commission     = vm.envAddress('COMMISSION_RECIPIENT');
@@ -81,6 +102,27 @@ contract DeployAll is Script {
         address ethUsdFeed     = vm.envOr('ETH_USD_FEED', address(0));
         uint256 ethUsdHb       = vm.envOr('ETH_USD_HEARTBEAT', uint256(0));
         uint256 minFundsIn     = vm.envUint('MIN_FUNDS_IN_AMOUNT');
+        uint256 minSourceConf  = vm.envOr('MIN_SOURCE_CONFIRMATIONS', uint256(6));
+        uint256 maxLatestConf  = vm.envOr('MAX_LATEST_CONFIRMATIONS', uint256(1));
+        uint256 minConfGap     = vm.envOr('MIN_CONFIRMATION_GAP',     uint256(5));
+        address seqFeed        = vm.envOr('SEQUENCER_UPTIME_FEED', address(0));
+        uint256 ethUsdMinPrice = vm.envOr('ETH_USD_MIN_PRICE', uint256(0));
+        uint256 ethUsdMaxPrice = vm.envOr('ETH_USD_MAX_PRICE', uint256(0));
+        bool    reqHardening   = vm.envOr('REQUIRE_CHAINLINK_HARDENING', false);
+
+        // ---- 1a. Misconfiguration checks (fail-fast, before any broadcast) ---
+        // Price band is all-or-nothing: a half-set band would otherwise be
+        // silently ignored (setter only runs when max != 0).
+        require((ethUsdMinPrice == 0) == (ethUsdMaxPrice == 0),
+            'set both ETH_USD_MIN_PRICE and ETH_USD_MAX_PRICE, or neither');
+        // Opt-in prod guard (set REQUIRE_CHAINLINK_HARDENING=true for Arbitrum):
+        // when NATIVE commission is enabled, the sequencer feed and price band
+        // must be wired too, so the R-I-14 protections are not silently absent.
+        if (reqHardening) {
+            require(ethUsdFeed != address(0), 'hardening: ETH_USD_FEED must be set');
+            require(seqFeed != address(0),    'hardening: SEQUENCER_UPTIME_FEED must be set');
+            require(ethUsdMaxPrice != 0,      'hardening: ETH_USD_MIN/MAX_PRICE must be set');
+        }
 
         address deployer    = vm.addr(pk);
         uint64  startNonce  = vm.getNonce(deployer);
@@ -108,14 +150,14 @@ contract DeployAll is Script {
         );
 
         // ---- 5. Route plugins (nonce n+3, n+4) ---------------------------
-        rgbVerifier = new RGBVerifier(btcRelay);
+        rgbVerifier = new RGBVerifier(btcRelay, minSourceConf, maxLatestConf, minConfGap);
         rgbModule   = new RgbSettlementModule(address(routeRegistry));
 
         // ---- 6. MultisigProxy (nonce n+5) --------------------------------
         proxy = new MultisigProxy(
             address(bridge),
             address(cm),
-            enc, encThr,
+            enc, encThr, initialSrcChain,
             fed, fedThr,
             commission,
             timelock,
@@ -126,6 +168,17 @@ contract DeployAll is Script {
         if (ethUsdFeed != address(0)) {
             require(ethUsdHb != 0, 'ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided');
             cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
+        }
+
+        // ---- 7b. Wire optional R-I-14 Arbitrum hardening (owner-only, before
+        //          the ownership transfer): the L2 sequencer-uptime feed and the
+        //          ETH/USD sanity band. On Arbitrum these SHOULD be set whenever
+        //          the NATIVE commission path (ETH_USD_FEED) is used.
+        if (seqFeed != address(0)) {
+            cm.setSequencerUptimeFeed(seqFeed);
+        }
+        if (ethUsdMaxPrice != 0) {
+            cm.setEthUsdPriceBounds(ethUsdMinPrice, ethUsdMaxPrice);
         }
 
         // ---- 8. Start two-step ownership handover to federation ----------
@@ -144,6 +197,9 @@ contract DeployAll is Script {
         console2.log('RouteRegistry deployed at:      ', address(routeRegistry));
         console2.log('Bridge deployed at:             ', address(bridge));
         console2.log('RGBVerifier deployed at:        ', address(rgbVerifier));
+        console2.log('  minSourceConfirmations:       ', rgbVerifier.minSourceConfirmations());
+        console2.log('  maxLatestConfirmations:       ', rgbVerifier.maxLatestConfirmations());
+        console2.log('  minConfirmationGap:           ', rgbVerifier.minConfirmationGap());
         console2.log('RgbSettlementModule deployed at:', address(rgbModule));
         console2.log('MultisigProxy deployed at:      ', address(proxy));
         if (ethUsdFeed != address(0)) {
@@ -151,6 +207,15 @@ contract DeployAll is Script {
             console2.log('ETH/USD heartbeat (s):          ', ethUsdHb);
         } else {
             console2.log('ETH/USD feed:                   ', 'UNSET (NATIVE quotes will revert until governance wires one)');
+        }
+        if (seqFeed != address(0)) {
+            console2.log('Sequencer uptime feed wired:    ', seqFeed);
+        } else {
+            console2.log('Sequencer uptime feed:          ', 'UNSET (set on Arbitrum when NATIVE commission is used)');
+        }
+        if (ethUsdMaxPrice != 0) {
+            console2.log('ETH/USD price band min:         ', ethUsdMinPrice);
+            console2.log('ETH/USD price band max:         ', ethUsdMaxPrice);
         }
 
         // ---- 10. Invariant checks ---------------------------------------
@@ -170,6 +235,13 @@ contract DeployAll is Script {
         if (ethUsdFeed != address(0)) {
             require(cm.ethUsdFeed() == ethUsdFeed,          'CM.ethUsdFeed mismatch');
             require(cm.ethUsdHeartbeat() == ethUsdHb,       'CM.ethUsdHeartbeat mismatch');
+        }
+        if (seqFeed != address(0)) {
+            require(cm.sequencerUptimeFeed() == seqFeed,    'CM.sequencerUptimeFeed mismatch');
+        }
+        if (ethUsdMaxPrice != 0) {
+            require(cm.ethUsdMinPrice() == ethUsdMinPrice && cm.ethUsdMaxPrice() == ethUsdMaxPrice,
+                'CM.ethUsdPriceBounds mismatch');
         }
 
         // ---- 11. Post-deploy reminder -----------------------------------

--- a/ethereum/script/deploy/DeployCommissionManager.s.sol
+++ b/ethereum/script/deploy/DeployCommissionManager.s.sol
@@ -21,6 +21,14 @@ import { CommissionManager } from '../../src/CommissionManager.sol';
 ///                       the feed answer is considered stale. Arbitrum One
 ///                       ETH/USD heartbeats at 86400 s — use ~87000 with a
 ///                       small buffer.
+///   SEQUENCER_UPTIME_FEED — Optional (Arbitrum, R-I-14) Chainlink L2 Sequencer
+///                       Uptime feed. When set, NATIVE quotes reject prices
+///                       during sequencer downtime + the post-restart grace.
+///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — Optional (R-I-14) ETH/USD sanity
+///                       band in feed decimals; set both or neither.
+///   REQUIRE_CHAINLINK_HARDENING (false) — when true, revert unless ETH_USD_FEED,
+///                       SEQUENCER_UPTIME_FEED, and the price band are all set
+///                       (recommended for Arbitrum production).
 ///
 /// Usage:
 ///   forge script script/deploy/DeployCommissionManager.s.sol \
@@ -31,12 +39,34 @@ contract DeployCommissionManager is Script {
         address bridgeAddress = vm.envAddress('BRIDGE_ADDRESS');
         address ethUsdFeed    = vm.envOr('ETH_USD_FEED', address(0));
         uint256 ethUsdHb      = vm.envOr('ETH_USD_HEARTBEAT', uint256(0));
+        address seqFeed        = vm.envOr('SEQUENCER_UPTIME_FEED', address(0));
+        uint256 ethUsdMinPrice = vm.envOr('ETH_USD_MIN_PRICE', uint256(0));
+        uint256 ethUsdMaxPrice = vm.envOr('ETH_USD_MAX_PRICE', uint256(0));
+        bool    reqHardening   = vm.envOr('REQUIRE_CHAINLINK_HARDENING', false);
+
+        // Misconfiguration checks (fail-fast, before broadcast). Price band is
+        // all-or-nothing (a half-set band would be silently ignored). The opt-in
+        // prod guard enforces the full R-I-14 config when NATIVE is enabled.
+        require((ethUsdMinPrice == 0) == (ethUsdMaxPrice == 0),
+            'set both ETH_USD_MIN_PRICE and ETH_USD_MAX_PRICE, or neither');
+        if (reqHardening) {
+            require(ethUsdFeed != address(0), 'hardening: ETH_USD_FEED must be set');
+            require(seqFeed != address(0),    'hardening: SEQUENCER_UPTIME_FEED must be set');
+            require(ethUsdMaxPrice != 0,      'hardening: ETH_USD_MIN/MAX_PRICE must be set');
+        }
 
         vm.startBroadcast(pk);
         cm = new CommissionManager(bridgeAddress);
         if (ethUsdFeed != address(0)) {
             require(ethUsdHb != 0, 'ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided');
             cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
+        }
+        // R-I-14 Arbitrum hardening (owner-only; deployer is owner here).
+        if (seqFeed != address(0)) {
+            cm.setSequencerUptimeFeed(seqFeed);
+        }
+        if (ethUsdMaxPrice != 0) {
+            cm.setEthUsdPriceBounds(ethUsdMinPrice, ethUsdMaxPrice);
         }
         vm.stopBroadcast();
 
@@ -48,6 +78,13 @@ contract DeployCommissionManager is Script {
             console2.log('ETH/USD heartbeat (s):        ', ethUsdHb);
         } else {
             console2.log('ETH/USD feed:                 ', 'UNSET (NATIVE quotes will revert until configured)');
+        }
+        if (seqFeed != address(0)) {
+            console2.log('Sequencer uptime feed wired:  ', seqFeed);
+        }
+        if (ethUsdMaxPrice != 0) {
+            console2.log('ETH/USD price band min:       ', ethUsdMinPrice);
+            console2.log('ETH/USD price band max:       ', ethUsdMaxPrice);
         }
     }
 }

--- a/ethereum/script/deploy/DeployMultisigProxy.s.sol
+++ b/ethereum/script/deploy/DeployMultisigProxy.s.sol
@@ -14,6 +14,7 @@ import { MultisigProxy } from '../../src/MultisigProxy.sol';
 ///   COMMISSION_MANAGER    — existing CommissionManager deployment
 ///   ENCLAVE_SIGNERS       — comma-separated TEE signer addresses
 ///   ENCLAVE_THRESHOLD     — M for enclave M-of-N
+///   INITIAL_ENCLAVE_SOURCE_CHAIN_ID — source chain id the initial enclave set authorises (non-zero)
 ///   FEDERATION_SIGNERS    — comma-separated governance signer addresses
 ///   FEDERATION_THRESHOLD  — M for federation M-of-N
 ///   COMMISSION_RECIPIENT  — destination for commission withdrawals
@@ -30,6 +31,7 @@ contract DeployMultisigProxy is Script {
         address commissionManager  = vm.envAddress('COMMISSION_MANAGER');
         address[] memory enc       = vm.envAddress('ENCLAVE_SIGNERS', ',');
         uint256 encThr             = vm.envUint('ENCLAVE_THRESHOLD');
+        uint256 initialSrcChain    = vm.envUint('INITIAL_ENCLAVE_SOURCE_CHAIN_ID');
         address[] memory fed       = vm.envAddress('FEDERATION_SIGNERS', ',');
         uint256 fedThr             = vm.envUint('FEDERATION_THRESHOLD');
         address commission         = vm.envAddress('COMMISSION_RECIPIENT');
@@ -40,7 +42,7 @@ contract DeployMultisigProxy is Script {
         proxy = new MultisigProxy(
             bridgeAddr,
             commissionManager,
-            enc, encThr,
+            enc, encThr, initialSrcChain,
             fed, fedThr,
             commission,
             timelock,
@@ -51,7 +53,8 @@ contract DeployMultisigProxy is Script {
         console2.log('MultisigProxy deployed at:', address(proxy));
         console2.log('Bridge:                   ', proxy.bridge());
         console2.log('CommissionManager:        ', proxy.commissionManager());
-        console2.log('Enclave threshold:        ', proxy.enclaveThreshold());
+        console2.log('Initial enclave srcChain: ', initialSrcChain);
+        console2.log('Enclave threshold:        ', proxy.enclaveThreshold(initialSrcChain));
         console2.log('Federation threshold:     ', proxy.federationThreshold());
         console2.log('Commission recipient:     ', proxy.commissionRecipient());
         console2.log('Timelock duration (sec):  ', proxy.timelockDuration());

--- a/ethereum/script/deploy/DeployRGBVerifier.s.sol
+++ b/ethereum/script/deploy/DeployRGBVerifier.s.sol
@@ -7,27 +7,38 @@ import { RGBVerifier } from '../../src/verifiers/RGBVerifier.sol';
 /// @title DeployRGBVerifier
 /// @notice Deploys the RGB-route finality verifier (thin wrapper around the
 ///         Atomiq `IBtcRelayView` SPV header relay). The verifier is
-///         stateless apart from the immutable `btcRelay` reference; rotation
-///         = redeploy + federation `proposeSetRoute` pointing the RGB route
-///         at the new verifier.
+///         stateless apart from its immutable config (`btcRelay` plus the
+///         confirmation-depth thresholds); retuning = redeploy + federation
+///         `proposeSetRoute` pointing the RGB route at the new verifier.
 ///
-/// Env:
+/// Env (required):
 ///   PRIVATE_KEY        — deployer private key
 ///   BTC_RELAY_ADDRESS  — deployed `IBtcRelayView` instance
+///
+/// Env (optional, confirmation-depth thresholds; defaults in parens):
+///   MIN_SOURCE_CONFIRMATIONS (6) — min depth of the source (RGB burn/lock) block
+///   MAX_LATEST_CONFIRMATIONS (1) — max depth of the latest (freshness) block; must be >= 1
+///   MIN_CONFIRMATION_GAP     (5) — min depth gap between source and latest
 ///
 /// Usage:
 ///   forge script script/deploy/DeployRGBVerifier.s.sol \
 ///     --rpc-url $RPC_URL --broadcast --verify
 contract DeployRGBVerifier is Script {
     function run() external returns (RGBVerifier verifier) {
-        uint256 pk       = vm.envUint('PRIVATE_KEY');
-        address btcRelay = vm.envAddress('BTC_RELAY_ADDRESS');
+        uint256 pk        = vm.envUint('PRIVATE_KEY');
+        address btcRelay  = vm.envAddress('BTC_RELAY_ADDRESS');
+        uint256 minSource = vm.envOr('MIN_SOURCE_CONFIRMATIONS', uint256(6));
+        uint256 maxLatest = vm.envOr('MAX_LATEST_CONFIRMATIONS', uint256(1));
+        uint256 minGap    = vm.envOr('MIN_CONFIRMATION_GAP',     uint256(5));
 
         vm.startBroadcast(pk);
-        verifier = new RGBVerifier(btcRelay);
+        verifier = new RGBVerifier(btcRelay, minSource, maxLatest, minGap);
         vm.stopBroadcast();
 
-        console2.log('RGBVerifier deployed at:', address(verifier));
-        console2.log('BtcRelay (immutable):   ', verifier.btcRelay());
+        console2.log('RGBVerifier deployed at:   ', address(verifier));
+        console2.log('BtcRelay (immutable):      ', verifier.btcRelay());
+        console2.log('minSourceConfirmations:    ', verifier.minSourceConfirmations());
+        console2.log('maxLatestConfirmations:    ', verifier.maxLatestConfirmations());
+        console2.log('minConfirmationGap:        ', verifier.minConfirmationGap());
     }
 }

--- a/ethereum/script/interact/BridgeFundsIn.s.sol
+++ b/ethereum/script/interact/BridgeFundsIn.s.sol
@@ -13,9 +13,14 @@ import { ICommissionManager } from '../../src/interfaces/ICommissionManager.sol'
 ///         `block.chainid` by the Bridge — the script just reads it back to
 ///         drive the quote.
 ///
+///         The canonical `operationId` is derived on-chain by the Bridge and
+///         returned; this script logs it. The RGB route carries the RGB OpId
+///         in `settlementData` (`abi.encode(uint256 rgbOpId)`), sourced from
+///         `RGB_OP_ID`.
+///
 /// Env:
 ///   PRIVATE_KEY, BRIDGE_ADDRESS, AMOUNT (wei),
-///   DESTINATION_CHAIN_ID, DESTINATION_ADDRESS, OPERATION_ID
+///   DESTINATION_CHAIN_ID, DESTINATION_ADDRESS, RGB_OP_ID
 contract BridgeFundsIn is Script {
     function run() external {
         uint256 pk            = vm.envUint('PRIVATE_KEY');
@@ -23,7 +28,7 @@ contract BridgeFundsIn is Script {
         uint256 amount        = vm.envUint('AMOUNT');
         uint256 destChainId   = vm.envUint('DESTINATION_CHAIN_ID');
         string memory dAddr   = vm.envString('DESTINATION_ADDRESS');
-        uint256 operationId   = vm.envUint('OPERATION_ID');
+        uint256 rgbOpId       = vm.envUint('RGB_OP_ID');
 
         Bridge bridge = Bridge(bridgeAddr);
         address token = bridge.TOKEN();
@@ -40,12 +45,16 @@ contract BridgeFundsIn is Script {
 
         vm.startBroadcast(pk);
         IERC20(token).approve(bridgeAddr, amount);
-        // `settlementData` is empty for the RGB route — its settlement
-        // module ignores inbound data. Other routes whose modules consume
-        // extra data on `onFundsIn` would need to source the blob from env.
-        bridge.fundsIn{ value: nativeCommission }(amount, destChainId, dAddr, operationId, '');
+        // RGB route: `settlementData` carries the RGB OpId as `abi.encode(uint256)`;
+        // the settlement module decodes it and surfaces it in the FundsIn event.
+        // Other routes define their own blob layout.
+        bytes32 operationId = bridge.fundsIn{ value: nativeCommission }(
+            amount, destChainId, dAddr, abi.encode(rgbOpId)
+        );
         vm.stopBroadcast();
 
-        console2.log('fundsIn succeeded. Bridge balance:', IERC20(token).balanceOf(bridgeAddr));
+        console2.log('fundsIn succeeded. Derived operationId:');
+        console2.logBytes32(operationId);
+        console2.log('Bridge balance:', IERC20(token).balanceOf(bridgeAddr));
     }
 }

--- a/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
+++ b/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
@@ -56,7 +56,7 @@ contract MultisigExecuteFundsOut is Script {
 
         IBridge.FundsOutParams memory params = _loadParams();
 
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(params.sourceChainId);
         uint256 deadline = block.timestamp + vm.envUint('DEADLINE_OFFSET');
         uint256 bitmap   = vm.envUint('ENCLAVE_BITMAP');
 
@@ -73,6 +73,6 @@ contract MultisigExecuteFundsOut is Script {
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
         vm.stopBroadcast();
 
-        console2.log('fundsOutCall() succeeded. New nonce:', proxy.teeNonce());
+        console2.log('fundsOutCall() succeeded. New nonce:', proxy.teeNonce(params.sourceChainId));
     }
 }

--- a/ethereum/src/BaseBridge.sol
+++ b/ethereum/src/BaseBridge.sol
@@ -19,6 +19,16 @@ contract BaseBridge is BridgeBase {
     // Events
     // =========================================================================
 
+    /// @notice Emitted on every fundsIn.
+    /// @param sender      Address that deposited the tokens.
+    /// @param operationId Backend-assigned operation identifier.
+    /// @param amount      Amount of tokens locked.
+    event FundsIn(
+        address indexed sender,
+        uint256 indexed operationId,
+        uint256 amount
+    );
+
     /// @notice Emitted when tokens are released from the bridge.
     /// @param recipient       Recipient on this chain.
     /// @param amount          Amount of tokens released.

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -19,12 +19,12 @@ import { OutflowRateLimiter } from './libraries/OutflowRateLimiter.sol';
 ///         protocol fees are held separately from bridge liquidity.
 ///
 /// @dev - Owner is `MultisigProxy`. `fundsOut` is called via
-///        `MultisigProxy.execute()` (TEE M-of-N).
+///        `MultisigProxy.fundsOutCall()` (TEE M-of-N).
 ///      - Route-specific finality verification and per-route settlement
 ///        accounting (RGB `fundsInRecords` etc.) live behind the
 ///        `RouteRegistry` dispatcher in dedicated plugin contracts. Bridge
-///        only owns: token custody, the common `burnId` replay guard, and
-///        commission routing.
+///        only owns: token custody, the common derived `burnId` replay guard,
+///        and commission routing.
 ///      - `fundsIn` has two overloads:
 ///        • Public 5-arg: any EVM user on this chain can lock tokens; the
 ///          source chain id is filled with `block.chainid`.
@@ -57,6 +57,23 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     ///         inclusion proof stays well under this).
     uint256 public constant MAX_PROOF_LENGTH = 1024;
 
+    /// @notice Domain-separated type hash for the on-chain `operationId`
+    ///         derivation. Binds the id to this contract, the deposit context
+    ///         and a formula version, so ids cannot collide across deployments
+    ///         or a future formula revision. Not an EIP-712 signing digest —
+    ///         it is an internal, unsigned domain separator for the id hash.
+    bytes32 public constant FUNDS_IN_OPERATION_TYPEHASH = keccak256(
+        'UtexoFundsInOperation(address bridge,uint256 sourceChainId,bytes32 sourceSender,uint256 senderNonce,address token,uint256 grossAmount,uint256 destinationChainId,bytes32 destinationAddressHash,bytes32 settlementDataHash,uint256 chainId)'
+    );
+
+    /// @notice Domain-separated type hash for the `fundsOut` replay key.
+    ///         Binds common release intent fields to this Bridge deployment and
+    ///         formula version, including the exact verifier proof the enclave
+    ///         signed for the release.
+    bytes32 public constant FUNDS_OUT_BURN_ID_TYPEHASH = keccak256(
+        'UtexoFundsOutBurnId(address bridge,uint256 chainId,address token,address recipient,uint256 amount,uint256 sourceChainId,uint256 destinationChainId,bytes32 sourceAddressHash,bytes32 proofHash,bytes32 settlementDataHash)'
+    );
+
     /// @notice CommissionManager that receives and custodies protocol fees.
     ICommissionManager public immutable commissionManager;
 
@@ -69,9 +86,16 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     /// @inheritdoc IBridge
     address public override lzAdapter;
 
-    /// @notice Set of burn identifiers already consumed by a successful
-    ///         `fundsOut`.
+    /// @notice Set of Bridge-derived burn identifiers already consumed by a
+    ///         successful `fundsOut`.
     mapping(uint256 burnId => bool consumed) public consumedBurnIds;
+
+    /// @notice Per-`(sourceChainId, sourceSender)` monotonic nonce. Folded into
+    ///         `operationId` so two otherwise-identical deposits from the same
+    ///         sender still produce distinct ids. Incremented once per successful
+    ///         `fundsIn`; a downstream revert rolls the increment back.
+    mapping(uint256 sourceChainId => mapping(bytes32 sourceSender => uint256 nonce))
+        public sourceSenderNonces;
 
     /// @notice Isolated liquidity per non-Arbitrum chain. Tracks the
     ///         net token amount locked on this chain on behalf of a given
@@ -235,16 +259,17 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         uint256 amount,
         uint256 destinationChainId,
         string  calldata destinationAddress,
-        uint256 operationId,
         bytes   calldata settlementData
-    ) external payable override whenNotPaused nonReentrant {
-        _fundsIn(
-            _msgSender(),
+    ) external payable override whenNotPaused nonReentrant returns (bytes32 operationId) {
+        // Direct EVM deposit: the source sender IS the caller.
+        address caller = _msgSender();
+        operationId = _fundsIn(
+            caller,
+            _toSourceSender(caller),
             amount,
             block.chainid,
             destinationChainId,
             destinationAddress,
-            operationId,
             settlementData
         );
     }
@@ -253,18 +278,21 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     function fundsIn(
         uint256 amount,
         uint256 sourceChainId,
+        bytes32 sourceSender,
         uint256 destinationChainId,
         string  calldata destinationAddress,
-        uint256 operationId,
         bytes   calldata settlementData
-    ) external payable override whenNotPaused nonReentrant onlyLZAdapter {
-        _fundsIn(
+    ) external payable override whenNotPaused nonReentrant onlyLZAdapter returns (bytes32 operationId) {
+        // LZ deposit: tokens are pulled from the adapter (`_msgSender()`), but
+        // the identity bound into `operationId` is the authenticated
+        // `sourceSender` forwarded from the source-chain entrypoint.
+        operationId = _fundsIn(
             _msgSender(),
+            sourceSender,
             amount,
             sourceChainId,
             destinationChainId,
             destinationAddress,
-            operationId,
             settlementData
         );
     }
@@ -281,15 +309,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         nonReentrant
         whenOutflowNotPaused
     {
-        if (fundsOutParams.amount             == 0)                       revert ZeroAmount();
-        if (fundsOutParams.recipient          == address(0))              revert InvalidRecipientAddress();
-        if (fundsOutParams.sourceChainId      == 0)                       revert InvalidSourceChainId();
-        if (fundsOutParams.destinationChainId == 0)                       revert InvalidDestinationChainId();
-        if (bytes(fundsOutParams.sourceAddress).length > MAX_ADDRESS_LENGTH) {
-            revert AddressTooLong(bytes(fundsOutParams.sourceAddress).length, MAX_ADDRESS_LENGTH);
-        }
-        if (fundsOutParams.proof.length > MAX_PROOF_LENGTH) revert ProofTooLong(fundsOutParams.proof.length, MAX_PROOF_LENGTH);
-        if (fundsOutParams.amount > IERC20(TOKEN).balanceOf(address(this))) revert AmountExceedBridgePool();
+        _validateFundsOutParams(fundsOutParams);
 
         // Common replay guard. Set the flag before any external interaction
         // so a revert anywhere downstream rolls the mark back with the rest
@@ -351,10 +371,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         );
 
         // Forward token commission to the CommissionManager pool.
-        if (tokenCommission != 0) {
-            IERC20(TOKEN).safeTransfer(address(commissionManager), tokenCommission);
-            commissionManager.receiveTokenCommission(TOKEN);
-        }
+        if (tokenCommission != 0) _forwardTokenCommission(tokenCommission);
 
         // Deliver the net amount to the recipient.
         IERC20(TOKEN).safeTransfer(fundsOutParams.recipient, netAmount);
@@ -385,6 +402,23 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     // Internal
     // =========================================================================
 
+    function _validateFundsOutParams(FundsOutParams calldata params) private view {
+        if (params.amount             == 0)          revert ZeroAmount();
+        if (params.recipient          == address(0)) revert InvalidRecipientAddress();
+        if (params.sourceChainId      == 0)          revert InvalidSourceChainId();
+        if (params.destinationChainId == 0)          revert InvalidDestinationChainId();
+
+        uint256 sourceAddressLength = bytes(params.sourceAddress).length;
+        if (sourceAddressLength > MAX_ADDRESS_LENGTH) {
+            revert AddressTooLong(sourceAddressLength, MAX_ADDRESS_LENGTH);
+        }
+        if (params.proof.length > MAX_PROOF_LENGTH) revert ProofTooLong(params.proof.length, MAX_PROOF_LENGTH);
+        if (params.amount > IERC20(TOKEN).balanceOf(address(this))) revert AmountExceedBridgePool();
+
+        uint256 expectedBurnId = _deriveBurnId(params);
+        if (params.burnId != expectedBurnId) revert InvalidBurnId(params.burnId, expectedBurnId);
+    }
+
     /// @dev Build an enabled outflow-limit config from uint256 inputs, safely
     ///      narrowing to the library's uint128 fields. USDT0 amounts fit in
     ///      uint128; a value above that is a misconfiguration and reverts.
@@ -404,16 +438,19 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         });
     }
 
-    /// @dev Shared body for both `fundsIn` overloads.
+    /// @dev Shared body for both `fundsIn` overloads. Derives the canonical
+    ///      `operationId` on-chain (never caller-supplied) and returns it.
+    /// @param from         EVM caller tokens are pulled from (user, or adapter).
+    /// @param sourceSender Original source-chain sender bound into `operationId`.
     function _fundsIn(
         address          from,
+        bytes32          sourceSender,
         uint256          amount,
         uint256          sourceChainId,
         uint256          destinationChainId,
         string  memory   destinationAddress,
-        uint256          operationId,
         bytes   calldata settlementData
-    ) private {
+    ) private returns (bytes32 operationId) {
         if (amount < minFundsInAmount)             revert AmountBelowMinimum(amount, minFundsInAmount);
         if (bytes(destinationAddress).length == 0) revert InvalidDestinationAddress();
         if (bytes(destinationAddress).length > MAX_ADDRESS_LENGTH) {
@@ -422,66 +459,219 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (sourceChainId      == 0)               revert InvalidSourceChainId();
         if (destinationChainId == 0)               revert InvalidDestinationChainId();
 
-        (
-            uint256 tokenCommission,
-            uint256 nativeCommission,
-            uint256 netAmount
-        ) = commissionManager.calculateFundsInCommission(
-            sourceChainId,
-            destinationChainId,
-            TOKEN,
-            amount
-        );
+        // Commission is quoted from the nominal `amount` so the native-commission
+        // quote (and the lower-bound `msg.value` check below) stays predictable
+        // for the caller. The nominal net is intentionally discarded — the
+        // credited net is derived from the ACTUAL received amount after the transfer.
+        (uint256 tokenCommission, uint256 nativeCommission, ) =
+            commissionManager.calculateFundsInCommission(
+                sourceChainId,
+                destinationChainId,
+                TOKEN,
+                amount
+            );
 
-        // Native payment must match the quote exactly (includes the zero-native case).
-        if (msg.value != nativeCommission) revert NativeValueMismatch();
+        // Native payment: require at least the freshly-quoted commission
+        // — an oracle move up between quote and execution reverts here. Any
+        // overpayment from a favorable move is collected as commission below
+        // (not refunded), so the rule is uniform for direct and LZ deposits.
+        // TOKEN-commission routes (nativeCommission == 0) accept no native.
+        if (msg.value < nativeCommission) revert NativeValueMismatch();
+        if (nativeCommission == 0 && msg.value != 0) revert NativeValueMismatch();
 
-        // Pull the full gross amount from `from` into this contract.
+        // Build the canonical context. The per-`(sourceChainId, sourceSender)`
+        // nonce is consumed here — before any external call, so a downstream
+        // revert rolls it back — and folded, with the deposit context, into the
+        // on-chain-derived operationId. Because the id binds the authenticated
+        // `sourceSender` and an incrementing nonce, a third party cannot predict
+        // or pre-empt it. Held in memory to keep the stack shallow.
+        FundsInContext memory ctx = FundsInContext({
+            token:         TOKEN,
+            sender:        from,
+            sourceSender:  sourceSender,
+            grossAmount:   amount,
+            netAmount:     0, // set below from the ACTUAL received amount
+            operationId:   bytes32(0), // filled in on the next line
+            senderNonce:   sourceSenderNonces[sourceChainId][sourceSender]++,
+            sourceChainId: sourceChainId,
+            destChainId:   destinationChainId,
+            destAddress:   destinationAddress
+        });
+        // operationId binds grossAmount (not netAmount), so it is stable
+        // regardless of any token transfer fee.
+        ctx.operationId = _deriveOperationId(ctx, settlementData);
+
+        // Pull the gross amount and measure what ACTUALLY arrived. A
+        // fee-on-transfer token can deliver less than `amount`; crediting the
+        // nominal amount would overstate custody and could brick release of the
+        // recorded balance. Everything downstream — records, isolated
+        // liquidity, event — is built from `received`, never from `amount`.
+        uint256 balanceBefore = IERC20(TOKEN).balanceOf(address(this));
         IERC20(TOKEN).safeTransferFrom(from, address(this), amount);
+        uint256 received = IERC20(TOKEN).balanceOf(address(this)) - balanceBefore;
 
-        // Delegate per-route inbound bookkeeping.
-        IRouteRegistry(routeRegistry).onFundsIn(
-            FundsInContext({
-                token:         TOKEN,
-                sender:        from,
-                grossAmount:   amount,
-                netAmount:     netAmount,
-                operationId:   operationId,
-                sourceChainId: sourceChainId,
-                destChainId:   destinationChainId,
-                destAddress:   destinationAddress
-            }),
-            settlementData
-        );
+        // The token commission is forwarded out of `received`; guard the
+        // subtraction so a token fee that eats more than the commission reverts
+        // cleanly instead of underflowing. A zero net (received == commission) is
+        // left to the existing zero-amount / dust handling, unchanged here.
+        if (received < tokenCommission) revert InsufficientReceived(received, tokenCommission);
+        ctx.netAmount = received - tokenCommission;
+
+        // Forward token commission BEFORE the settlement hook so that any
+        // external call the hook makes (or a contract reading `getContractBalance`
+        // during it) observes only the net amount the Bridge actually retains,
+        // never the in-flight commission about to leave. `netAmount` is
+        // already fixed above, so the hook does not depend on the tokens still
+        // being held here.
+        if (tokenCommission != 0) _forwardTokenCommission(tokenCommission);
+
+        // Delegate per-route inbound bookkeeping. The module returns an optional
+        // correlation id (the RGB OpId for the RGB route; 0 otherwise) to surface
+        // in the RGB-only `FundsIn` event below.
+        uint256 rgbOpId = IRouteRegistry(routeRegistry).onFundsIn(ctx, settlementData);
 
         // Isolated liquidity: credit the net deposit to its destination
         // chain's bucket. A later `fundsOut` from that chain can release at most
-        // the accumulated locked liquidity.
-        lockedLiquidity[destinationChainId] += netAmount;
+        // the accumulated locked liquidity. Credited from the ACTUAL received
+        // amount so the ledger can never exceed real custody.
+        lockedLiquidity[destinationChainId] += ctx.netAmount;
 
-        // Forward token commission, if any, to the CommissionManager pool.
-        if (tokenCommission != 0) {
-            IERC20(TOKEN).safeTransfer(address(commissionManager), tokenCommission);
-            commissionManager.receiveTokenCommission(TOKEN);
-        }
-
-        // Forward native commission, if any, to the CommissionManager pool.
-        if (nativeCommission != 0) {
-            (bool ok, ) = address(commissionManager).call{ value: nativeCommission }('');
+        // Forward the FULL native value to the CommissionManager pool. Any
+        // surplus over the quoted `nativeCommission` (favorable oracle drift) is
+        // collected as commission rather than refunded, so no native is
+        // ever left stranded in the Bridge.
+        if (msg.value != 0) {
+            (bool ok, ) = address(commissionManager).call{ value: msg.value }('');
             if (!ok) revert NativeValueMismatch();
         }
 
-        emit FundsIn(from, operationId, netAmount);
+        // RGB-only correlation event: emitted only when the route module
+        // returned a non-zero external id (the RGB OpId). Other routes skip it.
+        if (rgbOpId != 0) emit FundsIn(ctx.sender, rgbOpId, ctx.netAmount);
         emit BridgeFundsIn(
-            from,
-            operationId,
-            amount,
-            netAmount,
+            ctx.operationId,
+            ctx.sourceSender,
+            ctx.sender,
+            ctx.senderNonce,
+            ctx.grossAmount,
+            ctx.netAmount,
             tokenCommission,
-            nativeCommission,
-            sourceChainId,
-            destinationChainId,
-            destinationAddress
+            msg.value, // actual native collected (== nativeCommission + any drift surplus)
+            ctx.sourceChainId,
+            ctx.destChainId,
+            ctx.destAddress
         );
+
+        operationId = ctx.operationId;
+    }
+
+    /// @dev Left-pads an EVM address into the `bytes32` source-sender encoding
+    ///      used by `operationId` derivation and the LZ overload.
+    function _toSourceSender(address account) private pure returns (bytes32) {
+        return bytes32(uint256(uint160(account)));
+    }
+
+    /// @dev Transfer `amount` of TOKEN to the CommissionManager and credit the
+    ///      commission pool by the ACTUAL balance increase this transfer caused.
+    ///      Measuring the delta here (rather than in CM from `balanceOf - pool`)
+    ///      keeps the credit fee-on-transfer safe and prevents any pre-existing /
+    ///      unsolicited direct transfer to CM from being absorbed as commission.
+    function _forwardTokenCommission(uint256 amount) private {
+        address cm = address(commissionManager);
+        uint256 balBefore = IERC20(TOKEN).balanceOf(cm);
+        IERC20(TOKEN).safeTransfer(cm, amount);
+        uint256 credited = IERC20(TOKEN).balanceOf(cm) - balBefore;
+        commissionManager.receiveTokenCommission(TOKEN, credited);
+    }
+
+    /// @dev Canonical `operationId` = domain-separated hash of the deposit
+    ///      context. Binds the id to sender/gross-amount/route/destination so it
+    ///      is both unpredictable (via the authenticated `sourceSender` + nonce)
+    ///      and provably tied to this deposit. Uses `grossAmount` (the user's
+    ///      submitted amount, known before execution) rather than the
+    ///      commission-derived `netAmount`, so a backend can best-effort
+    ///      pre-compute the id; the canonical value is still the one in the
+    ///      `BridgeFundsIn` event. `ctx.operationId` is ignored (zero when called).
+    function _deriveOperationId(FundsInContext memory ctx, bytes calldata settlementData)
+        private
+        view
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                FUNDS_IN_OPERATION_TYPEHASH,
+                address(this),
+                ctx.sourceChainId,
+                ctx.sourceSender,
+                ctx.senderNonce,
+                TOKEN,
+                ctx.grossAmount,
+                ctx.destChainId,
+                keccak256(bytes(ctx.destAddress)),
+                keccak256(settlementData),
+                block.chainid
+            )
+        );
+    }
+
+    /// @dev Canonical `burnId` = domain-separated hash of the release intent.
+    ///      Route-specific burn identity should be placed in `settlementData`
+    ///      when a route has one; Bridge commits to it via `settlementDataHash`.
+    function _deriveBurnId(FundsOutParams calldata params) private view returns (uint256) {
+        return _deriveBurnIdFromFields(
+            params.recipient,
+            params.amount,
+            params.sourceChainId,
+            params.destinationChainId,
+            params.sourceAddress,
+            params.proof,
+            params.settlementData
+        );
+    }
+
+    function _deriveBurnIdFromFields(
+        address recipient,
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string calldata sourceAddress,
+        bytes calldata proof,
+        bytes calldata settlementData
+    ) private view returns (uint256) {
+        return uint256(
+            keccak256(
+                abi.encode(
+                    FUNDS_OUT_BURN_ID_TYPEHASH,
+                    address(this),
+                    block.chainid,
+                    TOKEN,
+                    recipient,
+                    amount,
+                    sourceChainId,
+                    destinationChainId,
+                    _hashCalldataString(sourceAddress),
+                    _hashCalldataBytes(proof),
+                    _hashCalldataBytes(settlementData)
+                )
+            )
+        );
+    }
+
+    function _hashCalldataString(string calldata value) private pure returns (bytes32 result) {
+        assembly {
+            let ptr := mload(0x40)
+            calldatacopy(ptr, value.offset, value.length)
+            result := keccak256(ptr, value.length)
+            mstore(0x40, add(ptr, and(add(value.length, 0x3f), not(0x1f))))
+        }
+    }
+
+    function _hashCalldataBytes(bytes calldata value) private pure returns (bytes32 result) {
+        assembly {
+            let ptr := mload(0x40)
+            calldatacopy(ptr, value.offset, value.length)
+            result := keccak256(ptr, value.length)
+            mstore(0x40, add(ptr, and(add(value.length, 0x3f), not(0x1f))))
+        }
     }
 }

--- a/ethereum/src/BridgeBase.sol
+++ b/ethereum/src/BridgeBase.sol
@@ -37,15 +37,10 @@ abstract contract BridgeBase is Ownable2Step, Pausable {
     // Events
     // =========================================================================
 
-    /// @notice Emitted on every fundsIn.
-    /// @param sender      Address that deposited the tokens.
-    /// @param operationId Backend-assigned operation identifier.
-    /// @param amount      Amount of tokens locked.
-    event FundsIn(
-        address indexed sender,
-        uint256 indexed operationId,
-        uint256 amount
-    );
+    /// @dev The `FundsIn` event is declared by each concrete bridge, because
+    ///      the two variants use different `operationId` types: the production
+    ///      `Bridge` derives a `bytes32` id on-chain (see `IBridge`), while the
+    ///      minimal `BaseBridge` echoes a caller-supplied `uint256` id.
 
     /// @notice Emitted when the outflow (withdrawal) path is frozen.
     /// @dev The inflow path reuses OpenZeppelin `Pausable`, which emits its own

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -77,6 +77,24 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     ///         in seconds. Quotes revert `StalePrice` when the answer is older.
     uint256 public ethUsdHeartbeat;
 
+    /// @notice Chainlink L2 Sequencer Uptime feed (Arbitrum). `address(0)`
+    ///         (default) disables the check for non-L2 / test environments;
+    ///         an Arbitrum deployment MUST wire it via `setSequencerUptimeFeed`.
+    address public sequencerUptimeFeed;
+
+    /// @notice Seconds after a sequencer restart during which NATIVE quotes are
+    ///         rejected — the L2-published price can lag the market right after
+    ///         recovery. Chainlink's recommended grace period is 3600s.
+    uint256 public constant SEQUENCER_GRACE_PERIOD = 3600;
+
+    /// @notice Optional [min, max] sanity band on the ETH/USD answer (in feed
+    ///         decimals). `ethUsdMaxPrice == 0` (default) disables the band; when
+    ///         set, an answer outside it (e.g. an aggregator floored/capped to
+    ///         `minAnswer`/`maxAnswer` during an extreme move) reverts
+    ///         `PriceOutOfBounds`.
+    uint256 public ethUsdMinPrice;
+    uint256 public ethUsdMaxPrice;
+
     // ============ Modifiers ============
 
     /// @dev Restricts call to `bridgeAddress`.
@@ -252,14 +270,38 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
 
         address feedAddr = ethUsdFeed;
         if (feedAddr == address(0)) revert EthUsdFeedNotSet();
+
+        // L2 sequencer liveness (Arbitrum). Skipped when unset so non-L2 / test
+        // environments are unaffected; an Arbitrum deployment wires it.
+        if (sequencerUptimeFeed != address(0)) _requireSequencerUp();
+
         AggregatorV3Interface feed = AggregatorV3Interface(feedAddr);
 
         (, int256 answer, , uint256 updatedAt, ) = feed.latestRoundData();
         if (answer <= 0) revert InvalidPrice();
         if (block.timestamp - updatedAt > ethUsdHeartbeat) revert StalePrice();
+        // Optional circuit-breaker band (disabled when ethUsdMaxPrice == 0):
+        // rejects a floored/capped aggregator answer that `answer > 0` misses.
+        if (ethUsdMaxPrice != 0 &&
+            (uint256(answer) < ethUsdMinPrice || uint256(answer) > ethUsdMaxPrice)) {
+            revert PriceOutOfBounds();
+        }
 
         uint256 scale = 10 ** (18 - tokenDecimals + uint256(feed.decimals()));
         nativeFee = (tokenFee * scale) / uint256(answer);
+    }
+
+    /// @dev Reverts unless the Arbitrum L2 sequencer is up and past the grace
+    ///      period. Only invoked when `sequencerUptimeFeed` is configured. The
+    ///      uptime feed is a standard `AggregatorV3Interface`: `answer == 0`
+    ///      means the sequencer is up, `answer == 1` means down; `startedAt` is
+    ///      when the current status round began (i.e. the last restart when it
+    ///      transitions back to up).
+    function _requireSequencerUp() internal view {
+        (, int256 answer, uint256 startedAt, , ) =
+            AggregatorV3Interface(sequencerUptimeFeed).latestRoundData();
+        if (answer != 0) revert SequencerDown();
+        if (block.timestamp - startedAt <= SEQUENCER_GRACE_PERIOD) revert GracePeriodNotOver();
     }
 
     /**
@@ -334,6 +376,33 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         ethUsdFeed = feed;
         ethUsdHeartbeat = heartbeat;
         emit EthUsdFeedUpdated(feed, heartbeat);
+    }
+
+    /// @inheritdoc ICommissionManager
+    /// @dev `address(0)` disables the sequencer-uptime gate (non-L2 / test
+    ///      environments). On Arbitrum, federation MUST set the Chainlink
+    ///      Sequencer Uptime feed so NATIVE quotes reject prices during
+    ///      downtime and the post-restart grace period.
+    function setSequencerUptimeFeed(address feed) external onlyOwner {
+        sequencerUptimeFeed = feed;
+        emit SequencerUptimeFeedUpdated(feed);
+    }
+
+    /// @inheritdoc ICommissionManager
+    /// @dev Pass `(0, 0)` to disable the band; otherwise require
+    ///      `0 < minPrice < maxPrice` (values in the feed's decimals, e.g.
+    ///      `100e8` / `100_000e8` for an 8-decimal ETH/USD feed).
+    function setEthUsdPriceBounds(uint256 minPrice, uint256 maxPrice) external onlyOwner {
+        if (minPrice == 0 && maxPrice == 0) {
+            ethUsdMinPrice = 0;
+            ethUsdMaxPrice = 0;
+            emit EthUsdPriceBoundsUpdated(0, 0);
+            return;
+        }
+        if (minPrice == 0 || minPrice >= maxPrice) revert InvalidPriceBounds();
+        ethUsdMinPrice = minPrice;
+        ethUsdMaxPrice = maxPrice;
+        emit EthUsdPriceBoundsUpdated(minPrice, maxPrice);
     }
 
     /**
@@ -490,19 +559,22 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     // ============ Commission Collection Functions ============
 
     /**
-     * @notice Credits token commission: increases `tokenCommissionPool[token]` by the actual balance delta.
+     * @notice Credits `credited` token units to `tokenCommissionPool[token]`.
      * @param token ERC-20 token (non-zero). Bridge must transfer tokens before this call.
-     * @dev Pool tracks on-chain balance; no calldata amount (supports fee-on-transfer tokens).
+     * @param credited The Bridge-measured balance increase of THIS contract from
+     *        its `safeTransfer` (fee-on-transfer safe). Credited as-is rather than
+     *        recomputed from `balanceOf - pool`, so a pre-existing/unsolicited
+     *        direct transfer is never folded into the pool.
+     * @dev Reverts if the resulting pool would exceed the on-chain balance —
+     *      guards against a caller crediting more than actually arrived.
      */
-    function receiveTokenCommission(address token) external onlyBridge {
+    function receiveTokenCommission(address token, uint256 credited) external onlyBridge {
         if (token == address(0)) revert InvalidToken();
-        uint256 newBalance = IERC20(token).balanceOf(address(this));
-        uint256 priorPool = tokenCommissionPool[token];
-        if (newBalance < priorPool) revert BalanceBelowRecordedPool();
-        uint256 recorded = newBalance - priorPool;
-        if (recorded == 0) revert NothingReceived();
-        tokenCommissionPool[token] = newBalance;
-        emit TokenCommissionReceived(token, recorded);
+        if (credited == 0) revert NothingReceived();
+        uint256 newPool = tokenCommissionPool[token] + credited;
+        if (IERC20(token).balanceOf(address(this)) < newPool) revert BalanceBelowRecordedPool();
+        tokenCommissionPool[token] = newPool;
+        emit TokenCommissionReceived(token, credited);
     }
 
     /**

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -43,25 +43,48 @@ contract MultisigProxy is IMultisigProxy {
     ///         until then (closes adapter-execute by default).
     address public lzAdapter;
 
-    address[] private _enclaveSigners;
-    uint256 public enclaveThreshold;
+    /// @notice Per-source-chain enclave signer sets. Each source network (RGB,
+    ///         Concordium/Arch, …) is validated by its own TEE code and therefore
+    ///         has its own key set; a release for `sourceChainId` is authorised
+    ///         only by the set registered for that chain. Selected on the release
+    ///         path via `params.sourceChainId`, which is already committed to in
+    ///         the enclave EIP-712 digest — so a signature for one source chain
+    ///         cannot be replayed against another.
+    mapping(uint256 sourceChainId => address[]) private _enclaveSigners;
+
+    /// @notice Per-source-chain enclave quorum. `0` means the source chain is
+    ///         not registered — used as the existence guard on the release path.
+    mapping(uint256 sourceChainId => uint256) public enclaveThreshold;
+
+    /// @notice Registered enclave source chains, for enumeration and the
+    ///         cross-set disjointness checks. Bounded by `MAX_ENCLAVE_SOURCE_CHAINS`.
+    uint256[] private _enclaveSourceChains;
 
     address[] private _federationSigners;
     uint256 public federationThreshold;
 
     address public commissionRecipient;
 
-    /// @notice Sequential nonce shared by the typed TEE methods (`fundsOut` /
-    ///         `lzFundsOut`). Each successful call must match the current value
-    ///         and then increments it, giving all enclave releases a single
-    ///         total order and one-shot replay protection.
-    uint256 public teeNonce;
+    /// @notice Per-source-chain nonce for the typed TEE methods (`fundsOutCall`
+    ///         / `lzFundsOutCall`). Each source chain has its own lane, so the
+    ///         TEE operating one network cannot invalidate another network's
+    ///         pre-signed release. Each successful call must match the current
+    ///         value for its `sourceChainId` and then increments it.
+    mapping(uint256 sourceChainId => uint256) public teeNonce;
 
     /// @notice Federation proposals.
     mapping(bytes32 => Proposal) private _proposals;
 
-    /// @notice Sequential nonce for all federation operations (propose, cancel, emergency).
+    /// @notice Sequential nonce for the regular federation lane: `_propose`
+    ///         (all typed proposals) and `cancelProposal`.
     uint256 public proposalNonce;
+
+    /// @notice Sequential nonce for the emergency lane: `emergencyPause` /
+    ///         `emergencyUnpause`. Kept separate from `proposalNonce` so an
+    ///         emergency action cannot invalidate an already-signed regular
+    ///         proposal. Cross-lane replay is independently prevented by
+    ///         each operation's distinct EIP-712 typehash.
+    uint256 public emergencyNonce;
 
     /// @notice Minimum delay (seconds) between proposal creation and execution.
     uint256 public timelockDuration;
@@ -93,10 +116,26 @@ contract MultisigProxy is IMultisigProxy {
     ///         unreachable). 20 is ample for an enclave/federation committee.
     uint256 public constant MAX_SIGNERS = 20;
 
+    /// @notice Hard upper bound on the number of registered enclave source
+    ///         chains. Bounds the cross-set disjointness loop (run on every
+    ///         signer rotation), keeping governance updates gas-predictable.
+    uint256 public constant MAX_ENCLAVE_SOURCE_CHAINS = 32;
+
     /// @notice Length of a Solidity function selector (`bytes4`) in bytes. Used
     ///         to guard `callData` against payloads too short to even carry a
     ///         selector before it is sliced via `calldataload`.
     uint256 public constant SELECTOR_LENGTH = 4;
+
+    /// @notice CommissionManager withdrawal selectors that the generic
+    ///         `AdminExecuteCommissionManager` path is NOT allowed to call —
+    ///         they take a free recipient and would bypass the pinned
+    ///         `commissionRecipient`. Withdrawals must go through the
+    ///         dedicated WithdrawTokenCommissionCM / WithdrawNativeCommissionCM
+    ///         ops, which force the recipient to `commissionRecipient`.
+    bytes4 private constant _SEL_WITHDRAW_TOKEN      = bytes4(keccak256('withdrawTokenCommission(address,address,uint256)'));
+    bytes4 private constant _SEL_WITHDRAW_NATIVE     = bytes4(keccak256('withdrawNativeCommission(address,uint256)'));
+    bytes4 private constant _SEL_WITHDRAW_ALL_TOKEN  = bytes4(keccak256('withdrawAllTokenCommission(address,address)'));
+    bytes4 private constant _SEL_WITHDRAW_ALL_NATIVE = bytes4(keccak256('withdrawAllNativeCommission(address)'));
 
     uint256 private immutable _cachedChainId;
     bytes32 private immutable _cachedDomainSeparator;
@@ -118,7 +157,7 @@ contract MultisigProxy is IMultisigProxy {
         'ProposeAdminExecute(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
     );
     bytes32 private constant _PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH = keccak256(
-        'ProposeUpdateEnclaveSigners(address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
+        'ProposeUpdateEnclaveSigners(uint256 sourceChainId,address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
     );
     bytes32 private constant _PROPOSE_UPDATE_FEDERATION_SIGNERS_TYPEHASH = keccak256(
         'ProposeUpdateFederationSigners(address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
@@ -199,6 +238,7 @@ contract MultisigProxy is IMultisigProxy {
         address commissionManager_,
         address[] memory enclaveSigners_,
         uint256 enclaveThreshold_,
+        uint256 initialEnclaveSourceChain_,
         address[] memory federationSigners_,
         uint256 federationThreshold_,
         address commissionRecipient_,
@@ -208,6 +248,7 @@ contract MultisigProxy is IMultisigProxy {
         if (bridge_ == address(0)) revert ZeroBridge();
         if (commissionManager_ == address(0)) revert ZeroCommissionManager();
         if (enclaveSigners_.length == 0) revert NoSigners();
+        if (initialEnclaveSourceChain_ == 0) revert UnknownSourceChain(0);
         _requireValidThreshold(enclaveThreshold_, enclaveSigners_.length);
         if (federationSigners_.length == 0) revert NoSigners();
         _requireValidThreshold(federationThreshold_, federationSigners_.length);
@@ -224,8 +265,9 @@ contract MultisigProxy is IMultisigProxy {
 
         bridge = bridge_;
         commissionManager = commissionManager_;
-        _enclaveSigners = enclaveSigners_;
-        enclaveThreshold = enclaveThreshold_;
+        _enclaveSigners[initialEnclaveSourceChain_] = enclaveSigners_;
+        enclaveThreshold[initialEnclaveSourceChain_] = enclaveThreshold_;
+        _enclaveSourceChains.push(initialEnclaveSourceChain_);
         _federationSigners = federationSigners_;
         federationThreshold = federationThreshold_;
         commissionRecipient = commissionRecipient_;
@@ -250,18 +292,22 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata enclaveSigs
     ) external {
         _checkTeeTiming(deadline);
-        if (nonce != teeNonce) revert InvalidNonce();
+        // Select the enclave set by the release's source chain. `sourceChainId`
+        // is committed to in the digest below, so a signature is bound to the
+        // set of exactly one source chain. A zero threshold = unregistered.
+        if (enclaveThreshold[params.sourceChainId] == 0) revert UnknownSourceChain(params.sourceChainId);
+        if (nonce != teeNonce[params.sourceChainId]) revert InvalidNonce();
 
         _verifySignatures(
             _hashTypedData(_fundsOutStructHash(params, nonce, deadline)),
-            enclaveBitmap, enclaveSigs, _enclaveSigners, enclaveThreshold
+            enclaveBitmap, enclaveSigs, _enclaveSigners[params.sourceChainId], enclaveThreshold[params.sourceChainId]
         );
 
-        teeNonce++;
+        teeNonce[params.sourceChainId]++;
 
         IBridge(bridge).fundsOut(params);
 
-        emit FundsOutExecuted(nonce, enclaveBitmap);
+        emit FundsOutExecuted(params.sourceChainId, nonce, enclaveBitmap);
     }
 
     /// @dev EIP-712 struct hash for `TeeFundsOut`. Isolated in its own frame to
@@ -300,17 +346,18 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata enclaveSigs
     ) external payable {
         _checkTeeTiming(deadline);
-        if (nonce != teeNonce) revert InvalidNonce();
+        if (enclaveThreshold[params.sourceChainId] == 0) revert UnknownSourceChain(params.sourceChainId);
+        if (nonce != teeNonce[params.sourceChainId]) revert InvalidNonce();
 
         address adapter = lzAdapter;
         if (adapter == address(0)) revert LZAdapterNotSet();
 
         _verifySignatures(
             _hashTypedData(_lzFundsOutStructHash(params, nonce, deadline)),
-            enclaveBitmap, enclaveSigs, _enclaveSigners, enclaveThreshold
+            enclaveBitmap, enclaveSigs, _enclaveSigners[params.sourceChainId], enclaveThreshold[params.sourceChainId]
         );
 
-        teeNonce++;
+        teeNonce[params.sourceChainId]++;
 
         // Release to the adapter, then bridge exactly what the adapter received,
         // so the release and the cross-chain send are bound on-chain. The Bridge
@@ -336,7 +383,7 @@ contract MultisigProxy is IMultisigProxy {
             params.dstEid, params.recipient, delivered, params.minAmountLD, params.extraOptions
         );
 
-        emit LzFundsOutExecuted(nonce, enclaveBitmap, params.dstEid, params.recipient, delivered);
+        emit LzFundsOutExecuted(params.sourceChainId, nonce, enclaveBitmap, params.dstEid, params.recipient, delivered);
     }
 
     /// @dev EIP-712 struct hash for `TeeLzFundsOut`. Isolated in its own frame
@@ -391,14 +438,14 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata fedSigs
     ) external {
         if (block.timestamp > deadline) revert Expired();
-        if (nonce != proposalNonce) revert InvalidNonce();
+        if (nonce != emergencyNonce) revert InvalidNonce();
 
         bytes32 digest = _hashTypedData(
             keccak256(abi.encode(_EMERGENCY_PAUSE_TYPEHASH, nonce, deadline))
         );
         _verifySignatures(digest, fedBitmap, fedSigs, _federationSigners, federationThreshold);
 
-        proposalNonce++;
+        emergencyNonce++;
 
         // Emergency freeze of BOTH inflow and outflow — no timelock, federation
         // signatures only. Also halts the enclave/TEE release path (it routes
@@ -417,14 +464,14 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata fedSigs
     ) external {
         if (block.timestamp > deadline) revert Expired();
-        if (nonce != proposalNonce) revert InvalidNonce();
+        if (nonce != emergencyNonce) revert InvalidNonce();
 
         bytes32 digest = _hashTypedData(
             keccak256(abi.encode(_EMERGENCY_UNPAUSE_TYPEHASH, nonce, deadline))
         );
         _verifySignatures(digest, fedBitmap, fedSigs, _federationSigners, federationThreshold);
 
-        proposalNonce++;
+        emergencyNonce++;
 
         // Lift the emergency freeze on BOTH inflow and outflow.
         (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('emergencyUnpauseAll()'));
@@ -459,6 +506,7 @@ contract MultisigProxy is IMultisigProxy {
 
     /// @inheritdoc IMultisigProxy
     function proposeUpdateEnclaveSigners(
+        uint256 sourceChainId,
         address[] calldata newSigners,
         uint256 newThreshold,
         uint256 nonce,
@@ -469,19 +517,21 @@ contract MultisigProxy is IMultisigProxy {
         // Validate the proposed set up front so a malformed rotation reverts
         // here instead of consuming a nonce + timelock slot and failing only at
         // execution. Disjointness is intentionally left to execute time: it
-        // depends on the live counterpart set, which may change before then.
+        // depends on the live federation and other enclave sets, which may
+        // change before then.
+        if (sourceChainId == 0) revert UnknownSourceChain(0);
         if (newSigners.length == 0) revert NoSigners();
         _requireValidThreshold(newThreshold, newSigners.length);
         _validateSigners(newSigners);
 
         bytes32 structHash = keccak256(abi.encode(
             _PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH,
-            _hashAddressArray(newSigners), newThreshold, nonce, deadline
+            sourceChainId, _hashAddressArray(newSigners), newThreshold, nonce, deadline
         ));
 
         return _propose(
             OperationType.UpdateEnclaveSigners,
-            abi.encode(newSigners, newThreshold),
+            abi.encode(sourceChainId, newSigners, newThreshold),
             nonce, deadline, structHash, fedBitmap, fedSigs
         );
     }
@@ -586,6 +636,10 @@ contract MultisigProxy is IMultisigProxy {
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
+
+        // Commission withdrawals must use the pinned-recipient ops; reject them
+        // on the generic path up front (fail-fast, no wasted proposal slot).
+        _requireNotCommissionWithdrawSelector(selector);
 
         bytes32 structHash = keccak256(abi.encode(
             _PROPOSE_ADMIN_EXECUTE_CM_TYPEHASH, selector, keccak256(callData), nonce, deadline
@@ -891,19 +945,26 @@ contract MultisigProxy is IMultisigProxy {
 
     /// @inheritdoc IMultisigProxy
     function verifyEnclaveSignature(
+        uint256 sourceChainId,
         bytes32 digest,
         bytes calldata signature,
         uint256 signerIndex
     ) external view returns (bool) {
-        if (signerIndex >= _enclaveSigners.length) revert IndexOutOfRange();
+        address[] storage set = _enclaveSigners[sourceChainId];
+        if (signerIndex >= set.length) revert IndexOutOfRange();
         address recovered = ECDSA.recover(digest, signature);
-        return recovered == _enclaveSigners[signerIndex];
+        return recovered == set[signerIndex];
     }
 
 
     /// @inheritdoc IMultisigProxy
-    function getEnclaveSigners() external view returns (address[] memory) {
-        return _enclaveSigners;
+    function getEnclaveSigners(uint256 sourceChainId) external view returns (address[] memory) {
+        return _enclaveSigners[sourceChainId];
+    }
+
+    /// @inheritdoc IMultisigProxy
+    function getEnclaveSourceChains() external view returns (uint256[] memory) {
+        return _enclaveSourceChains;
     }
 
     /// @inheritdoc IMultisigProxy
@@ -969,21 +1030,37 @@ contract MultisigProxy is IMultisigProxy {
             _propagateRevert(ok, ret);
 
         } else if (opType == OperationType.UpdateEnclaveSigners) {
-            (address[] memory newSigners, uint256 newThreshold) = abi.decode(opData, (address[], uint256));
+            (uint256 sourceChainId, address[] memory newSigners, uint256 newThreshold) =
+                abi.decode(opData, (uint256, address[], uint256));
+            if (sourceChainId == 0) revert UnknownSourceChain(0);
             if (newSigners.length == 0) revert NoSigners();
             _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
+            // Keep every trust domain independent: disjoint from the federation
+            // and from every *other* enclave source chain (skip this chain, so a
+            // partial rotation that keeps some of its own keys is allowed).
             _requireDisjoint(newSigners, _federationSigners);
-            _enclaveSigners = newSigners;
-            enclaveThreshold = newThreshold;
-            emit EnclaveSignersUpdated(newSigners, newThreshold);
+            _requireDisjointFromAllEnclaveSets(newSigners, sourceChainId);
+
+            // Register a brand-new source chain (bounded); existing ones just
+            // overwrite their set/threshold.
+            if (enclaveThreshold[sourceChainId] == 0) {
+                if (_enclaveSourceChains.length >= MAX_ENCLAVE_SOURCE_CHAINS) {
+                    revert TooManyEnclaveSourceChains(_enclaveSourceChains.length + 1, MAX_ENCLAVE_SOURCE_CHAINS);
+                }
+                _enclaveSourceChains.push(sourceChainId);
+            }
+            _enclaveSigners[sourceChainId] = newSigners;
+            enclaveThreshold[sourceChainId] = newThreshold;
+            emit EnclaveSignersUpdated(sourceChainId, newSigners, newThreshold);
 
         } else if (opType == OperationType.UpdateFederationSigners) {
             (address[] memory newSigners, uint256 newThreshold) = abi.decode(opData, (address[], uint256));
             if (newSigners.length == 0) revert NoSigners();
             _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
-            _requireDisjoint(newSigners, _enclaveSigners);
+            // Federation must stay disjoint from every enclave source-chain set.
+            _requireDisjointFromAllEnclaveSets(newSigners, 0);
             _federationSigners = newSigners;
             federationThreshold = newThreshold;
             emit FederationSignersUpdated(newSigners, newThreshold);
@@ -1010,7 +1087,11 @@ contract MultisigProxy is IMultisigProxy {
             emit TimelockDurationUpdated(newDuration);
 
         } else if (opType == OperationType.AdminExecuteCommissionManager) {
-            // opData = raw CommissionManager callData
+            // opData = raw CommissionManager callData. Enforce (again, at the
+            // execution boundary) that this generic path cannot call a
+            // withdrawal selector and re-point commission away from the pinned
+            // `commissionRecipient`.
+            _requireNotCommissionWithdrawSelector(_firstSelector(opData));
             (bool ok, bytes memory ret) = commissionManager.call(opData);
             _propagateRevert(ok, ret);
 
@@ -1205,6 +1286,19 @@ contract MultisigProxy is IMultisigProxy {
         }
     }
 
+    /// @dev Reverts if `candidate` overlaps any registered enclave source-chain
+    ///      set, skipping `exceptSourceChain` (pass `0` to skip none). Used to
+    ///      keep every enclave set disjoint from the others and from the
+    ///      federation. Cost is bounded by `MAX_ENCLAVE_SOURCE_CHAINS` *
+    ///      `MAX_SIGNERS` * candidate length.
+    function _requireDisjointFromAllEnclaveSets(address[] memory candidate, uint256 exceptSourceChain) private view {
+        uint256[] memory chains = _enclaveSourceChains;
+        for (uint256 i = 0; i < chains.length; i++) {
+            if (chains[i] == exceptSourceChain) continue;
+            _requireDisjoint(candidate, _enclaveSigners[chains[i]]);
+        }
+    }
+
     function _validateSigners(address[] memory signers) private pure {
         // Bound the set before the O(N^2) duplicate scan below, and keep every
         // signer index within the uint256 signature bitmap (R-I-06).
@@ -1241,6 +1335,29 @@ contract MultisigProxy is IMultisigProxy {
             } else {
                 revert CallFailed();
             }
+        }
+    }
+
+    /// @dev First 4 bytes of `data` as a selector, or `0x00000000` if `data` is
+    ///      shorter than a selector (such a payload can never be a withdrawal
+    ///      call and the downstream raw call rejects it anyway).
+    function _firstSelector(bytes memory data) private pure returns (bytes4 selector) {
+        if (data.length >= SELECTOR_LENGTH) {
+            assembly { selector := mload(add(data, 0x20)) }
+        }
+    }
+
+    /// @dev Reverts if `selector` is one of the CommissionManager withdrawal
+    ///      selectors, which the generic AdminExecuteCommissionManager path must
+    ///      not reach (they bypass the pinned `commissionRecipient`).
+    function _requireNotCommissionWithdrawSelector(bytes4 selector) private pure {
+        if (
+            selector == _SEL_WITHDRAW_TOKEN ||
+            selector == _SEL_WITHDRAW_NATIVE ||
+            selector == _SEL_WITHDRAW_ALL_TOKEN ||
+            selector == _SEL_WITHDRAW_ALL_NATIVE
+        ) {
+            revert ForbiddenCommissionManagerSelector(selector);
         }
     }
 }

--- a/ethereum/src/RouteRegistry.sol
+++ b/ethereum/src/RouteRegistry.sol
@@ -142,11 +142,12 @@ contract RouteRegistry is IRouteRegistry, Ownable2Step {
         external
         override
         onlyBridge
+        returns (uint256 externalId)
     {
         RouteConfig memory route = _routes[_routeKey(ctx.sourceChainId, ctx.destChainId)];
         if (!route.enabled) revert RouteNotEnabled(ctx.sourceChainId, ctx.destChainId);
 
-        ISettlementModule(route.settlementModule).onFundsIn(ctx, settlementData);
+        return ISettlementModule(route.settlementModule).onFundsIn(ctx, settlementData);
     }
 
     /// @inheritdoc IRouteRegistry

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -11,6 +11,7 @@ interface IBridge {
     error InvalidSourceChainId();
     error ZeroAmount();
     error AmountBelowMinimum(uint256 amount, uint256 minimum);
+    error InsufficientReceived(uint256 received, uint256 tokenCommission);
     error InvalidMinFundsInAmount();
     error AddressTooLong(uint256 length, uint256 maxLength);
     error ProofTooLong(uint256 length, uint256 maxLength);
@@ -20,6 +21,7 @@ interface IBridge {
     error InvalidCommissionManagerAddress();
     error NotLZAdapter();
     error InvalidLZAdapter();
+    error InvalidBurnId(uint256 provided, uint256 expected);
     error BurnIdAlreadyConsumed(uint256 burnId);
     error NativeValueMismatch();
 
@@ -62,10 +64,32 @@ interface IBridge {
     /// @param available  Accrued allowance carried over after the update.
     event GlobalOutflowLimitUpdated(uint256 capacity, uint256 refillRate, uint256 available);
 
-    /// @param sender             Address that deposited the tokens (the EOA on the
-    ///                           public overload, or the LZ adapter on the
-    ///                           adapter-only overload).
-    /// @param operationId        Backend-assigned operation identifier.
+    /// @notice RGB-route deposit event. Emitted only when the route's settlement
+    ///         module returns a non-zero external correlation id — in practice
+    ///         the RGB OpId, which the RGB side consumes as `uint256`. Routes
+    ///         whose module returns 0 (e.g. `NullSettlementModule`) do not emit
+    ///         it. The canonical, route-agnostic id is `BridgeFundsIn.operationId`
+    ///         (bytes32); this event exists for the RGB integration only.
+    /// @param sender  EVM caller Bridge saw (user, or the LZ adapter).
+    /// @param rgbOpId RGB operation id, decoded by the route module from its
+    ///                `settlementData`. Not an on-chain dedup key.
+    /// @param amount  Net amount bridged (post-commission).
+    event FundsIn(
+        address indexed sender,
+        uint256 indexed rgbOpId,
+        uint256 amount
+    );
+
+    /// @param operationId        Canonical bridge-side operation id, derived
+    ///                           on-chain by Bridge and unpredictable by third
+    ///                           parties. This is the backend's canonical key.
+    /// @param sourceSender       Original source-chain sender (left-padded to
+    ///                           `bytes32`); the identity bound into `operationId`.
+    /// @param sender             EVM caller Bridge saw (the EOA on the public
+    ///                           overload, or the LZ adapter on the adapter-only
+    ///                           overload).
+    /// @param senderNonce        Per-`(sourceChainId, sourceSender)` nonce folded
+    ///                           into `operationId`.
     /// @param amount             Gross amount the user supplied (pre-commission).
     /// @param netAmount          Amount actually bridged after token commission is taken.
     /// @param tokenCommission    Fee charged in the bridged token (deducted from `amount`).
@@ -76,8 +100,10 @@ interface IBridge {
     ///                           destinations like RGB / Bitcoin).
     /// @param destinationAddress Target address on the destination chain.
     event BridgeFundsIn(
+        bytes32 indexed operationId,
+        bytes32 indexed sourceSender,
         address indexed sender,
-        uint256 indexed operationId,
+        uint256 senderNonce,
         uint256 amount,
         uint256 netAmount,
         uint256 tokenCommission,
@@ -91,8 +117,8 @@ interface IBridge {
     /// @param amount             Gross amount released from the bridge pool (pre-commission).
     /// @param netAmount          Amount actually delivered to `recipient`.
     /// @param tokenCommission    Fee taken in the bridged token (sent to the CommissionManager).
-    /// @param burnId             Identifier extracted from the burn consignment on the
-    ///                           source side. Stored on-chain to block fundsOut replays.
+    /// @param burnId             Bridge-derived replay key. Stored on-chain to
+    ///                           block fundsOut replays for the same release intent.
     /// @param sourceChainId      Source chain id (non-EVM side for RGB→EVM releases).
     /// @param destinationChainId Destination chain id (EVM target receiving the release).
     /// @param sourceAddress      Sender address on the source chain.
@@ -115,32 +141,41 @@ interface IBridge {
     ///         `sourceChainId` half of the commission route key is filled with
     ///         `block.chainid` — non-spoofable by the caller.
     /// @dev Payable: if the active route uses NATIVE commission currency, `msg.value`
-    ///      must equal the quoted native commission; otherwise `msg.value` must be 0.
+    ///      must be at least the quoted native commission — any surplus (from
+    ///      favorable ETH/USD drift between quote and execution) is collected as
+    ///      commission, not refunded (R-I-03). If the route takes no native
+    ///      commission (TOKEN currency), `msg.value` must be 0.
     /// @dev `settlementData` is an opaque per-route blob forwarded into the
     ///      route's `ISettlementModule.onFundsIn`. Routes whose module does not
     ///      consume any extra data (e.g. RGB) accept an empty bytes string.
+    /// @dev The `operationId` is derived on-chain (not caller-supplied) and
+    ///      returned; read the canonical value from the emitted event.
+    /// @return operationId The canonical bridge-side operation id.
     function fundsIn(
         uint256 amount,
         uint256 destinationChainId,
         string  calldata destinationAddress,
-        uint256 operationId,
         bytes   calldata settlementData
-    ) external payable;
+    ) external payable returns (bytes32 operationId);
 
     /// @notice Adapter-only overload. Used by `UtexoLZAdapter.lzCompose` to
     ///         forward a cross-chain deposit while preserving the original
-    ///         source-chain id (carried in `composeMsg` from the source side).
+    ///         source-chain id and sender (carried in `composeMsg` from the
+    ///         source side).
     /// @dev Reverts `NotLZAdapter` if `msg.sender` is not the configured
     ///      `lzAdapter`. Until federation sets a non-zero adapter, the
-    ///      overload is effectively closed.
+    ///      overload is effectively closed. `sourceSender` is authenticated by
+    ///      the source-chain entrypoint and adapter, not by an arbitrary
+    ///      caller — it is bound into the derived `operationId`.
+    /// @return operationId The canonical bridge-side operation id.
     function fundsIn(
         uint256 amount,
         uint256 sourceChainId,
+        bytes32 sourceSender,
         uint256 destinationChainId,
         string  calldata destinationAddress,
-        uint256 operationId,
         bytes   calldata settlementData
-    ) external payable;
+    ) external payable returns (bytes32 operationId);
 
     // =========================================================================
     // External — owner-only (called via MultisigProxy)
@@ -149,8 +184,9 @@ interface IBridge {
     /// @notice Release parameters for `fundsOut`.
     /// @param recipient          Recipient on this chain.
     /// @param amount             Gross amount to release (pre-commission).
-    /// @param burnId             Single-use replay guard; MUST be unique across
-    ///                           every successful `fundsOut`.
+    /// @param burnId             Bridge-derived replay guard. Must equal the
+    ///                           Bridge's canonical hash of the release fields,
+    ///                           including `proof` and `settlementData`.
     /// @param sourceChainId      Source chain id.
     /// @param destinationChainId Destination chain id; part of the
     ///                           CommissionManager route key.

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -63,6 +63,10 @@ interface ICommissionManager {
     error StalePrice();
     error TokenDecimalsTooLarge();
     error InvalidHeartbeat();
+    error SequencerDown();
+    error GracePeriodNotOver();
+    error PriceOutOfBounds();
+    error InvalidPriceBounds();
 
     // ============ Events ============
 
@@ -93,6 +97,12 @@ interface ICommissionManager {
 
     event EthUsdFeedUpdated(address indexed feed, uint256 heartbeat);
 
+    /// @notice Emitted on `setSequencerUptimeFeed` (`address(0)` disables the check).
+    event SequencerUptimeFeedUpdated(address indexed feed);
+
+    /// @notice Emitted on `setEthUsdPriceBounds` (both zero disables the band).
+    event EthUsdPriceBoundsUpdated(uint256 minPrice, uint256 maxPrice);
+
     event TokenCommissionWithdrawn(
         address indexed token,
         address indexed to,
@@ -119,6 +129,14 @@ interface ICommissionManager {
     function ethUsdFeed() external view returns (address);
 
     function ethUsdHeartbeat() external view returns (uint256);
+
+    function sequencerUptimeFeed() external view returns (address);
+
+    function SEQUENCER_GRACE_PERIOD() external view returns (uint256);
+
+    function ethUsdMinPrice() external view returns (uint256);
+
+    function ethUsdMaxPrice() external view returns (uint256);
 
     // ============ Core calculations ============
 
@@ -175,6 +193,16 @@ interface ICommissionManager {
     ///         disable NATIVE quoting until a new feed is set.
     function setEthUsdFeed(address feed, uint256 heartbeat) external;
 
+    /// @notice Configure (or rotate) the Chainlink L2 Sequencer Uptime feed used
+    ///         to gate NATIVE quotes on Arbitrum. Pass `address(0)` to disable
+    ///         the check (non-L2 / test environments).
+    function setSequencerUptimeFeed(address feed) external;
+
+    /// @notice Configure the optional [min, max] sanity band on the ETH/USD
+    ///         answer (feed decimals). Pass `(0, 0)` to disable; otherwise
+    ///         `0 < minPrice < maxPrice`.
+    function setEthUsdPriceBounds(uint256 minPrice, uint256 maxPrice) external;
+
     function setCommissionRule(
         uint256 sourceChainId,
         uint256 destChainId,
@@ -214,7 +242,13 @@ interface ICommissionManager {
 
     // ============ Commission ingress (bridge) ============
 
-    function receiveTokenCommission(address token) external;
+    /// @notice Credit `credited` token units to the commission pool. The Bridge
+    ///         measures `credited` as the actual balance increase of this
+    ///         contract around its `safeTransfer` (so a fee-on-transfer token is
+    ///         handled and no pre-existing/unsolicited balance is absorbed,
+    ///         R-I-04). Reverts if the resulting pool would exceed the on-chain
+    ///         balance. Callable only by the Bridge.
+    function receiveTokenCommission(address token, uint256 credited) external;
 
     /// @notice Native commission ingress; only `bridgeAddress` may call with non-zero value (see implementation).
     receive() external payable;

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -13,7 +13,8 @@ import { IBridge } from './IBridge.sol';
 ///        - `fundsOutCall`   — a single `Bridge.fundsOut` (RGB → Arbitrum);
 ///        - `lzFundsOutCall`  — `Bridge.fundsOut` to the LZ adapter then
 ///          `adapter.sendOut`, with the two legs bound on-chain (RGB → non-Arbitrum).
-///      Both share a single sequential `teeNonce` for replay protection.
+///      Each source chain has its own `teeNonce` lane, selected by the
+///      release's `sourceChainId`, for per-network replay protection.
 ///
 ///      FEDERATION SIGNERS (governance / admin nodes)
 ///      All administrative operations go through a two-phase timelock:
@@ -67,10 +68,13 @@ interface IMultisigProxy {
     error DuplicateSigner();
     error SignerSetsOverlap(address signer);
     error TooManySigners(uint256 count, uint256 max);
+    error UnknownSourceChain(uint256 sourceChainId);
+    error TooManyEnclaveSourceChains(uint256 count, uint256 max);
     error CallFailed();
     error UnknownOperationType();
     error ZeroRecipient();
     error ZeroTarget();
+    error ForbiddenCommissionManagerSelector(bytes4 selector);
     error LZAdapterNotSet();
     error InvalidLZAdapter();
 
@@ -132,8 +136,9 @@ interface IMultisigProxy {
     // =========================================================================
 
     // TEE — typed enclave releases
-    event FundsOutExecuted(uint256 indexed nonce, uint256 enclaveBitmap);
+    event FundsOutExecuted(uint256 indexed sourceChainId, uint256 indexed nonce, uint256 enclaveBitmap);
     event LzFundsOutExecuted(
+        uint256 indexed sourceChainId,
         uint256 indexed nonce,
         uint256 enclaveBitmap,
         uint32  dstEid,
@@ -158,7 +163,7 @@ interface IMultisigProxy {
     event EmergencyUnpaused(uint256 nonce, uint256 fedBitmap);
 
     // Emitted when proposals are executed
-    event EnclaveSignersUpdated(address[] newSigners, uint256 newThreshold);
+    event EnclaveSignersUpdated(uint256 indexed sourceChainId, address[] newSigners, uint256 newThreshold);
     event FederationSignersUpdated(address[] newSigners, uint256 newThreshold);
     event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
@@ -232,9 +237,12 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose replacing the enclave signer set.
-    /// @dev opData = abi.encode(address[] newSigners, uint256 newThreshold)
+    /// @notice Propose replacing (or registering) the enclave signer set for a
+    ///         given source chain. A `sourceChainId` with no set yet is
+    ///         registered on execution (bounded by `MAX_ENCLAVE_SOURCE_CHAINS`).
+    /// @dev opData = abi.encode(uint256 sourceChainId, address[] newSigners, uint256 newThreshold)
     function proposeUpdateEnclaveSigners(
+        uint256 sourceChainId,
         address[] calldata newSigners,
         uint256 newThreshold,
         uint256 nonce,
@@ -463,24 +471,29 @@ interface IMultisigProxy {
     // View
     // =========================================================================
 
-    /// @notice Verify that `signature` over `digest` was produced by the enclave signer at `signerIndex`.
+    /// @notice Verify that `signature` over `digest` was produced by the enclave
+    ///         signer at `signerIndex` for the given `sourceChainId` set.
     function verifyEnclaveSignature(
+        uint256 sourceChainId,
         bytes32 digest,
         bytes calldata signature,
         uint256 signerIndex
     ) external view returns (bool);
 
-    function teeNonce() external view returns (uint256);
+    function teeNonce(uint256 sourceChainId) external view returns (uint256);
     function bridge() external view returns (address);
     function commissionManager() external view returns (address);
     function lzAdapter() external view returns (address);
-    function getEnclaveSigners() external view returns (address[] memory);
-    function enclaveThreshold() external view returns (uint256);
+    function getEnclaveSigners(uint256 sourceChainId) external view returns (address[] memory);
+    function getEnclaveSourceChains() external view returns (uint256[] memory);
+    function enclaveThreshold(uint256 sourceChainId) external view returns (uint256);
     function getFederationSigners() external view returns (address[] memory);
     function federationThreshold() external view returns (uint256);
     function commissionRecipient() external view returns (address);
     function DOMAIN_SEPARATOR() external view returns (bytes32);
     function proposalNonce() external view returns (uint256);
+
+    function emergencyNonce() external view returns (uint256);
     function timelockDuration() external view returns (uint256);
     function MIN_TIMELOCK() external view returns (uint256);
     function getProposal(bytes32 proposalId) external view returns (Proposal memory);

--- a/ethereum/src/interfaces/IRouteRegistry.sol
+++ b/ethereum/src/interfaces/IRouteRegistry.sol
@@ -101,7 +101,11 @@ interface IRouteRegistry {
     /// @notice Forwards the inbound context to the settlement module of the
     ///         route `(ctx.sourceChainId, ctx.destChainId)`. Reverts if the
     ///         route is not enabled. Callable only by `bridge`.
-    function onFundsIn(FundsInContext calldata ctx, bytes calldata settlementData) external;
+    /// @return externalId The settlement module's optional correlation id (see
+    ///                    `ISettlementModule.onFundsIn`); forwarded to Bridge.
+    function onFundsIn(FundsInContext calldata ctx, bytes calldata settlementData)
+        external
+        returns (uint256 externalId);
 
     /// @notice Runs the verifier (view-only proof check) and then the
     ///         settlement module's `beforeFundsOut` hook, in that order, for

--- a/ethereum/src/interfaces/ISettlementModule.sol
+++ b/ethereum/src/interfaces/ISettlementModule.sol
@@ -28,7 +28,14 @@ interface ISettlementModule {
     /// @param ctx            Canonical fundsIn context built by Bridge.
     /// @param settlementData Opaque per-route data supplied by the caller;
     ///                       layout defined by the module itself.
-    function onFundsIn(FundsInContext calldata ctx, bytes calldata settlementData) external;
+    /// @return externalId    Optional route-specific correlation id for Bridge's
+    ///                       `FundsIn` event (the RGB OpId for the RGB route; `0`
+    ///                       for modules that need none, so Bridge emits no
+    ///                       `FundsIn`). NOT an on-chain dedup key — the
+    ///                       canonical key is `ctx.operationId`.
+    function onFundsIn(FundsInContext calldata ctx, bytes calldata settlementData)
+        external
+        returns (uint256 externalId);
 
     /// @notice Hook invoked by `RouteRegistry.beforeFundsOut` *before* Bridge
     ///         releases funds. The module performs any route-specific state

--- a/ethereum/src/interfaces/RouteTypes.sol
+++ b/ethereum/src/interfaces/RouteTypes.sol
@@ -17,13 +17,25 @@ pragma solidity 0.8.35;
 ///         after commission has been computed and tokens have been pulled,
 ///         then forwarded into `RouteRegistry.onFundsIn` → `ISettlementModule`.
 /// @param token              ERC-20 the Bridge accepts (the bridged asset).
-/// @param sender             Address that initiated the deposit — the EOA on
-///                           the public overload, or the LZ adapter on the
-///                           adapter-only overload.
+/// @param sender             EVM caller Bridge saw — the EOA on the public
+///                           overload, or the LZ adapter on the adapter-only
+///                           overload. This is who tokens are pulled from; it
+///                           is NOT the identity bound into `operationId`.
+/// @param sourceSender       Original source-chain sender, left-padded to
+///                           `bytes32`. Equals `sender` for direct EVM
+///                           deposits; for LZ deposits it is the authenticated
+///                           user forwarded by the adapter. This is the
+///                           identity bound into `operationId`.
 /// @param grossAmount        Gross amount the user supplied (pre-commission).
 /// @param netAmount          Amount actually bridged after token commission
 ///                           has been taken.
-/// @param operationId        Backend-assigned operation identifier.
+/// @param operationId        Canonical bridge-side operation id, derived
+///                           on-chain by Bridge (see `Bridge._deriveOperationId`).
+///                           Unpredictable by third parties, so it cannot be
+///                           pre-empted; read it from the emitted event.
+/// @param senderNonce        Per-`(sourceChainId, sourceSender)` nonce folded
+///                           into `operationId` so repeated identical deposits
+///                           produce distinct ids.
 /// @param sourceChainId      `block.chainid` for direct EVM deposits, or the
 ///                           non-spoofable chain id forwarded by the adapter.
 /// @param destChainId        Target chain id (backend-assigned for non-EVM
@@ -32,9 +44,11 @@ pragma solidity 0.8.35;
 struct FundsInContext {
     address token;
     address sender;
+    bytes32 sourceSender;
     uint256 grossAmount;
     uint256 netAmount;
-    uint256 operationId;
+    bytes32 operationId;
+    uint256 senderNonce;
     uint256 sourceChainId;
     uint256 destChainId;
     string  destAddress;
@@ -48,10 +62,9 @@ struct FundsInContext {
 /// @param recipient          Final recipient on this chain.
 /// @param amount             Gross amount being released from the pool
 ///                           (pre-commission).
-/// @param burnId             Source-side burn identifier — the common replay
-///                           guard enforced by Bridge itself. Carried in the
+/// @param burnId             Bridge-derived release replay key. Carried in the
 ///                           context so verifiers and settlement modules can
-///                           reference it if they need to.
+///                           reference the canonical key if they need to.
 /// @param sourceChainId      Source chain id.
 /// @param destChainId        Destination chain id (this chain, in practice).
 /// @param sourceAddress      Sender address on the source chain.

--- a/ethereum/src/settlement/NullSettlementModule.sol
+++ b/ethereum/src/settlement/NullSettlementModule.sol
@@ -21,8 +21,10 @@ import { FundsInContext, FundsOutContext } from '../interfaces/RouteTypes.sol';
 ///      decision visible on-chain.
 contract NullSettlementModule is ISettlementModule {
     /// @inheritdoc ISettlementModule
-    function onFundsIn(FundsInContext calldata, bytes calldata) external pure override {
-        // Intentionally empty.
+    /// @dev Returns `0`: no external correlation id, so Bridge emits no
+    ///      `FundsIn` event for routes using this module.
+    function onFundsIn(FundsInContext calldata, bytes calldata) external pure override returns (uint256) {
+        return 0;
     }
 
     /// @inheritdoc ISettlementModule

--- a/ethereum/src/settlement/RgbSettlementModule.sol
+++ b/ethereum/src/settlement/RgbSettlementModule.sol
@@ -38,9 +38,11 @@ import { FundsInContext, FundsOutContext } from '../interfaces/RouteTypes.sol';
 ///      redeploy the module + rotate the route under federation governance.
 ///
 ///      `settlementData` layout:
-///        - `onFundsIn`:  ignored (Bridge already supplies the canonical
-///                        `operationId` / `netAmount` inside `ctx`).
-///        - `beforeFundsOut`: `abi.encode(uint256[] operationIds, uint256[] amounts)`
+///        - `onFundsIn`:  `abi.encode(uint256 rgbOpId)` — the RGB OpId, decoded
+///                        and returned for Bridge's `FundsIn` event. The record
+///                        is keyed by the bridge-derived `ctx.operationId`, not
+///                        by this value.
+///        - `beforeFundsOut`: `abi.encode(bytes32[] operationIds, uint256[] amounts)`
 ///                        (equal-length parallel arrays).
 ///
 ///      This contract owns no tokens and mutates
@@ -62,15 +64,19 @@ contract RgbSettlementModule is ISettlementModule {
     ///         silently overwrite the previous net amount and is rejected.
     error DuplicateOperationId();
 
+    /// @notice `onFundsIn` `settlementData` decoded to a zero RGB OpId. The RGB
+    ///         route requires a non-zero OpId (it is threaded to the RGB side).
+    error InvalidRgbOpId();
+
     /// @notice A `beforeFundsOut` call referenced an `operationId` that has no
     ///         `fundsInRecords` entry (never recorded on-chain).
-    error FundsInNotFound(uint256 operationId);
+    error FundsInNotFound(bytes32 operationId);
 
     /// @notice A `beforeFundsOut` operation id exists, but the amount supplied
     ///         in `settlementData` does not match the on-chain mint record.
     ///         RGB binds an operationId to an exact mint amount, so the match
     ///         must be exact.
-    error AmountMismatch(uint256 operationId, uint256 provided, uint256 recorded);
+    error AmountMismatch(bytes32 operationId, uint256 provided, uint256 recorded);
 
     /// @notice `beforeFundsOut` `settlementData` decoded to `operationIds` and
     ///         `amounts` arrays of different lengths.
@@ -88,7 +94,7 @@ contract RgbSettlementModule is ISettlementModule {
     ///         value means "never recorded under this id". Records are written
     ///         once at `onFundsIn` and never cleared — they are a permanent
     ///         proof-of-mint ledger, not a consumable balance.
-    mapping(uint256 operationId => uint256 netAmount) public fundsInRecords;
+    mapping(bytes32 operationId => uint256 netAmount) public fundsInRecords;
 
     // =========================================================================
     // Modifiers
@@ -115,21 +121,29 @@ contract RgbSettlementModule is ISettlementModule {
     // =========================================================================
 
     /// @inheritdoc ISettlementModule
-    /// @dev Records the post-commission `netAmount` for `ctx.operationId`.
-    ///      Reverts `DuplicateOperationId` if a non-zero record already
-    ///      exists under the same id. `settlementData` is ignored for this
-    ///      module — the canonical fundsIn data is taken from `ctx`.
-    function onFundsIn(FundsInContext calldata ctx, bytes calldata /* settlementData */)
+    /// @dev Records the post-commission `netAmount` under the canonical
+    ///      `ctx.operationId` (the bridge-derived, unpredictable key). Reverts
+    ///      `DuplicateOperationId` if a non-zero record already exists under
+    ///      that key. `settlementData` carries the RGB OpId as `abi.encode(uint256
+    ///      rgbOpId)`; it is decoded and returned so Bridge can surface it in the
+    ///      RGB-only `FundsIn` event. The RGB OpId is NOT the dedup key — it is a
+    ///      pass-through correlation id (a mempool copy of it cannot pre-empt a
+    ///      deposit, since dedup is on `ctx.operationId`).
+    function onFundsIn(FundsInContext calldata ctx, bytes calldata settlementData)
         external
         override
         onlyRouteRegistry
+        returns (uint256 rgbOpId)
     {
         if (fundsInRecords[ctx.operationId] != 0) revert DuplicateOperationId();
         fundsInRecords[ctx.operationId] = ctx.netAmount;
+
+        rgbOpId = abi.decode(settlementData, (uint256));
+        if (rgbOpId == 0) revert InvalidRgbOpId();
     }
 
     /// @inheritdoc ISettlementModule
-    /// @dev Decodes `settlementData` as `(uint256[] operationIds, uint256[] amounts)`
+    /// @dev Decodes `settlementData` as `(bytes32[] operationIds, uint256[] amounts)`
     ///      and verifies every referenced mint: each `operationId` must exist
     ///      and its recorded amount must equal the supplied amount.
     function beforeFundsOut(FundsOutContext calldata /* ctx */, bytes calldata settlementData)
@@ -138,8 +152,8 @@ contract RgbSettlementModule is ISettlementModule {
         override
         onlyRouteRegistry
     {
-        (uint256[] memory operationIds, uint256[] memory amounts) =
-            abi.decode(settlementData, (uint256[], uint256[]));
+        (bytes32[] memory operationIds, uint256[] memory amounts) =
+            abi.decode(settlementData, (bytes32[], uint256[]));
 
         if (operationIds.length != amounts.length) revert SettlementDataLengthMismatch();
 

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -20,6 +20,7 @@ import {
 } from '../src/interfaces/ICommissionManager.sol';
 
 import { MockERC20 }        from './mocks/MockERC20.sol';
+import { FeeOnTransferERC20 } from './mocks/FeeOnTransferERC20.sol';
 import { MockBtcRelay }     from './mocks/MockBtcRelay.sol';
 import { MockAggregatorV3 } from './mocks/MockAggregatorV3.sol';
 import { MockSettlementModule } from './mocks/MockSettlementModule.sol';
@@ -29,10 +30,12 @@ import { Pausable }  from '@openzeppelin/contracts/utils/Pausable.sol';
 
 contract BridgeTest is Test {
     // Events re-declared locally for vm.expectEmit
-    event FundsIn(address indexed sender, uint256 indexed operationId, uint256 amount);
+    event FundsIn(address indexed sender, uint256 indexed rgbOpId, uint256 amount);
     event BridgeFundsIn(
+        bytes32 indexed operationId,
+        bytes32 indexed sourceSender,
         address indexed sender,
-        uint256 indexed operationId,
+        uint256 senderNonce,
         uint256 amount,
         uint256 netAmount,
         uint256 tokenCommission,
@@ -79,6 +82,11 @@ contract BridgeTest is Test {
     uint256 constant AMOUNT          = 100e18;
     uint256 constant TX_ID           = 42;
     uint256 constant BURN_ID         = 9_001;
+    /// @notice Non-zero RGB OpId threaded through the RGB-route settlementData.
+    uint256 constant RGB_OP_ID       = 0xABCDEF;
+    bytes32 constant FUNDS_OUT_BURN_ID_TYPEHASH = keccak256(
+        'UtexoFundsOutBurnId(address bridge,uint256 chainId,address token,address recipient,uint256 amount,uint256 sourceChainId,uint256 destinationChainId,bytes32 sourceAddressHash,bytes32 proofHash,bytes32 settlementDataHash)'
+    );
 
     // BtcRelay test data
     // RGB proof = two (height, commit) pairs. The source block (RGB burn/lock)
@@ -163,13 +171,83 @@ contract BridgeTest is Test {
     // helpers
     // ========================================================================
 
-    function _singleFundsInId() internal pure returns (uint256[] memory ids) {
-        ids = new uint256[](1);
-        ids[0] = TX_ID;
+    /// @dev RGB-route `settlementData` for `fundsIn`: the module decodes a
+    ///      non-zero `uint256 rgbOpId`.
+    function _rgbData() internal pure returns (bytes memory) {
+        return abi.encode(RGB_OP_ID);
+    }
+
+    /// @dev RGB-route `settlementData` with an explicit rgbOpId (for tests that
+    ///      need distinct ids or the zero-id revert path).
+    function _rgbData(uint256 rgbOpId) internal pure returns (bytes memory) {
+        return abi.encode(rgbOpId);
+    }
+
+    /// @dev Single-element `bytes32[]` for fundsOut settlement operationIds.
+    function _ids(bytes32 id) internal pure returns (bytes32[] memory arr) {
+        arr = new bytes32[](1);
+        arr[0] = id;
+    }
+
+    /// @dev Mirror of `Bridge._deriveOperationId` so tests can precompute the
+    ///      expected canonical id when they need it for an `expectEmit` topic.
+    ///      Prefer capturing the return value of `fundsIn`; this exists for the
+    ///      cases where the id is needed BEFORE the call (event assertions).
+    function _deriveOpId(
+        uint256 sourceChainId,
+        bytes32 sourceSender,
+        uint256 senderNonce,
+        uint256 grossAmount,
+        uint256 destinationChainId,
+        string memory destinationAddress,
+        bytes memory settlementData
+    ) internal view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                bridge.FUNDS_IN_OPERATION_TYPEHASH(),
+                address(bridge),
+                sourceChainId,
+                sourceSender,
+                senderNonce,
+                bridge.TOKEN(),
+                grossAmount,
+                destinationChainId,
+                keccak256(bytes(destinationAddress)),
+                keccak256(settlementData),
+                block.chainid
+            )
+        );
     }
 
     function _proof() internal pure returns (bytes memory) {
         return abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT);
+    }
+
+    /// @dev Mirror of `Bridge._deriveBurnId` so tests can build canonical
+    ///      `fundsOut` payloads after.
+    ///      The typehash is an internal formula/domain separator.
+    function _deriveBurnId(
+        address recipient_,
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory sourceAddress,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal view returns (uint256) {
+        return uint256(keccak256(abi.encode(
+            FUNDS_OUT_BURN_ID_TYPEHASH,
+            address(bridge),
+            block.chainid,
+            address(usdt0),
+            recipient_,
+            amount,
+            sourceChainId,
+            destinationChainId,
+            keccak256(bytes(sourceAddress)),
+            keccak256(proof),
+            keccak256(settlementData)
+        )));
     }
 
     /// @dev Build `settlementData` for the reworked RgbSettlementModule, which
@@ -184,7 +262,7 @@ contract BridgeTest is Test {
     ///      there would consume the cheatcode. Tests whose records differ from
     ///      `AMOUNT` (seeded liquidity, multi-amount, fuzz, deliberate
     ///      mismatch) use `_settlementWithAmounts` with explicit values.
-    function _settlement(uint256[] memory ids) internal pure returns (bytes memory) {
+    function _settlement(bytes32[] memory ids) internal pure returns (bytes memory) {
         uint256[] memory amounts = new uint256[](ids.length);
         for (uint256 i = 0; i < ids.length; i++) {
             amounts[i] = AMOUNT;
@@ -194,7 +272,7 @@ contract BridgeTest is Test {
 
     /// @dev Explicit `(ids, amounts)` encoding for records that are not `AMOUNT`
     ///      (seeded liquidity, multi-amount, fuzz) and for mismatch/length tests.
-    function _settlementWithAmounts(uint256[] memory ids, uint256[] memory amounts)
+    function _settlementWithAmounts(bytes32[] memory ids, uint256[] memory amounts)
         internal
         pure
         returns (bytes memory)
@@ -212,6 +290,24 @@ contract BridgeTest is Test {
     ///      and make the external Bridge call. Keeps `vm.prank` / `vm.expectRevert`
     ///      working: the inner `bridge.fundsOut` is the next external call.
     function _fundsOut(
+        address recipient_,
+        uint256 amount,
+        uint256 /* burnId */,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory sourceAddress,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal returns (uint256 burnId) {
+        burnId = _deriveBurnId(
+            recipient_, amount, sourceChainId, destinationChainId, sourceAddress, proof, settlementData
+        );
+        _fundsOutWithBurnId(
+            recipient_, amount, burnId, sourceChainId, destinationChainId, sourceAddress, proof, settlementData
+        );
+    }
+
+    function _fundsOutWithBurnId(
         address recipient_,
         uint256 amount,
         uint256 burnId,
@@ -453,7 +549,7 @@ contract BridgeTest is Test {
         // Floor is 1 (setUp), so a zero deposit is below the minimum.
         vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, uint256(0), uint256(1)));
         vm.prank(user);
-        bridge.fundsIn(0, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(0, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
     function test_fundsOut_revertsOnZeroAmount() public {
@@ -464,7 +560,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, 0, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(new bytes32[](0))
         );
     }
 
@@ -476,7 +572,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, uint256(999), uint256(1000)));
         vm.prank(user);
-        bridge.fundsIn(999, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(999, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
     function test_fundsIn_acceptsExactlyAtMinimum() public {
@@ -484,8 +580,8 @@ contract BridgeTest is Test {
         bridge.setMinFundsInAmount(1000);
 
         vm.prank(user);
-        bridge.fundsIn(1000, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
-        assertEq(rgbModule.fundsInRecords(TX_ID), 1000, 'deposit at the floor is accepted');
+        bytes32 opId = bridge.fundsIn(1000, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        assertEq(rgbModule.fundsInRecords(opId), 1000, 'deposit at the floor is accepted');
     }
 
     function test_fundsIn_acceptsAboveMinimum() public {
@@ -493,8 +589,8 @@ contract BridgeTest is Test {
         bridge.setMinFundsInAmount(1000);
 
         vm.prank(user);
-        bridge.fundsIn(1001, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
-        assertEq(rgbModule.fundsInRecords(TX_ID), 1001, 'deposit above the floor is accepted');
+        bytes32 opId = bridge.fundsIn(1001, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        assertEq(rgbModule.fundsInRecords(opId), 1001, 'deposit above the floor is accepted');
     }
 
     function test_fundsIn_dustThatRoundsCommissionToZeroIsRejected() public {
@@ -510,12 +606,12 @@ contract BridgeTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, uint256(24), uint256(25)));
         vm.prank(user);
-        bridge.fundsIn(24, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(24, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         // At the floor the deposit is accepted and pays a non-zero commission.
         vm.prank(user);
-        bridge.fundsIn(25, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
-        assertEq(rgbModule.fundsInRecords(TX_ID), 24, 'net = 25 - 1 commission');
+        bytes32 opId = bridge.fundsIn(25, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        assertEq(rgbModule.fundsInRecords(opId), 24, 'net = 25 - 1 commission');
     }
 
     function test_fundsInFromAdapter_revertsBelowMinimum() public {
@@ -532,7 +628,7 @@ contract BridgeTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, uint256(999), uint256(1000)));
         vm.prank(mockAdapter);
-        bridge.fundsIn(999, SOURCE_CHAIN_ID, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(999, SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
     function test_fundsIn_revertsOnDestinationAddressTooLong() public {
@@ -541,20 +637,20 @@ contract BridgeTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IBridge.AddressTooLong.selector, max + 1, max));
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, tooLong, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, tooLong, _rgbData());
     }
 
     function test_fundsIn_acceptsDestinationAddressAtMaxLength() public {
         uint256 max = bridge.MAX_ADDRESS_LENGTH();
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, _str(max), TX_ID, '');
-        assertEq(rgbModule.fundsInRecords(TX_ID), AMOUNT, 'deposit at the address-length cap is accepted');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, _str(max), _rgbData());
+        assertEq(rgbModule.fundsInRecords(opId), AMOUNT, 'deposit at the address-length cap is accepted');
     }
 
     function test_fundsOut_revertsOnSourceAddressTooLong() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         uint256 max = bridge.MAX_ADDRESS_LENGTH();
         string memory tooLong = _str(max + 1);
@@ -564,13 +660,13 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, tooLong,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(_ids(opId))
         );
     }
 
     function test_fundsOut_acceptsSourceAddressAtMaxLength() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         uint256 max = bridge.MAX_ADDRESS_LENGTH();
 
@@ -578,7 +674,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, _str(max),
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(_ids(opId))
         );
         assertEq(usdt0.balanceOf(recipient), AMOUNT, 'release with sourceAddress at the cap succeeds');
     }
@@ -602,7 +698,7 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnProofTooLong() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         uint256 max = bridge.MAX_PROOF_LENGTH();
         bytes memory tooLong = _bytesOfLength(max + 1);
@@ -612,13 +708,13 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            tooLong, _settlement(_singleFundsInId())
+            tooLong, _settlement(_ids(opId))
         );
     }
 
     function test_fundsOut_acceptsProofAtMaxLength() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         // A proof at the exact cap passes the length guard. It then reverts in
         // the verifier (the blob is not a valid (height, commitment) pair), so
@@ -626,12 +722,16 @@ contract BridgeTest is Test {
         // call reaches the verifier instead.
         uint256 max = bridge.MAX_PROOF_LENGTH();
         bytes memory atMax = _bytesOfLength(max);
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 burnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, atMax, settlementData
+        );
 
         vm.prank(multisig);
         try bridge.fundsOut(IBridge.FundsOutParams(
-            recipient, AMOUNT, BURN_ID,
+            recipient, AMOUNT, burnId,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            atMax, _settlement(_singleFundsInId())
+            atMax, settlementData
         )) {
             // a decodable proof would succeed; this blob won't, so we don't
             // expect to land here — but if a future verifier accepts it, the
@@ -647,7 +747,7 @@ contract BridgeTest is Test {
         // The production-shaped 64-byte RGB proof is well under the cap and the
         // happy path still succeeds.
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertLt(_proof().length, bridge.MAX_PROOF_LENGTH(), 'sanity: real proof under cap');
 
@@ -655,7 +755,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(_ids(opId))
         );
         assertEq(usdt0.balanceOf(recipient), AMOUNT, 'release with a normal proof succeeds');
     }
@@ -668,7 +768,7 @@ contract BridgeTest is Test {
         // No adapter set in setUp — caller is `user`.
         vm.prank(user);
         vm.expectRevert(IBridge.NotLZAdapter.selector);
-        bridge.fundsIn(AMOUNT, 1, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, 1, bytes32(uint256(uint160(user))), RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
     function test_fundsInFromAdapter_acceptsCustomSourceChainId() public {
@@ -681,6 +781,7 @@ contract BridgeTest is Test {
         usdt0.approve(address(bridge), AMOUNT);
 
         uint256 customSrc = 137; // pretend Polygon
+        bytes32 sourceSender = bytes32(uint256(uint160(user))); // authenticated far-chain sender
 
         // Register a route for the custom (Polygon, RGB) pair — the adapter
         // overload simply forwards whatever sourceChainId the composeMsg
@@ -691,15 +792,26 @@ contract BridgeTest is Test {
             true, address(rgbVerifier), address(rgbModule)
         );
 
+        // The nonce for this (sourceChainId, sourceSender) starts at 0.
+        bytes32 expectedOpId = _deriveOpId(
+            customSrc, sourceSender, 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+
         // Drop the emitter filter so Forge's expectEmit scans past the token's
         // Transfer event (emitter = usdt0) and matches BridgeFundsIn by topic0.
+        // FundsIn (RGB route) carries the rgbOpId; sender = the adapter.
         vm.expectEmit(true, true, false, true);
-        emit BridgeFundsIn(mockAdapter, TX_ID, AMOUNT, AMOUNT, 0, 0, customSrc, RGB_CHAIN_ID, DST_ADDR);
+        emit FundsIn(mockAdapter, RGB_OP_ID, AMOUNT);
+        vm.expectEmit(true, true, true, true);
+        emit BridgeFundsIn(
+            expectedOpId, sourceSender, mockAdapter, 0, AMOUNT, AMOUNT, 0, 0, customSrc, RGB_CHAIN_ID, DST_ADDR
+        );
 
         vm.prank(mockAdapter);
-        bridge.fundsIn(AMOUNT, customSrc, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, customSrc, sourceSender, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        assertEq(rgbModule.fundsInRecords(TX_ID), AMOUNT, 'record stored on module');
+        assertEq(opId, expectedOpId, 'returned id matches derivation');
+        assertEq(rgbModule.fundsInRecords(opId), AMOUNT, 'record stored on module');
     }
 
     // ========================================================================
@@ -710,7 +822,7 @@ contract BridgeTest is Test {
         uint256 userBefore = usdt0.balanceOf(user);
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
         assertEq(usdt0.balanceOf(user),            userBefore - AMOUNT);
@@ -718,19 +830,26 @@ contract BridgeTest is Test {
 
     function test_fundsIn_storesRecordOnModule() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        assertEq(rgbModule.fundsInRecords(TX_ID), AMOUNT);
+        assertEq(rgbModule.fundsInRecords(opId), AMOUNT);
     }
 
     function test_fundsIn_emitsBothEvents() public {
+        bytes32 sourceSender = bytes32(uint256(uint160(user)));
+        bytes32 expectedOpId = _deriveOpId(
+            SOURCE_CHAIN_ID, sourceSender, 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+
         vm.expectEmit(true, true, false, true);
-        emit FundsIn(user, TX_ID, AMOUNT);
-        vm.expectEmit(true, true, false, true);
-        emit BridgeFundsIn(user, TX_ID, AMOUNT, AMOUNT, 0, 0, SOURCE_CHAIN_ID, RGB_CHAIN_ID, DST_ADDR);
+        emit FundsIn(user, RGB_OP_ID, AMOUNT);
+        vm.expectEmit(true, true, true, true);
+        emit BridgeFundsIn(
+            expectedOpId, sourceSender, user, 0, AMOUNT, AMOUNT, 0, 0, SOURCE_CHAIN_ID, RGB_CHAIN_ID, DST_ADDR
+        );
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
     function test_fundsIn_anyUserCanCall() public {
@@ -740,7 +859,7 @@ contract BridgeTest is Test {
         usdt0.approve(address(bridge), AMOUNT);
 
         vm.prank(stranger);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
     }
@@ -752,13 +871,13 @@ contract BridgeTest is Test {
     function test_fundsIn_revertsOnEmptyDestinationAddress() public {
         vm.expectRevert(IBridge.InvalidDestinationAddress.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, '', TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, '', _rgbData());
     }
 
     function test_fundsIn_revertsOnEmptyDestinationChain() public {
         vm.expectRevert(IBridge.InvalidDestinationChainId.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, 0, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, 0, DST_ADDR, _rgbData());
     }
 
     function test_fundsIn_revertsWhenPaused() public {
@@ -767,18 +886,24 @@ contract BridgeTest is Test {
 
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
-    function test_fundsIn_revertsOnDuplicateOperationId() public {
+    // Post R-W-08 the operationId is derived on-chain with a per-sender nonce,
+    // so two identical deposits from the same sender now get DISTINCT ids and
+    // both succeed — the caller can no longer force a DuplicateOperationId by
+    // replaying params. The duplicate guard is exercised directly at the module
+    // level (RgbSettlementModule.t.sol) instead.
+    function test_fundsIn_repeatedDepositsDoNotCollide() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId1 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        // Duplicate-operationId guard moved into RgbSettlementModule. The
-        // revert propagates up through routeRegistry → Bridge unchanged.
-        vm.expectRevert(RgbSettlementModule.DuplicateOperationId.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId2 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertTrue(opId1 != opId2, 'nonce makes identical deposits distinct');
+        assertEq(rgbModule.fundsInRecords(opId1), AMOUNT, 'first record');
+        assertEq(rgbModule.fundsInRecords(opId2), AMOUNT, 'second record');
     }
 
     // ========================================================================
@@ -787,19 +912,25 @@ contract BridgeTest is Test {
 
     function test_fundsOut_transfersAndEmits() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 burnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
 
         vm.expectEmit(true, true, false, true);
         emit BridgeFundsOut(
-            recipient, AMOUNT, AMOUNT, 0, BURN_ID,
+            recipient, AMOUNT, AMOUNT, 0, burnId,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR
         );
 
         vm.prank(multisig);
         _fundsOut(
-            recipient, AMOUNT, BURN_ID,
+            recipient, AMOUNT, burnId,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            proof, settlementData
         );
 
         assertEq(usdt0.balanceOf(recipient),       AMOUNT);
@@ -808,33 +939,31 @@ contract BridgeTest is Test {
 
     function test_fundsOut_keepsRecordAfterRelease() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         vm.prank(multisig);
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(_ids(opId))
         );
 
         // The mint ledger is permanent (proof-of-mint), not a consumable balance.
-        assertEq(rgbModule.fundsInRecords(TX_ID), AMOUNT, 'record unchanged after release');
+        assertEq(rgbModule.fundsInRecords(opId), AMOUNT, 'record unchanged after release');
     }
 
     function test_fundsOut_multipleFundsInIds() public {
-        uint256 txId1 = 100;
-        uint256 txId2 = 101;
         uint256 amount1 = 60e18;
         uint256 amount2 = 40e18;
 
         vm.prank(user);
-        bridge.fundsIn(amount1, RGB_CHAIN_ID, DST_ADDR, txId1, '');
+        bytes32 opId1 = bridge.fundsIn(amount1, RGB_CHAIN_ID, DST_ADDR, _rgbData(1));
         vm.prank(user);
-        bridge.fundsIn(amount2, RGB_CHAIN_ID, DST_ADDR, txId2, '');
+        bytes32 opId2 = bridge.fundsIn(amount2, RGB_CHAIN_ID, DST_ADDR, _rgbData(2));
 
-        uint256[] memory ids = new uint256[](2);
-        ids[0] = txId1;
-        ids[1] = txId2;
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = opId1;
+        ids[1] = opId2;
         uint256[] memory amounts = new uint256[](2);
         amounts[0] = amount1;
         amounts[1] = amount2;
@@ -848,8 +977,8 @@ contract BridgeTest is Test {
 
         assertEq(usdt0.balanceOf(recipient), amount1 + amount2);
         // Records are a permanent proof-of-mint ledger — not consumed on release.
-        assertEq(rgbModule.fundsInRecords(txId1), amount1, 'record 1 unchanged');
-        assertEq(rgbModule.fundsInRecords(txId2), amount2, 'record 2 unchanged');
+        assertEq(rgbModule.fundsInRecords(opId1), amount1, 'record 1 unchanged');
+        assertEq(rgbModule.fundsInRecords(opId2), amount2, 'record 2 unchanged');
     }
 
     // ========================================================================
@@ -858,7 +987,7 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnUnverifiedBlock() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         // Well-formed two-pair proof, but the source block is unknown to the relay.
         bytes memory badProof =
@@ -870,7 +999,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            badProof, _settlement(_singleFundsInId())
+            badProof, _settlement(_ids(opId))
         );
     }
 
@@ -881,12 +1010,12 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsOnUnknownFundsInId() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = 999;
+        bytes32 unknown = bytes32(uint256(999));
+        bytes32[] memory ids = _ids(unknown);
 
-        vm.expectRevert(abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, 999));
+        vm.expectRevert(abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, unknown));
         vm.prank(multisig);
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
@@ -896,18 +1025,17 @@ contract BridgeTest is Test {
     }
 
     function test_fundsOut_revertsOnAmountMismatch() public {
-        // Record a mint of 50e18 under txId1, then claim it for a different
-        // amount in settlementData. The module binds operationId → exact mint
-        // amount, so the mismatch must revert (surfaced through the Bridge).
-        uint256 txId1 = 100;
+        // Record a mint of 50e18, then claim it for a different amount in
+        // settlementData. The module binds operationId → exact mint amount, so
+        // the mismatch must revert (surfaced through the Bridge).
         vm.prank(user);
-        bridge.fundsIn(50e18, RGB_CHAIN_ID, DST_ADDR, txId1, '');
+        bytes32 opId = bridge.fundsIn(50e18, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        uint256[] memory ids     = new uint256[](1); ids[0] = txId1;
-        uint256[] memory amounts = new uint256[](1); amounts[0] = 60e18; // != recorded 50e18
+        bytes32[] memory ids     = _ids(opId);
+        uint256[] memory amounts = _one(60e18); // != recorded 50e18
 
         vm.expectRevert(abi.encodeWithSelector(
-            RgbSettlementModule.AmountMismatch.selector, txId1, uint256(60e18), uint256(50e18)
+            RgbSettlementModule.AmountMismatch.selector, opId, uint256(60e18), uint256(50e18)
         ));
         vm.prank(multisig);
         _fundsOut(
@@ -918,45 +1046,147 @@ contract BridgeTest is Test {
     }
 
     function test_fundsOut_revertsOnReplayedBurnId() public {
-        uint256 txId1 = 200;
-        uint256 txId2 = 201;
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId1, '');
+        bytes32 opId1 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(1));
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, txId2, '');
+        bytes32 opId2 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(2));
 
-        uint256[] memory ids1 = new uint256[](1); ids1[0] = txId1;
-        uint256[] memory ids2 = new uint256[](1); ids2[0] = txId2;
+        bytes32[] memory ids1 = _ids(opId1);
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlement(ids1);
+        uint256 burnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
 
         vm.prank(multisig);
         _fundsOut(
-            recipient, AMOUNT, BURN_ID,
+            recipient, AMOUNT, burnId,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(ids1)
+            proof, settlementData
         );
-        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burnId recorded');
+        assertTrue(bridge.consumedBurnIds(burnId), 'burnId recorded');
 
         // Second fundsOut with the same burnId — must revert before any
         // module mutation, leaving the second record untouched.
-        vm.expectRevert(abi.encodeWithSelector(IBridge.BurnIdAlreadyConsumed.selector, BURN_ID));
+        vm.expectRevert(abi.encodeWithSelector(IBridge.BurnIdAlreadyConsumed.selector, burnId));
         vm.prank(multisig);
         _fundsOut(
-            recipient, AMOUNT, BURN_ID,
+            recipient, AMOUNT, burnId,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(ids2)
+            proof, settlementData
         );
-        assertEq(rgbModule.fundsInRecords(txId2), AMOUNT, 'second fundsIn record preserved');
+        assertEq(rgbModule.fundsInRecords(opId2), AMOUNT, 'second fundsIn record preserved');
+    }
+
+    function test_fundsOut_revertsOnInvalidDerivedBurnId() public {
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 expectedBurnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+        uint256 invalidBurnId = expectedBurnId ^ 1;
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IBridge.InvalidBurnId.selector, invalidBurnId, expectedBurnId
+        ));
+        vm.prank(multisig);
+        _fundsOutWithBurnId(
+            recipient,
+            AMOUNT,
+            invalidBurnId,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            proof,
+            settlementData
+        );
+
+        assertFalse(bridge.consumedBurnIds(expectedBurnId), 'expected burn id unchanged');
+        assertFalse(bridge.consumedBurnIds(invalidBurnId), 'invalid burn id unchanged');
+    }
+
+    function test_fundsOut_revertsWhenProofChangesAfterBurnIdDerivation() public {
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        bytes memory signedProof = _proof();
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 signedBurnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, signedProof, settlementData
+        );
+
+        bytes memory changedProof =
+            abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, keccak256('changed-proof'));
+        uint256 expectedBurnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, changedProof, settlementData
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IBridge.InvalidBurnId.selector, signedBurnId, expectedBurnId
+        ));
+        vm.prank(multisig);
+        _fundsOutWithBurnId(
+            recipient,
+            AMOUNT,
+            signedBurnId,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            changedProof,
+            settlementData
+        );
+
+        assertFalse(bridge.consumedBurnIds(signedBurnId), 'signed burn id unchanged');
+    }
+
+    function test_fundsOut_revertsWhenSettlementDataChangesAfterBurnIdDerivation() public {
+        vm.prank(user);
+        bytes32 opId1 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(1));
+        vm.prank(user);
+        bytes32 opId2 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(2));
+
+        bytes memory proof = _proof();
+        bytes memory signedSettlementData = _settlement(_ids(opId1));
+        bytes memory changedSettlementData = _settlement(_ids(opId2));
+        uint256 signedBurnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, signedSettlementData
+        );
+        uint256 expectedBurnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, changedSettlementData
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IBridge.InvalidBurnId.selector, signedBurnId, expectedBurnId
+        ));
+        vm.prank(multisig);
+        _fundsOutWithBurnId(
+            recipient,
+            AMOUNT,
+            signedBurnId,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            proof,
+            changedSettlementData
+        );
+
+        assertFalse(bridge.consumedBurnIds(signedBurnId), 'signed burn id unchanged');
+        assertEq(rgbModule.fundsInRecords(opId1), AMOUNT, 'first record unchanged');
+        assertEq(rgbModule.fundsInRecords(opId2), AMOUNT, 'second record unchanged');
     }
 
     function test_fundsOut_revertsOnDoubleSpendsConsumedFundsIn() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         vm.prank(multisig);
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(_ids(opId))
         );
 
         // Top up the bridge directly (simulates a fresh pool) and try a second
@@ -968,6 +1198,10 @@ contract BridgeTest is Test {
         // does). The settlement module no longer consumes records (the mint
         // proof is permanent and would still pass), so the liquidity guard is
         // now the sole backstop against re-releasing a spent deposit.
+        bytes32 altLatestCommit = keccak256('test-btc-alt-latest-commitment');
+        btcRelay.setBlock(LATEST_HEIGHT + 1, altLatestCommit, LATEST_CONFIRMATIONS);
+        bytes memory altProof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT + 1, altLatestCommit);
+
         vm.expectRevert(abi.encodeWithSelector(
             IBridge.InsufficientChainLiquidity.selector, RGB_CHAIN_ID, AMOUNT, uint256(0)
         ));
@@ -975,7 +1209,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, AMOUNT, BURN_ID + 1,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            altProof, _settlement(_ids(opId))
         );
     }
 
@@ -991,14 +1225,14 @@ contract BridgeTest is Test {
     function test_isolatedLiquidity_fundsInCreditsNetAmount() public {
         // No commission in setUp → net == gross.
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
         assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), AMOUNT, 'bucket credited net amount');
     }
 
     function test_isolatedLiquidity_tokenCommissionCreditsNetNotGross() public {
         _setFundsInTokenRule(400); // 4%
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         uint256 fee = cm.calculateStableFee(AMOUNT, 400, 100);
         assertGt(fee, 0, 'sanity: positive fee');
@@ -1007,14 +1241,14 @@ contract BridgeTest is Test {
 
     function test_isolatedLiquidity_fundsOutDebitsGrossAmount() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         uint256 release = 40e18;
         vm.prank(multisig);
         _fundsOut(
             recipient, release, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(_ids(opId)) // settlement amount = recorded AMOUNT
         );
         assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), AMOUNT - release, 'bucket debited by gross release');
     }
@@ -1022,7 +1256,7 @@ contract BridgeTest is Test {
     function test_isolatedLiquidity_chainCannotConsumeAnotherChainsLiquidity() public {
         // Fund only the RGB bucket.
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         // A different source chain with an enabled route and a (full) outflow
         // bucket, so the rate limiter is NOT what blocks — only isolated
@@ -1043,13 +1277,13 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
             otherChain, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(_ids(opId))
         );
     }
 
     function test_isolatedLiquidity_revertRollsBackDebit() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         // Bad proof → verifier reverts downstream of the liquidity debit.
         bytes memory badProof = abi.encode(uint256(999_999), keccak256('unknown'));
@@ -1058,7 +1292,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            badProof, _settlement(_singleFundsInId())
+            badProof, _settlement(_ids(opId))
         );
         assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), AMOUNT, 'debit rolled back on revert');
     }
@@ -1071,7 +1305,7 @@ contract BridgeTest is Test {
         amount = bound(amount, bridge.minFundsInAmount(), AMOUNT * 10);
 
         vm.prank(user);
-        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
         assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), amount, 'credited');
 
         // Mint an unlocked buffer so the pool balance exceeds the locked amount;
@@ -1087,7 +1321,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, amount + 1, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlementWithAmounts(_singleFundsInId(), _one(amount))
+            _proof(), _settlementWithAmounts(_ids(opId), _one(amount))
         );
 
         // Exactly the locked amount succeeds and zeroes the bucket.
@@ -1095,7 +1329,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, amount, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlementWithAmounts(_singleFundsInId(), _one(amount))
+            _proof(), _settlementWithAmounts(_ids(opId), _one(amount))
         );
         assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), 0, 'fully debited');
     }
@@ -1120,15 +1354,19 @@ contract BridgeTest is Test {
     ///      — no external call — so inline use after a cheatcode is safe.
     uint256 _seedAmt;
 
+    /// @dev Bridge-derived operationId of the last `_seedRGB` deposit; used as
+    ///      the record key in `_releaseRGB` settlement data.
+    bytes32 _seedOpId;
+
     function _seedRGB(uint256 amount) internal {
         _seedAmt = amount; // no fundsIn commission in this suite → net == gross
         vm.prank(user);
-        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, SEED_TX, '');
+        _seedOpId = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
     function _releaseRGB(uint256 amount, uint256 burnId) internal {
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = SEED_TX;
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = _seedOpId;
         vm.prank(multisig);
         _fundsOut(
             recipient, amount, burnId, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
@@ -1190,8 +1428,18 @@ contract BridgeTest is Test {
         vm.warp(block.timestamp + 1); // one second later
 
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), rate, 'only refillRate accrued, not a fresh cap');
+        bytes32 altLatestCommit = keccak256('test-btc-short-gap-latest-commitment');
+        btcRelay.setBlock(LATEST_HEIGHT + 1, altLatestCommit, LATEST_CONFIRMATIONS);
+        bytes memory altProof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT + 1, altLatestCommit);
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = _seedOpId;
+
         vm.expectPartialRevert(OutflowRateLimiter.TokenOutflowThrottled.selector);
-        _releaseRGB(cap, BURN_ID + 1);
+        vm.prank(multisig);
+        _fundsOut(
+            recipient, cap, BURN_ID + 1, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            altProof, _settlementWithAmounts(ids, _one(_seedAmt))
+        );
     }
 
     function test_outflow_perChainIsolation() public {
@@ -1250,10 +1498,9 @@ contract BridgeTest is Test {
         // Fund the unconfigured chain's isolated liquidity so only the missing
         // (disabled) bucket blocks the release.
         vm.prank(user);
-        bridge.fundsIn(100 ether, unconfigured, DST_ADDR, SEED_TX, '');
+        bytes32 opId = bridge.fundsIn(100 ether, unconfigured, DST_ADDR, _rgbData());
 
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = SEED_TX;
+        bytes32[] memory ids = _ids(opId);
         vm.expectRevert(OutflowRateLimiter.LimitNotConfigured.selector);
         vm.prank(multisig);
         _fundsOut(recipient, 100 ether, BURN_ID, unconfigured, SOURCE_CHAIN_ID, SRC_ADDR, _proof(), _settlementWithAmounts(ids, _one(100 ether)));
@@ -1265,8 +1512,8 @@ contract BridgeTest is Test {
 
         uint256 globalBefore = bridge.availableGlobalOutflow();
         bytes memory badProof = abi.encode(uint256(999_999), keccak256('unknown'));
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = SEED_TX;
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = _seedOpId;
 
         vm.expectRevert();
         vm.prank(multisig);
@@ -1359,40 +1606,40 @@ contract BridgeTest is Test {
 
     function test_fundsOut_revertsIfNotOwner() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         vm.prank(user);
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(_ids(opId))
         );
     }
 
     function test_fundsOut_revertsOnZeroRecipient() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         vm.expectRevert(BridgeBase.InvalidRecipientAddress.selector);
         vm.prank(multisig);
         _fundsOut(
             address(0), AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(_ids(opId))
         );
     }
 
     function test_fundsOut_revertsIfAmountExceedsPool() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         vm.expectRevert(BridgeBase.AmountExceedBridgePool.selector);
         vm.prank(multisig);
         _fundsOut(
             recipient, AMOUNT + 1, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(_ids(opId))
         );
     }
 
@@ -1408,12 +1655,37 @@ contract BridgeTest is Test {
         uint256 expectedNet        = AMOUNT - expectedCommission;
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(usdt0.balanceOf(address(bridge)),         expectedNet,         'bridge net');
         assertEq(usdt0.balanceOf(address(cm)),             expectedCommission,  'cm pool');
         assertEq(cm.tokenCommissionPool(address(usdt0)),   expectedCommission,  'cm recorded');
-        assertEq(rgbModule.fundsInRecords(TX_ID),          expectedNet,         'record = net');
+        assertEq(rgbModule.fundsInRecords(opId),           expectedNet,         'record = net');
+    }
+
+    // R-I-04 end-to-end: a token already donated directly to the CommissionManager
+    // is NOT absorbed as commission. Bridge measures the delta of its own transfer,
+    // so the pool grows by exactly the real fee; the donation stays a stray balance.
+    function test_fundsIn_tokenCommission_doesNotAbsorbCmDonation_afterFix() public {
+        _setFundsInTokenRule(400); // 4%
+        uint256 expectedCommission = (AMOUNT * 400) / 100 / 100;
+
+        // Unsolicited direct transfer into the CommissionManager.
+        address donor = makeAddr('cmDonor');
+        uint256 donation = 5e18;
+        usdt0.mint(donor, donation);
+        vm.prank(donor);
+        usdt0.transfer(address(cm), donation);
+
+        assertEq(cm.tokenCommissionPool(address(usdt0)), 0,        'pre pool (donation not counted)');
+        assertEq(usdt0.balanceOf(address(cm)),           donation, 'pre cm balance holds donation');
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        // Pool grew by exactly the real commission — the donation was not folded in.
+        assertEq(cm.tokenCommissionPool(address(usdt0)), expectedCommission,            'pool grew only by real commission');
+        assertEq(usdt0.balanceOf(address(cm)),           donation + expectedCommission, 'donation still present as stray balance');
     }
 
     // ========================================================================
@@ -1432,12 +1704,12 @@ contract BridgeTest is Test {
 
         vm.deal(user, nativeC);
         vm.prank(user);
-        bridge.fundsIn{ value: nativeC }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn{ value: nativeC }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(usdt0.balanceOf(address(bridge)), AMOUNT);
         assertEq(address(cm).balance,              nativeC);
         assertEq(cm.nativeCommissionPool(),        nativeC);
-        assertEq(rgbModule.fundsInRecords(TX_ID),  AMOUNT);
+        assertEq(rgbModule.fundsInRecords(opId),   AMOUNT);
     }
 
     // ========================================================================
@@ -1446,7 +1718,7 @@ contract BridgeTest is Test {
 
     function test_fundsOut_tokenCommission_routesToCM() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         uint256 percent = 500; // 5%
         _setFundsOutTokenRule(percent);
@@ -1458,7 +1730,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, AMOUNT, BURN_ID,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_singleFundsInId())
+            _proof(), _settlement(_ids(opId))
         );
 
         assertEq(usdt0.balanceOf(recipient),              expectedNet,         'recipient net');
@@ -1485,7 +1757,7 @@ contract BridgeTest is Test {
         vm.deal(user, 1 ether);
         vm.expectRevert(IBridge.NativeValueMismatch.selector);
         vm.prank(user);
-        bridge.fundsIn{ value: 1 ether }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn{ value: 1 ether }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
     function test_fundsIn_revertsOnNativeValueMismatch_nativeRuleButNoValue() public {
@@ -1493,36 +1765,50 @@ contract BridgeTest is Test {
 
         vm.expectRevert(IBridge.NativeValueMismatch.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
-    function test_nativeValueMismatchRejectsSmallOverpay_currentBehavior() public {
+    // R-I-03 after-fix: a native overpayment (favorable ETH/USD drift between
+    // quote and execution) is now accepted; the FULL msg.value is collected as
+    // commission (not refunded, not stranded) and the deposit completes.
+    function test_fundsIn_nativeOverpayAcceptedAndCollected_afterFix() public {
         _setFundsInNativeRule(100);
 
         (, uint256 nativeCommission,) =
             cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
         assertGt(nativeCommission, 0, 'native fee quoted');
 
-        vm.deal(user, nativeCommission + 1);
+        uint256 sent = nativeCommission + 0.01 ether; // overpay (price moved down)
+        vm.deal(user, sent);
 
-        uint256 userTokenBefore   = usdt0.balanceOf(user);
-        uint256 bridgeTokenBefore = usdt0.balanceOf(address(bridge));
-        uint256 cmNativeBefore    = address(cm).balance;
-        uint256 nativePoolBefore  = cm.nativeCommissionPool();
-        uint256 recordBefore      = rgbModule.fundsInRecords(TX_ID);
+        uint256 cmNativeBefore   = address(cm).balance;
+        uint256 nativePoolBefore = cm.nativeCommissionPool();
 
-        // Current behavior: native fundsIn requires exact msg.value. Even a
-        // 1-wei overpay reverts before token pull, commission credit, or RGB
-        // settlement bookkeeping.
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn{ value: sent }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        // Full msg.value collected as commission — surplus neither refunded nor
+        // left in the Bridge.
+        assertEq(address(cm).balance,       cmNativeBefore + sent,   'cm received full msg.value');
+        assertEq(cm.nativeCommissionPool(), nativePoolBefore + sent, 'native pool credited full msg.value');
+        assertEq(address(bridge).balance,   0,                       'no native stranded in bridge');
+        // Deposit completed: RGB record created (NATIVE rule → token commission 0, net == gross).
+        assertEq(rgbModule.fundsInRecords(opId), AMOUNT, 'deposit recorded from actual amount');
+    }
+
+    // R-I-03: underpaying the freshly-quoted native commission (price moved up)
+    // still reverts — the lower bound is enforced.
+    function test_fundsIn_nativeUnderpayReverts_afterFix() public {
+        _setFundsInNativeRule(100);
+
+        (, uint256 nativeCommission,) =
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
+        assertGt(nativeCommission, 1, 'native fee quoted');
+
+        vm.deal(user, nativeCommission);
         vm.expectRevert(IBridge.NativeValueMismatch.selector);
         vm.prank(user);
-        bridge.fundsIn{ value: nativeCommission + 1 }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
-
-        assertEq(usdt0.balanceOf(user),           userTokenBefore,   'user token unchanged');
-        assertEq(usdt0.balanceOf(address(bridge)), bridgeTokenBefore, 'bridge token unchanged');
-        assertEq(address(cm).balance,             cmNativeBefore,    'cm native unchanged');
-        assertEq(cm.nativeCommissionPool(),       nativePoolBefore,  'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore,      'record unchanged');
+        bridge.fundsIn{ value: nativeCommission - 1 }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
     // ========================================================================
@@ -1556,7 +1842,7 @@ contract BridgeTest is Test {
 
     function test_getContractBalance() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(bridge.getContractBalance(), AMOUNT);
     }
@@ -1574,10 +1860,10 @@ contract BridgeTest is Test {
         usdt0.mint(user, amount);
 
         vm.prank(user);
-        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(usdt0.balanceOf(address(bridge)), amount);
-        assertEq(rgbModule.fundsInRecords(TX_ID),  amount);
+        assertEq(rgbModule.fundsInRecords(opId),   amount);
     }
 
     // ========================================================================
@@ -1600,7 +1886,10 @@ contract BridgeTest is Test {
         uint256 userEthBefore    = user.balance;
         uint256 bridgeEthBefore  = address(bridge).balance;
         uint256 cmEthBefore      = address(cm).balance;
-        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+        bytes32 expectedOpId = _deriveOpId(
+            SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+        uint256 recordBefore     = rgbModule.fundsInRecords(expectedOpId);
 
         assertEq(bridgeBefore,     0, 'pre bridge token');
         assertEq(cmBefore,         0, 'pre cm token');
@@ -1609,11 +1898,13 @@ contract BridgeTest is Test {
         assertEq(recordBefore,     0, 'pre record');
 
         vm.expectEmit(true, true, false, true);
-        emit FundsIn(user, TX_ID, netAmount);
-        vm.expectEmit(true, true, false, true);
+        emit FundsIn(user, RGB_OP_ID, netAmount);
+        vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
+            expectedOpId,
+            bytes32(uint256(uint160(user))),
             user,
-            TX_ID,
+            0,
             AMOUNT,
             netAmount,
             tokenCommission,
@@ -1625,7 +1916,8 @@ contract BridgeTest is Test {
 
         // Execute the real direct fundsIn path: user → Bridge → RouteRegistry → RGB module → CM.
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        assertEq(opId, expectedOpId, 'returned id matches derivation');
 
         assertEq(usdt0.balanceOf(user),            userBefore - AMOUNT,      'user gross spent');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore + netAmount, 'bridge net delta');
@@ -1639,7 +1931,7 @@ contract BridgeTest is Test {
         assertEq(user.balance,                    userEthBefore,    'user native unchanged');
         assertEq(address(bridge).balance,         bridgeEthBefore,  'bridge native unchanged');
         assertEq(address(cm).balance,             cmEthBefore,      'cm native unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore + netAmount, 'record delta = net');
+        assertEq(rgbModule.fundsInRecords(opId), recordBefore + netAmount, 'record delta = net');
 
         // Gross USDT0 is conserved between Bridge liquidity and CM commission custody.
         assertEq(
@@ -1671,7 +1963,10 @@ contract BridgeTest is Test {
         uint256 userEthBefore     = user.balance;
         uint256 bridgeEthBefore   = address(bridge).balance;
         uint256 cmEthBefore       = address(cm).balance;
-        uint256 recordBefore      = rgbModule.fundsInRecords(TX_ID);
+        bytes32 expectedOpId = _deriveOpId(
+            SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+        uint256 recordBefore      = rgbModule.fundsInRecords(expectedOpId);
 
         assertEq(bridgeTokenBefore, 0, 'pre bridge token');
         assertEq(cmTokenBefore,     0, 'pre cm token');
@@ -1680,11 +1975,13 @@ contract BridgeTest is Test {
         assertEq(recordBefore,      0, 'pre record');
 
         vm.expectEmit(true, true, false, true);
-        emit FundsIn(user, TX_ID, netAmount);
-        vm.expectEmit(true, true, false, true);
+        emit FundsIn(user, RGB_OP_ID, netAmount);
+        vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
+            expectedOpId,
+            bytes32(uint256(uint160(user))),
             user,
-            TX_ID,
+            0,
             AMOUNT,
             netAmount,
             0,
@@ -1696,7 +1993,8 @@ contract BridgeTest is Test {
 
         // Execute exact-value native commission path; token principal stays whole.
         vm.prank(user);
-        bridge.fundsIn{ value: nativeCommission }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn{ value: nativeCommission }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        assertEq(opId, expectedOpId, 'returned id matches derivation');
 
         assertEq(usdt0.balanceOf(user),            userTokenBefore - AMOUNT,       'user token gross spent');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeTokenBefore + netAmount,  'bridge token delta');
@@ -1706,7 +2004,7 @@ contract BridgeTest is Test {
         assertEq(user.balance,                     userEthBefore - nativeCommission,    'user native paid');
         assertEq(address(bridge).balance,          bridgeEthBefore,                      'bridge native unchanged');
         assertEq(address(cm).balance,              cmEthBefore + nativeCommission,       'cm native delta');
-        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore + netAmount,             'record delta = net');
+        assertEq(rgbModule.fundsInRecords(opId),   recordBefore + netAmount,             'record delta = net');
 
         // Native fee is conserved in CM custody while the full USDT0 principal stays in Bridge.
         assertEq(usdt0.balanceOf(address(bridge)) - bridgeTokenBefore, AMOUNT,           'gross token in bridge');
@@ -1722,7 +2020,7 @@ contract BridgeTest is Test {
         uint256 percent = 500; // 5%
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
         _setFundsOutTokenRule(percent);
 
         (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount) =
@@ -1731,8 +2029,7 @@ contract BridgeTest is Test {
         assertEq(nativeCommission, 0, 'native fee is zero');
         assertEq(netAmount, releaseAmount - tokenCommission, 'net recipient amount');
 
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = TX_ID;
+        bytes32[] memory ids = _ids(opId);
 
         // Snapshot the Bridge fundsOut state after a larger RGB record exists.
         uint256 bridgeBefore    = usdt0.balanceOf(address(bridge));
@@ -1740,7 +2037,7 @@ contract BridgeTest is Test {
         uint256 cmBefore        = usdt0.balanceOf(address(cm));
         uint256 cmPoolBefore    = cm.tokenCommissionPool(address(usdt0));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
-        uint256 recordBefore    = rgbModule.fundsInRecords(TX_ID);
+        uint256 recordBefore    = rgbModule.fundsInRecords(opId);
 
         assertEq(bridgeBefore,     AMOUNT, 'pre bridge pool');
         assertEq(recipientBefore,  0,      'pre recipient token');
@@ -1748,7 +2045,13 @@ contract BridgeTest is Test {
         assertEq(cmPoolBefore,     0,      'pre cm pool');
         assertEq(nativePoolBefore, 0,      'pre native pool');
         assertEq(recordBefore,     AMOUNT, 'pre record');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlement(ids);
+        uint256 burnId = _deriveBurnId(
+            recipient, releaseAmount, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+        assertFalse(bridge.consumedBurnIds(burnId), 'pre burn id');
 
         vm.expectEmit(true, true, false, true);
         emit BridgeFundsOut(
@@ -1756,7 +2059,7 @@ contract BridgeTest is Test {
             releaseAmount,
             netAmount,
             tokenCommission,
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
@@ -1770,15 +2073,15 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient,
             releaseAmount,
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR,
-            _proof(),
-            _settlement(ids)
+            proof,
+            settlementData
         );
 
-        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
+        assertTrue(bridge.consumedBurnIds(burnId), 'burn id consumed');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore - releaseAmount, 'bridge gross debit');
         assertEq(usdt0.balanceOf(recipient),       recipientBefore + netAmount,  'recipient net delta');
         assertEq(usdt0.balanceOf(address(cm)),     cmBefore + tokenCommission,   'cm fee delta');
@@ -1788,7 +2091,7 @@ contract BridgeTest is Test {
             'cm pool delta'
         );
         assertEq(cm.nativeCommissionPool(),        nativePoolBefore,             'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore, 'record unchanged (proof-of-mint permanent)');
+        assertEq(rgbModule.fundsInRecords(opId),   recordBefore, 'record unchanged (proof-of-mint permanent)');
 
         // The gross Bridge debit splits into recipient net payout and CM token commission.
         assertEq(
@@ -1823,7 +2126,10 @@ contract BridgeTest is Test {
         uint256 cmBefore         = usdt0.balanceOf(address(cm));
         uint256 cmPoolBefore     = cm.tokenCommissionPool(address(usdt0));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
-        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+        bytes32 expectedOpId = _deriveOpId(
+            SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+        uint256 recordBefore     = rgbModule.fundsInRecords(expectedOpId);
 
         assertEq(bridgeBefore, 0, 'pre bridge token');
         assertEq(cmBefore,     0, 'pre cm token');
@@ -1835,14 +2141,14 @@ contract BridgeTest is Test {
         // module revert prevents successful Bridge events from persisting.
         vm.expectRevert(MockSettlementModule.MockModuleForcedRevert.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(usdt0.balanceOf(user),            userBefore,       'user token unchanged');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore,     'bridge token unchanged');
         assertEq(usdt0.balanceOf(address(cm)),     cmBefore,         'cm token unchanged');
         assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
         assertEq(cm.nativeCommissionPool(),        nativePoolBefore, 'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore,     'rgb record unchanged');
+        assertEq(rgbModule.fundsInRecords(expectedOpId), recordBefore, 'rgb record unchanged');
         assertEq(revertingModule.onFundsInCount(), 0,                'module state unchanged');
     }
 
@@ -1865,7 +2171,10 @@ contract BridgeTest is Test {
         uint256 cmBefore         = usdt0.balanceOf(address(cm));
         uint256 cmPoolBefore     = cm.tokenCommissionPool(address(usdt0));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
-        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+        bytes32 expectedOpId = _deriveOpId(
+            SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+        uint256 recordBefore     = rgbModule.fundsInRecords(expectedOpId);
 
         assertEq(bridgeBefore, 0, 'pre bridge token');
         assertEq(cmBefore,     0, 'pre cm token');
@@ -1876,14 +2185,14 @@ contract BridgeTest is Test {
         // late revert prevents successful Bridge events from persisting.
         vm.expectRevert(ICommissionManager.OnlyBridge.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(usdt0.balanceOf(user),            userBefore,       'user token unchanged');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore,     'bridge token unchanged');
         assertEq(usdt0.balanceOf(address(cm)),     cmBefore,         'cm token unchanged');
         assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
         assertEq(cm.nativeCommissionPool(),        nativePoolBefore, 'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore,     'rgb record unchanged');
+        assertEq(rgbModule.fundsInRecords(expectedOpId), recordBefore, 'rgb record unchanged');
     }
 
     // ========================================================================
@@ -1892,7 +2201,7 @@ contract BridgeTest is Test {
 
     function test_fundsOut_verifierRevertRollsBackBurnIdAndRecords() public {
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         // Well-formed two-pair proof, but the source block is unknown to the relay.
         bytes memory badProof =
@@ -1903,9 +2212,13 @@ contract BridgeTest is Test {
         uint256 cmBefore         = usdt0.balanceOf(address(cm));
         uint256 cmPoolBefore     = cm.tokenCommissionPool(address(usdt0));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
-        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+        uint256 recordBefore     = rgbModule.fundsInRecords(opId);
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 burnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, badProof, settlementData
+        );
 
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(burnId), 'pre burn id');
         assertEq(bridgeBefore, AMOUNT, 'pre bridge pool');
         assertEq(recipientBefore, 0, 'pre recipient token');
         assertEq(cmBefore, 0, 'pre cm token');
@@ -1921,50 +2234,53 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient,
             AMOUNT,
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR,
             badProof,
-            _settlement(_singleFundsInId())
+            settlementData
         );
 
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'burn id unchanged');
+        assertFalse(bridge.consumedBurnIds(burnId), 'burn id unchanged');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, 'bridge token unchanged');
         assertEq(usdt0.balanceOf(recipient),       recipientBefore, 'recipient token unchanged');
         assertEq(usdt0.balanceOf(address(cm)),     cmBefore, 'cm token unchanged');
         assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
         assertEq(cm.nativeCommissionPool(),        nativePoolBefore, 'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore, 'rgb record unchanged');
+        assertEq(rgbModule.fundsInRecords(opId),   recordBefore, 'rgb record unchanged');
     }
 
     function test_fundsOut_settlementRevertRollsBackBurnIdAndRecords() public {
-        uint256 txId1 = 100;
-        uint256 txId2 = 101;
         uint256 amount1 = 50e18;
         uint256 amount2 = 50e18;
         uint256 releaseAmount = 50e18;
 
         vm.prank(user);
-        bridge.fundsIn(amount1, RGB_CHAIN_ID, DST_ADDR, txId1, '');
+        bytes32 opId1 = bridge.fundsIn(amount1, RGB_CHAIN_ID, DST_ADDR, _rgbData(1));
         vm.prank(user);
-        bridge.fundsIn(amount2, RGB_CHAIN_ID, DST_ADDR, txId2, '');
+        bytes32 opId2 = bridge.fundsIn(amount2, RGB_CHAIN_ID, DST_ADDR, _rgbData(2));
 
-        // Reference txId1 with a deliberately wrong amount so the settlement
+        // Reference opId1 with a deliberately wrong amount so the settlement
         // module reverts (AmountMismatch) after the Bridge has already marked
         // the burn id and debited liquidity — exercising the rollback.
-        uint256[] memory ids        = new uint256[](1); ids[0] = txId1;
-        uint256[] memory badAmounts = new uint256[](1); badAmounts[0] = amount1 + 1;
+        bytes32[] memory ids        = _ids(opId1);
+        uint256[] memory badAmounts = _one(amount1 + 1);
 
         uint256 bridgeBefore     = usdt0.balanceOf(address(bridge));
         uint256 recipientBefore  = usdt0.balanceOf(recipient);
         uint256 cmBefore         = usdt0.balanceOf(address(cm));
         uint256 cmPoolBefore     = cm.tokenCommissionPool(address(usdt0));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
-        uint256 record1Before    = rgbModule.fundsInRecords(txId1);
-        uint256 record2Before    = rgbModule.fundsInRecords(txId2);
+        uint256 record1Before    = rgbModule.fundsInRecords(opId1);
+        uint256 record2Before    = rgbModule.fundsInRecords(opId2);
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlementWithAmounts(ids, badAmounts);
+        uint256 burnId = _deriveBurnId(
+            recipient, releaseAmount, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
 
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(burnId), 'pre burn id');
         assertEq(bridgeBefore, amount1 + amount2, 'pre bridge pool');
         assertEq(recipientBefore, 0, 'pre recipient token');
         assertEq(cmBefore, 0, 'pre cm token');
@@ -1977,42 +2293,42 @@ contract BridgeTest is Test {
         // must atomically roll back the burn-id mark and the liquidity debit.
         // (Records are view-only now, so they are trivially unchanged.)
         vm.expectRevert(abi.encodeWithSelector(
-            RgbSettlementModule.AmountMismatch.selector, txId1, amount1 + 1, amount1
+            RgbSettlementModule.AmountMismatch.selector, opId1, amount1 + 1, amount1
         ));
         vm.prank(multisig);
         _fundsOut(
             recipient,
             releaseAmount,
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR,
-            _proof(),
-            _settlementWithAmounts(ids, badAmounts)
+            proof,
+            settlementData
         );
 
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'burn id unchanged');
+        assertFalse(bridge.consumedBurnIds(burnId), 'burn id unchanged');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, 'bridge token unchanged');
         assertEq(usdt0.balanceOf(recipient),       recipientBefore, 'recipient token unchanged');
         assertEq(usdt0.balanceOf(address(cm)),     cmBefore, 'cm token unchanged');
         assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
         assertEq(cm.nativeCommissionPool(),        nativePoolBefore, 'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(txId1),  record1Before, 'record 1 unchanged');
-        assertEq(rgbModule.fundsInRecords(txId2),  record2Before, 'record 2 unchanged');
+        assertEq(rgbModule.fundsInRecords(opId1),  record1Before, 'record 1 unchanged');
+        assertEq(rgbModule.fundsInRecords(opId2),  record2Before, 'record 2 unchanged');
     }
 
     // Current behavior reproduction
     // ========================================================================
 
-    function test_fundsOutAcceptsProofNotBoundToReleaseContext_currentBehavior() public {
+    function test_fundsOutVerifierProofStillNotRouteContextAware_currentBehavior() public {
         address alternateRecipient = makeAddr('alternateRecipient');
         uint256 releaseAmount = 37e18;
-        uint256 alternateBurnId = BURN_ID + 777;
         // R-C-01 (isolated liquidity + outflow limit) gates the `sourceChainId`
         // dimension: a release can only draw from a funded + rate-limited source
-        // chain. So this reproduction keeps the source on the funded RGB chain
-        // and shows the *remaining* unbound dimensions — recipient, amount,
-        // burnId and destinationChainId are still not bound to the verifier proof.
+        // chain. So this reproduction keeps the source on the funded RGB chain.
+        // R-M-01 now binds the release intent and exact proof into burnId, but
+        // RGBVerifier itself still validates only BTC block commitments; it does
+        // not parse route/business context from the proof.
         uint256 alternateSourceChainId = RGB_CHAIN_ID;
         uint256 alternateDestinationChainId = SOURCE_CHAIN_ID + 77;
         string memory alternateSourceAddress = 'rgb:unbound/source/utxo999';
@@ -2027,30 +2343,39 @@ contract BridgeTest is Test {
         );
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
         uint256 recipientBefore = usdt0.balanceOf(alternateRecipient);
-        uint256 recordBefore = rgbModule.fundsInRecords(TX_ID);
+        uint256 recordBefore = rgbModule.fundsInRecords(opId);
 
         assertEq(bridgeBefore, AMOUNT, 'pre bridge pool');
         assertEq(recipientBefore, 0, 'pre recipient token');
         assertEq(recordBefore, AMOUNT, 'pre record');
-        assertFalse(bridge.consumedBurnIds(alternateBurnId), 'pre burn id');
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 burnId = _deriveBurnId(
+            alternateRecipient,
+            releaseAmount,
+            alternateSourceChainId,
+            alternateDestinationChainId,
+            alternateSourceAddress,
+            proof,
+            settlementData
+        );
+        assertFalse(bridge.consumedBurnIds(burnId), 'pre burn id');
 
-        // Current behavior: this is still an authorized fundsOut call, but the
-        // RGBVerifier checks only the encoded BTC block commitment proof. The
-        // record was created on the default route and the release is accepted on
-        // this alternate enabled route because the proof is not bound to release
-        // context on-chain. If that binding is enforced later, invert this to
-        // expect a revert.
+        // Current verifier behavior: this is an authorized fundsOut call with a
+        // matching Bridge-derived burnId, but RGBVerifier checks only the encoded
+        // BTC block commitments. If the RGB proof later carries enough context
+        // for verifier-level binding, invert this to expect a verifier revert.
         vm.expectEmit(true, true, false, true, address(bridge));
         emit BridgeFundsOut(
             alternateRecipient,
             releaseAmount,
             releaseAmount,
             0,
-            alternateBurnId,
+            burnId,
             alternateSourceChainId,
             alternateDestinationChainId,
             alternateSourceAddress
@@ -2060,72 +2385,50 @@ contract BridgeTest is Test {
         _fundsOut(
             alternateRecipient,
             releaseAmount,
-            alternateBurnId,
+            burnId,
             alternateSourceChainId,
             alternateDestinationChainId,
             alternateSourceAddress,
-            _proof(),
-            _settlement(_singleFundsInId())
+            proof,
+            settlementData
         );
 
-        assertTrue(bridge.consumedBurnIds(alternateBurnId), 'burn id consumed');
+        assertTrue(bridge.consumedBurnIds(burnId), 'burn id consumed');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore - releaseAmount, 'bridge debit');
         assertEq(usdt0.balanceOf(alternateRecipient), recipientBefore + releaseAmount, 'recipient credited');
-        assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore, 'record unchanged (proof-of-mint permanent)');
+        assertEq(rgbModule.fundsInRecords(opId), recordBefore, 'record unchanged (proof-of-mint permanent)');
     }
 
-    function test_operationIdPreemptionBlocksVictimRgbDeposit_currentBehavior() public {
+    // R-W-08 FIX: the pre-emption attack is closed. The operationId is now
+    // derived on-chain from the authenticated `sourceSender` + a per-sender
+    // nonce, so an attacker cannot compute (let alone occupy) a victim's id by
+    // copying the RGB OpId out of the mempool. A preemptor sharing the same
+    // rgbOpId lands on a DIFFERENT derived id, and the victim's deposit still
+    // succeeds under its own id.
+    function test_fundsIn_preemptorCannotBlockVictimDeposit() public {
         address preemptor = makeAddr('operationIdPreemptor');
-        uint256 predictedOperationId = TX_ID + 9_000;
         uint256 preemptAmount = 25e18;
 
         usdt0.mint(preemptor, preemptAmount);
         vm.prank(preemptor);
         usdt0.approve(address(bridge), preemptAmount);
 
-        uint256 preemptorBefore = usdt0.balanceOf(preemptor);
-        uint256 victimBefore = usdt0.balanceOf(user);
-        uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
-        uint256 recordBefore = rgbModule.fundsInRecords(predictedOperationId);
-
-        assertEq(preemptorBefore, preemptAmount, 'pre preemptor token');
-        assertEq(recordBefore, 0, 'pre predicted record');
-
-        // Current behavior: operationId uniqueness is enforced only by the
-        // settlement record. A different address can occupy a predicted id
-        // first, but doing so locks that address's own USDT0 in the Bridge.
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsIn(preemptor, predictedOperationId, preemptAmount);
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit BridgeFundsIn(
-            preemptor,
-            predictedOperationId,
-            preemptAmount,
-            preemptAmount,
-            0,
-            0,
-            SOURCE_CHAIN_ID,
-            RGB_CHAIN_ID,
-            DST_ADDR
-        );
-
+        // Preemptor deposits first, reusing the SAME rgbOpId the victim will use.
         vm.prank(preemptor);
-        bridge.fundsIn(preemptAmount, RGB_CHAIN_ID, DST_ADDR, predictedOperationId, '');
+        bytes32 preemptOpId = bridge.fundsIn(preemptAmount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        assertEq(rgbModule.fundsInRecords(preemptOpId), preemptAmount, 'preemptor record');
 
-        uint256 bridgeAfterPreempt = usdt0.balanceOf(address(bridge));
-        uint256 recordAfterPreempt = rgbModule.fundsInRecords(predictedOperationId);
+        uint256 victimBefore = usdt0.balanceOf(user);
 
-        assertEq(usdt0.balanceOf(preemptor), preemptorBefore - preemptAmount, 'preemptor funds locked');
-        assertEq(bridgeAfterPreempt, bridgeBefore + preemptAmount, 'bridge credited by preemptor');
-        assertEq(recordAfterPreempt, recordBefore + preemptAmount, 'record occupied');
-
-        vm.expectRevert(RgbSettlementModule.DuplicateOperationId.selector);
+        // Victim's deposit with identical params + identical rgbOpId still
+        // succeeds: its derived id binds the victim's sourceSender, so it cannot
+        // collide with the preemptor's id.
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, predictedOperationId, '');
+        bytes32 victimOpId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        assertEq(usdt0.balanceOf(user), victimBefore, 'victim token unchanged');
-        assertEq(usdt0.balanceOf(address(bridge)), bridgeAfterPreempt, 'bridge unchanged after victim revert');
-        assertEq(rgbModule.fundsInRecords(predictedOperationId), recordAfterPreempt, 'preempted record unchanged');
+        assertTrue(victimOpId != preemptOpId, 'victim id distinct from preemptor id');
+        assertEq(rgbModule.fundsInRecords(victimOpId), AMOUNT, 'victim record created');
+        assertEq(usdt0.balanceOf(user), victimBefore - AMOUNT, 'victim deposit went through');
     }
 
     // Current behavior: a plain ERC20 transfer can change Bridge's raw balance,
@@ -2133,7 +2436,9 @@ contract BridgeTest is Test {
     function test_directTokenTransferDoesNotCreateFundsInAccounting_currentBehavior() public {
         address donor = makeAddr('directTransferDonor');
         uint256 directAmount = 17e18;
-        uint256 operationId = TX_ID + 11_000;
+        bytes32 expectedOpId = _deriveOpId(
+            SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
 
         usdt0.mint(donor, directAmount);
 
@@ -2143,7 +2448,7 @@ contract BridgeTest is Test {
         uint256 cmBefore = usdt0.balanceOf(address(cm));
         uint256 cmPoolBefore = cm.tokenCommissionPool(address(usdt0));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
-        uint256 recordBefore = rgbModule.fundsInRecords(operationId);
+        uint256 recordBefore = rgbModule.fundsInRecords(expectedOpId);
 
         assertEq(donorBefore, directAmount, 'pre donor token');
         assertEq(bridgeBefore, 0, 'pre bridge token');
@@ -2157,14 +2462,16 @@ contract BridgeTest is Test {
         assertEq(usdt0.balanceOf(address(cm)), cmBefore, 'cm token unchanged');
         assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
         assertEq(cm.nativeCommissionPool(), nativePoolBefore, 'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(operationId), recordBefore, 'record not created');
+        assertEq(rgbModule.fundsInRecords(expectedOpId), recordBefore, 'record not created');
 
         vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsIn(user, operationId, AMOUNT);
-        vm.expectEmit(true, true, false, true, address(bridge));
+        emit FundsIn(user, RGB_OP_ID, AMOUNT);
+        vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
+            expectedOpId,
+            bytes32(uint256(uint160(user))),
             user,
-            operationId,
+            0,
             AMOUNT,
             AMOUNT,
             0,
@@ -2175,32 +2482,36 @@ contract BridgeTest is Test {
         );
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, operationId, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(usdt0.balanceOf(user), userBefore - AMOUNT, 'user fundsIn spent');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore + directAmount + AMOUNT, 'bridge includes direct plus fundsIn');
-        assertEq(rgbModule.fundsInRecords(operationId), recordBefore + AMOUNT, 'record created only by fundsIn');
+        assertEq(rgbModule.fundsInRecords(opId), recordBefore + AMOUNT, 'record created only by fundsIn');
     }
 
     // Current behavior: Bridge only rejects an empty destination address, so a
     // non-empty string is accepted and emitted without format validation.
     function test_fundsIn_acceptsInvalidButNonEmptyDestinationAddress_currentBehavior() public {
         string memory invalidDestination = 'not-rgb-destination';
-        uint256 operationId = TX_ID + 12_000;
+        bytes32 expectedOpId = _deriveOpId(
+            SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, AMOUNT, RGB_CHAIN_ID, invalidDestination, _rgbData()
+        );
 
         uint256 userBefore = usdt0.balanceOf(user);
         uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
-        uint256 recordBefore = rgbModule.fundsInRecords(operationId);
+        uint256 recordBefore = rgbModule.fundsInRecords(expectedOpId);
 
         assertEq(bridgeBefore, 0, 'pre bridge token');
         assertEq(recordBefore, 0, 'pre record');
 
         vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsIn(user, operationId, AMOUNT);
-        vm.expectEmit(true, true, false, true, address(bridge));
+        emit FundsIn(user, RGB_OP_ID, AMOUNT);
+        vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
+            expectedOpId,
+            bytes32(uint256(uint160(user))),
             user,
-            operationId,
+            0,
             AMOUNT,
             AMOUNT,
             0,
@@ -2211,17 +2522,20 @@ contract BridgeTest is Test {
         );
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, invalidDestination, operationId, '');
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, invalidDestination, _rgbData());
 
         assertEq(usdt0.balanceOf(user), userBefore - AMOUNT, 'user fundsIn spent');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore + AMOUNT, 'bridge credited');
-        assertEq(rgbModule.fundsInRecords(operationId), recordBefore + AMOUNT, 'record created');
+        assertEq(rgbModule.fundsInRecords(opId), recordBefore + AMOUNT, 'record created');
     }
 
     // Current behavior: Bridge calls the settlement hook after pulling gross
     // funds but before forwarding token commission, so a hook can observe funds
     // that will not remain as Bridge liquidity after the call.
-    function test_onFundsInHookSeesBalanceIncludingFutureCommission_currentBehavior() public {
+    // R-W-17 after-fix: the token commission is forwarded before the onFundsIn
+    // hook, so a settlement module reading getContractBalance during the hook
+    // observes only the net the Bridge retains — never the in-flight commission.
+    function test_onFundsInHookSeesNetBalanceNotFutureCommission_afterFix() public {
         uint256 percent = 400; // 4%
         _setFundsInTokenRule(percent);
 
@@ -2232,6 +2546,8 @@ contract BridgeTest is Test {
 
         MockSettlementModule observingModule = new MockSettlementModule();
         observingModule.setFundsInBalanceProbe(address(usdt0), address(bridge));
+        // Return a non-zero external id so Bridge emits the RGB-only FundsIn event.
+        observingModule.setExternalIdToReturn(RGB_OP_ID);
 
         vm.prank(deployer);
         routeRegistry.setRoute(
@@ -2250,12 +2566,18 @@ contract BridgeTest is Test {
         assertEq(cmBefore, 0, 'pre cm token');
         assertEq(cmPoolBefore, 0, 'pre cm pool');
 
+        bytes32 expectedOpId = _deriveOpId(
+            SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+
         vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsIn(user, TX_ID + 10_000, netAmount);
-        vm.expectEmit(true, true, false, true, address(bridge));
+        emit FundsIn(user, RGB_OP_ID, netAmount);
+        vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
+            expectedOpId,
+            bytes32(uint256(uint160(user))),
             user,
-            TX_ID + 10_000,
+            0,
             AMOUNT,
             netAmount,
             tokenCommission,
@@ -2266,14 +2588,14 @@ contract BridgeTest is Test {
         );
 
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 10_000, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(observingModule.onFundsInCount(), 1, 'module called once');
         assertEq(observingModule.lastNetAmount(), netAmount, 'module got net amount');
         assertEq(
             observingModule.lastObservedBalanceOnFundsIn(),
-            bridgeBefore + AMOUNT,
-            'hook saw gross bridge balance'
+            bridgeBefore + netAmount,
+            'hook sees only the retained net, not the in-flight commission'
         );
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore + netAmount, 'final bridge net');
         assertEq(usdt0.balanceOf(address(cm)), cmBefore + tokenCommission, 'cm token delta');
@@ -2287,7 +2609,7 @@ contract BridgeTest is Test {
     // failures exercise post-pull rollback.
     function testFuzz_fundsIn_revertPathsLeaveStateUnchanged(
         uint128 amountSeed,
-        uint128 operationSalt
+        uint128 /* operationSalt */
     ) public {
         // Lower bound keeps commission/native fee nonzero so intended reverts fire.
         uint256 amount = bound(uint256(amountSeed), 100, AMOUNT);
@@ -2296,7 +2618,6 @@ contract BridgeTest is Test {
             uint256 snapshotId = vm.snapshotState();
             _assertFundsInRevertPathLeavesStateUnchanged(
                 amount,
-                TX_ID + 30_000 + uint256(operationSalt) + failureMode,
                 failureMode
             );
             assertTrue(vm.revertToStateAndDelete(snapshotId), 'scenario snapshot restored');
@@ -2305,7 +2626,6 @@ contract BridgeTest is Test {
 
     function _assertFundsInRevertPathLeavesStateUnchanged(
         uint256 amount,
-        uint256 operationId,
         uint8 failureMode
     ) internal {
         bytes memory expectedRevert;
@@ -2363,11 +2683,14 @@ contract BridgeTest is Test {
         uint256 cmNativeBefore     = address(cm).balance;
         uint256 cmPoolBefore       = cm.tokenCommissionPool(address(usdt0));
         uint256 nativePoolBefore   = cm.nativeCommissionPool();
-        uint256 recordBefore       = rgbModule.fundsInRecords(operationId);
+        bytes32 expectedOpId = _deriveOpId(
+            SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, amount, RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+        uint256 recordBefore       = rgbModule.fundsInRecords(expectedOpId);
 
         vm.expectRevert(expectedRevert);
         vm.prank(user);
-        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, operationId, '');
+        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(usdt0.balanceOf(user),            userTokenBefore,    'user token unchanged');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeTokenBefore,  'bridge token unchanged');
@@ -2377,24 +2700,24 @@ contract BridgeTest is Test {
         assertEq(address(cm).balance,              cmNativeBefore,     'cm native unchanged');
         assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore, 'cm pool unchanged');
         assertEq(cm.nativeCommissionPool(),        nativePoolBefore,   'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(operationId), recordBefore,  'rgb record unchanged');
+        assertEq(rgbModule.fundsInRecords(expectedOpId), recordBefore, 'rgb record unchanged');
 
         if (failureMode == 1) {
             assertEq(revertingModule.onFundsInCount(), 0, 'module state unchanged');
         }
     }
 
-    // A positive-net RGB deposit must occupy its operationId exactly once; the
-    // duplicate revert happens after token pull, so the second attempt must roll
-    // back without changing balances, pools, or the existing RGB record.
-    function testFuzz_fundsIn_positiveNetDepositCreatesRecordAndRejectsDuplicate(
+    // A positive-net RGB deposit records net under its DERIVED operationId. Post
+    // R-W-08 a repeated identical deposit no longer collides (the per-sender
+    // nonce yields a distinct id), so the second deposit succeeds and creates a
+    // second record. The module-level DuplicateOperationId guard is covered in
+    // RgbSettlementModule.t.sol.
+    function testFuzz_fundsIn_positiveNetDepositCreatesRecordAndDistinctRepeat(
         uint128 amountSeed,
-        uint16 percentSeed,
-        uint128 operationSalt
+        uint16 percentSeed
     ) public {
         uint256 amount = bound(uint256(amountSeed), 100, AMOUNT);
         uint256 percent = bound(uint256(percentSeed), 100, 9_000);
-        uint256 operationId = TX_ID + 40_000 + uint256(operationSalt);
 
         _setFundsInTokenRule(percent);
 
@@ -2403,7 +2726,6 @@ contract BridgeTest is Test {
 
         assertGt(tokenCommission, 0, 'pre positive token fee');
         assertGt(netAmount, 0, 'pre positive net');
-        assertEq(rgbModule.fundsInRecords(operationId), 0, 'pre record empty');
 
         uint256 userBefore = usdt0.balanceOf(user);
         uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
@@ -2411,12 +2733,18 @@ contract BridgeTest is Test {
         uint256 cmPoolBefore = cm.tokenCommissionPool(address(usdt0));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
 
+        bytes32 expectedOpId = _deriveOpId(
+            SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, amount, RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+
         vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsIn(user, operationId, netAmount);
-        vm.expectEmit(true, true, false, true, address(bridge));
+        emit FundsIn(user, RGB_OP_ID, netAmount);
+        vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
+            expectedOpId,
+            bytes32(uint256(uint160(user))),
             user,
-            operationId,
+            0,
             amount,
             netAmount,
             tokenCommission,
@@ -2427,7 +2755,8 @@ contract BridgeTest is Test {
         );
 
         vm.prank(user);
-        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, operationId, '');
+        bytes32 opId1 = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        assertEq(opId1, expectedOpId, 'returned id matches derivation');
 
         assertEq(usdt0.balanceOf(user), userBefore - amount, 'user spent gross once');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore + netAmount, 'bridge got net');
@@ -2438,7 +2767,7 @@ contract BridgeTest is Test {
             'cm pool recorded fee'
         );
         assertEq(cm.nativeCommissionPool(), nativePoolBefore, 'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(operationId), netAmount, 'record = net');
+        assertEq(rgbModule.fundsInRecords(opId1), netAmount, 'record = net');
         assertEq(
             (usdt0.balanceOf(address(bridge)) - bridgeBefore) +
             (usdt0.balanceOf(address(cm)) - cmBefore),
@@ -2446,26 +2775,21 @@ contract BridgeTest is Test {
             'gross token conserved'
         );
 
-        uint256 userAfterFirst = usdt0.balanceOf(user);
-        uint256 bridgeAfterFirst = usdt0.balanceOf(address(bridge));
-        uint256 cmAfterFirst = usdt0.balanceOf(address(cm));
-        uint256 cmPoolAfterFirst = cm.tokenCommissionPool(address(usdt0));
-
-        vm.expectRevert(RgbSettlementModule.DuplicateOperationId.selector);
+        // Repeat identical deposit — nonce increments, so a DISTINCT id is
+        // derived and the deposit succeeds (no DuplicateOperationId).
         vm.prank(user);
-        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, operationId, '');
+        bytes32 opId2 = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        assertEq(usdt0.balanceOf(user), userAfterFirst, 'duplicate user unchanged');
-        assertEq(usdt0.balanceOf(address(bridge)), bridgeAfterFirst, 'duplicate bridge unchanged');
-        assertEq(usdt0.balanceOf(address(cm)), cmAfterFirst, 'duplicate cm unchanged');
-        assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolAfterFirst, 'duplicate pool unchanged');
-        assertEq(cm.nativeCommissionPool(), nativePoolBefore, 'duplicate native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(operationId), netAmount, 'duplicate record unchanged');
+        assertTrue(opId2 != opId1, 'repeat deposit gets a distinct id');
+        assertEq(rgbModule.fundsInRecords(opId1), netAmount, 'first record unchanged');
+        assertEq(rgbModule.fundsInRecords(opId2), netAmount, 'second record created');
     }
 
-    // Current behavior: a positive gross deposit with zero net leaves the
-    // operationId reusable because the RGB duplicate guard is value-based.
-    function test_fundsIn_zeroNetDepositLeavesOperationIdReusable_currentBehavior() public {
+    // A positive gross deposit with zero net leaves a zero record — the RGB
+    // duplicate guard is value-based, so a zero record does not occupy the id.
+    // Post R-W-08 each deposit derives a distinct id anyway; this proves the
+    // zero-net record semantics still hold under a derived id.
+    function test_fundsIn_zeroNetDepositLeavesZeroRecord_currentBehavior() public {
         // stablePercent == multiplier^2 makes tokenCommission == amount.
         vm.prank(deployer);
         cm.setCommissionRule(
@@ -2481,21 +2805,17 @@ contract BridgeTest is Test {
             })
         );
 
-        _assertZeroNetDepositLeavesOperationIdReusable(1, TX_ID + 50_001);
-        _assertZeroNetDepositLeavesOperationIdReusable(AMOUNT / 2, TX_ID + 50_002);
-        _assertZeroNetDepositLeavesOperationIdReusable(AMOUNT, TX_ID + 50_003);
+        _assertZeroNetDepositLeavesZeroRecord(1);
+        _assertZeroNetDepositLeavesZeroRecord(AMOUNT / 2);
+        _assertZeroNetDepositLeavesZeroRecord(AMOUNT);
     }
 
-    function _assertZeroNetDepositLeavesOperationIdReusable(
-        uint256 amount,
-        uint256 operationId
-    ) internal {
+    function _assertZeroNetDepositLeavesZeroRecord(uint256 amount) internal {
         (uint256 tokenCommission,, uint256 netAmount) =
             cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), amount);
 
         assertEq(tokenCommission, amount, 'pre fee equals amount');
         assertEq(netAmount, 0, 'pre zero net');
-        assertEq(rgbModule.fundsInRecords(operationId), 0, 'pre record empty');
 
         uint256 userBefore = usdt0.balanceOf(user);
         uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
@@ -2504,53 +2824,389 @@ contract BridgeTest is Test {
         uint256 nativePoolBefore = cm.nativeCommissionPool();
 
         vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsIn(user, operationId, 0);
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit BridgeFundsIn(
-            user,
-            operationId,
-            amount,
-            0,
-            amount,
-            0,
-            SOURCE_CHAIN_ID,
-            RGB_CHAIN_ID,
-            DST_ADDR
-        );
-
+        emit FundsIn(user, RGB_OP_ID, 0);
         vm.prank(user);
-        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, operationId, '');
+        bytes32 opId1 = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         assertEq(usdt0.balanceOf(user), userBefore - amount, 'user spent first gross');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, 'bridge keeps no net');
         assertEq(usdt0.balanceOf(address(cm)), cmBefore + amount, 'cm got first gross');
         assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore + amount, 'cm pool first gross');
         assertEq(cm.nativeCommissionPool(), nativePoolBefore, 'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(operationId), 0, 'zero record leaves id reusable');
+        assertEq(rgbModule.fundsInRecords(opId1), 0, 'zero-net leaves zero record');
 
+        // A second identical deposit derives a distinct id and also leaves a
+        // zero record — no collision, no revert.
         vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsIn(user, operationId, 0);
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit BridgeFundsIn(
-            user,
-            operationId,
-            amount,
-            0,
-            amount,
-            0,
-            SOURCE_CHAIN_ID,
-            RGB_CHAIN_ID,
-            DST_ADDR
-        );
-
+        emit FundsIn(user, RGB_OP_ID, 0);
         vm.prank(user);
-        bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, operationId, '');
+        bytes32 opId2 = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
+        assertTrue(opId2 != opId1, 'second deposit distinct id');
         assertEq(usdt0.balanceOf(user), userBefore - (2 * amount), 'user spent duplicate gross');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, 'bridge still keeps no net');
         assertEq(usdt0.balanceOf(address(cm)), cmBefore + (2 * amount), 'cm got duplicate gross');
         assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore + (2 * amount), 'cm pool duplicate gross');
         assertEq(cm.nativeCommissionPool(), nativePoolBefore, 'duplicate native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(operationId), 0, 'duplicate still leaves zero record');
+        assertEq(rgbModule.fundsInRecords(opId2), 0, 'second zero record');
+    }
+
+    // ========================================================================
+    // R-W-08 — on-chain-derived, unpredictable operationId (new regression)
+    // ========================================================================
+
+    /// @dev The id is derived on-chain from the authenticated sender; two
+    ///      different senders with otherwise-identical deposits produce
+    ///      different ids, so an attacker cannot reproduce a victim's id.
+    function test_fundsIn_derivesUnpredictableOperationId_notCallerControlled() public {
+        address attacker = makeAddr('attacker');
+        usdt0.mint(attacker, AMOUNT);
+        vm.prank(attacker);
+        usdt0.approve(address(bridge), AMOUNT);
+
+        vm.prank(user);
+        bytes32 victimId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        vm.prank(attacker);
+        bytes32 attackerId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertTrue(victimId != attackerId, 'ids bound to distinct senders differ');
+        // The attacker's id equals the on-chain derivation for the attacker's
+        // sender — it cannot be any value the attacker freely chose.
+        assertEq(
+            attackerId,
+            _deriveOpId(SOURCE_CHAIN_ID, bytes32(uint256(uint160(attacker))), 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()),
+            'attacker id is the derived value'
+        );
+    }
+
+    /// @dev Same sender, identical params twice: distinct ids (nonce), and the
+    ///      per-(chain,sender) nonce advances to 2.
+    function test_fundsIn_repeatedIdenticalDepositsGetDistinctIds() public {
+        bytes32 sourceSender = bytes32(uint256(uint160(user)));
+        assertEq(bridge.sourceSenderNonces(SOURCE_CHAIN_ID, sourceSender), 0, 'nonce starts at 0');
+
+        vm.prank(user);
+        bytes32 id1 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        vm.prank(user);
+        bytes32 id2 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertTrue(id1 != id2, 'nonce makes identical deposits distinct');
+        assertEq(bridge.sourceSenderNonces(SOURCE_CHAIN_ID, sourceSender), 2, 'nonce incremented to 2');
+    }
+
+    /// @dev A downstream revert must roll back the nonce increment: the nonce
+    ///      stays 0 and a later successful deposit gets the nonce-0 id.
+    function test_fundsIn_nonceRollsBackOnRevert() public {
+        bytes32 sourceSender = bytes32(uint256(uint160(user)));
+
+        // Amount below the (raised) minimum reverts before the nonce is consumed.
+        vm.prank(multisig);
+        bridge.setMinFundsInAmount(1000);
+
+        vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, uint256(999), uint256(1000)));
+        vm.prank(user);
+        bridge.fundsIn(999, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(bridge.sourceSenderNonces(SOURCE_CHAIN_ID, sourceSender), 0, 'nonce not consumed on revert');
+
+        // A subsequent successful deposit gets the nonce-0 id.
+        bytes32 expectedNonce0Id = _deriveOpId(
+            SOURCE_CHAIN_ID, sourceSender, 0, 1000, RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn(1000, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        assertEq(opId, expectedNonce0Id, 'first success uses nonce 0');
+        assertEq(bridge.sourceSenderNonces(SOURCE_CHAIN_ID, sourceSender), 1, 'nonce now 1');
+    }
+
+    /// @dev RGB deposit with a zero rgbOpId reverts in the settlement module.
+    function test_fundsIn_zeroRgbOpIdReverts() public {
+        vm.expectRevert(RgbSettlementModule.InvalidRgbOpId.selector);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(0));
+    }
+
+    /// @dev The RGB route emits FundsIn carrying the rgbOpId and net amount.
+    function test_fundsIn_rgbRouteEmitsFundsInWithRgbOpId() public {
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit FundsIn(user, RGB_OP_ID, AMOUNT); // no commission → net == gross == AMOUNT
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+    }
+
+    /// @dev The returned bytes32 is the key under which the module records net.
+    function test_fundsIn_returnedOperationIdKeysTheRecord() public {
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        assertEq(rgbModule.fundsInRecords(opId), AMOUNT, 'returned id keys the record');
+    }
+
+    /// @dev Full deposit → fundsOut happy path using the captured bytes32 in the
+    ///      release settlement data.
+    function test_fundsOut_referencesDerivedOperationId() public {
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        vm.prank(multisig);
+        _fundsOut(
+            recipient, AMOUNT, BURN_ID,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            _proof(), _settlement(_ids(opId))
+        );
+
+        assertEq(usdt0.balanceOf(recipient), AMOUNT, 'release via derived id succeeds');
+    }
+
+    // ========================================================================
+    // fee-on-transfer safe ingress accounting
+    //
+    // `_fundsIn` credits the ledger from the ACTUAL amount received
+    // (balanceAfter - balanceBefore), not the nominal `amount`. For a
+    // fee-on-transfer token the bridge receives less than `amount`, so the
+    // record / lockedLiquidity / events must reflect `received - tokenCommission`
+    // and never the nominal figure (which would overstate the ledger and later
+    // brick the release with AmountExceedBridgePool).
+    //
+    // These tests build a full parallel stack whose Bridge TOKEN is a
+    // FeeOnTransferERC20, mirroring setUp() exactly (same predicted-bridge nonce
+    // math, CM, RouteRegistry, verifier reuse of `btcRelay`, module, both routes,
+    // feed, outflow limits, ownership transfer+accept, user funding).
+    // ========================================================================
+
+    struct FeeStack {
+        Bridge              bridge;
+        FeeOnTransferERC20  token;
+        RgbSettlementModule module;
+        CommissionManager   cm;
+    }
+
+    /// @dev Deploy a full parallel bridge stack backed by a fee-on-transfer
+    ///      token. Mirrors setUp() one-for-one. The RGB verifier / `btcRelay` /
+    ///      `_proof()` are shared (the source-block relay data is identical).
+    function _deployFeeStack(uint256 feeBps) internal returns (FeeStack memory s) {
+        s.token = new FeeOnTransferERC20('Fee USDT0', 'fUSDT0', feeBps);
+
+        vm.startPrank(deployer);
+        uint64  currentNonce    = vm.getNonce(deployer);
+        address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
+
+        s.cm = new CommissionManager(predictedBridge);
+        RouteRegistry feeRouteRegistry = new RouteRegistry(predictedBridge, deployer);
+        s.bridge = new Bridge(
+            address(s.token),
+            address(feeRouteRegistry),
+            payable(address(s.cm)),
+            address(0),
+            1
+        );
+
+        // Reuse the suite's RGB verifier (shares `btcRelay` + `_proof()`); a
+        // fresh module is bound to this stack's route registry.
+        s.module = new RgbSettlementModule(address(feeRouteRegistry));
+
+        feeRouteRegistry.setRoute(
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID,
+            true, address(rgbVerifier), address(s.module)
+        );
+        feeRouteRegistry.setRoute(
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID,
+            true, address(rgbVerifier), address(s.module)
+        );
+
+        s.cm.setEthUsdFeed(address(ethUsdFeed), 1 hours);
+
+        s.bridge.setOutflowLimit(RGB_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
+        s.bridge.setGlobalOutflowLimit(1_000_000 ether, uint256(1_000_000 ether) / 1 days);
+
+        s.bridge.transferOwnership(multisig);
+        vm.stopPrank();
+
+        vm.prank(multisig);
+        s.bridge.acceptOwnership();
+
+        // Fund `user` generously and approve the fee bridge. `mint` is untaxed,
+        // so `user` holds exactly the minted amount.
+        s.token.mint(user, AMOUNT * 10);
+        vm.prank(user);
+        s.token.approve(address(s.bridge), type(uint256).max);
+    }
+
+    /// @dev Set a FUNDS_IN TOKEN commission rule on a fee stack's CM for the
+    ///      (SOURCE_CHAIN_ID → RGB_CHAIN_ID) route.
+    function _setFeeStackFundsInTokenRule(
+        FeeStack memory s,
+        uint256 stablePercent,
+        uint8   multiplier
+    ) internal {
+        vm.prank(deployer);
+        s.cm.setCommissionRule(
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(s.token),
+            CommissionConfig({
+                stablePercent: stablePercent,
+                multiplier: multiplier,
+                side: CommissionSide.FUNDS_IN,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+    }
+
+    /// @dev Burn-id derivation bound to a fee stack's Bridge + token (the shared
+    ///      `_deriveBurnId` binds the setUp `bridge`/`usdt0`).
+    function _deriveBurnIdFor(
+        FeeStack memory s,
+        address recipient_,
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory sourceAddress,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal view returns (uint256) {
+        return uint256(keccak256(abi.encode(
+            FUNDS_OUT_BURN_ID_TYPEHASH,
+            address(s.bridge),
+            block.chainid,
+            address(s.token),
+            recipient_,
+            amount,
+            sourceChainId,
+            destinationChainId,
+            keccak256(bytes(sourceAddress)),
+            keccak256(proof),
+            keccak256(settlementData)
+        )));
+    }
+
+    // --- Record/ledger/event use ACTUAL received, not nominal ---
+
+    function test_fundsIn_feeToken_creditsActualReceivedNotNominal() public {
+        FeeStack memory s = _deployFeeStack(100); // 1% fee, no commission rule
+
+        uint256 received = AMOUNT - s.token.feeOn(AMOUNT);
+        assertLt(received, AMOUNT, 'sanity: fee token delivers less than nominal');
+
+        bytes32 sourceSender = bytes32(uint256(uint160(user)));
+
+        // BridgeFundsIn must carry gross `amount == AMOUNT` and `netAmount == received`.
+        vm.expectEmit(true, true, false, true);
+        emit FundsIn(user, RGB_OP_ID, received);
+        vm.expectEmit(false, true, true, true);
+        emit BridgeFundsIn(
+            bytes32(0), sourceSender, user, 0, AMOUNT, received, 0, 0, SOURCE_CHAIN_ID, RGB_CHAIN_ID, DST_ADDR
+        );
+
+        vm.prank(user);
+        bytes32 opId = s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(s.module.fundsInRecords(opId), received, 'record credits actual received');
+        assertEq(s.bridge.lockedLiquidity(RGB_CHAIN_ID), received, 'lockedLiquidity credits actual received');
+        assertEq(s.token.balanceOf(address(s.bridge)), received, 'bridge token balance == received');
+    }
+
+    // --- With a TOKEN commission the ledger is not overstated ---
+
+    function test_fundsIn_feeToken_ledgerNotOverstatedWithCommission() public {
+        FeeStack memory s = _deployFeeStack(100); // 1% transfer fee
+        // 4% FUNDS_IN TOKEN commission rule (stablePercent 400, multiplier 100).
+        _setFeeStackFundsInTokenRule(s, 400, 100);
+
+        uint256 received        = AMOUNT - s.token.feeOn(AMOUNT);
+        // Commission is quoted from the NOMINAL amount.
+        uint256 tokenCommission = s.cm.calculateStableFee(AMOUNT, 400, 100);
+        assertGt(tokenCommission, 0, 'sanity: non-zero commission');
+
+        vm.prank(user);
+        s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        // Ledger credited from actual received minus the (nominal-quoted) commission.
+        assertEq(
+            s.bridge.lockedLiquidity(RGB_CHAIN_ID),
+            received - tokenCommission,
+            'lockedLiquidity == received - tokenCommission'
+        );
+
+        // The Bridge→CM commission hop is itself taxed by the fee token, so the
+        // CM credits by its own balance delta: tokenCommission - feeOn(tokenCommission).
+        assertEq(
+            s.cm.tokenCommissionPool(address(s.token)),
+            tokenCommission - s.token.feeOn(tokenCommission),
+            'CM pool credited by its own balance delta'
+        );
+
+        // No overstate: the bridge's retained token balance equals the credited
+        // lockedLiquidity exactly (bridge sent `tokenCommission` out to the CM).
+        uint256 bridgeRetained = s.token.balanceOf(address(s.bridge));
+        assertEq(bridgeRetained, received - tokenCommission, 'bridge retained == lockedLiquidity');
+        assertEq(
+            s.bridge.lockedLiquidity(RGB_CHAIN_ID),
+            bridgeRetained,
+            'lockedLiquidity + bridge-retained invariant: credited == held'
+        );
+    }
+
+    // --- The recorded (actual) amount is releasable via fundsOut ---
+
+    function test_fundsOut_feeToken_recordedAmountIsReleasable() public {
+        FeeStack memory s = _deployFeeStack(100); // 1% fee, no commission
+
+        uint256 received = AMOUNT - s.token.feeOn(AMOUNT);
+
+        vm.prank(user);
+        bytes32 opId = s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        assertEq(s.module.fundsInRecords(opId), received, 'record == actual received');
+
+        // Release EXACTLY the recorded amount. Before the fix the record would
+        // have been the nominal AMOUNT (> bridge balance `received`) and the
+        // release would revert AmountExceedBridgePool.
+        bytes memory proof          = _proof();
+        bytes memory settlementData = _settlementWithAmounts(_ids(opId), _one(received));
+        uint256 burnId = _deriveBurnIdFor(
+            s, recipient, received, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+
+        uint256 recipientBefore = s.token.balanceOf(recipient);
+
+        vm.prank(multisig);
+        s.bridge.fundsOut(IBridge.FundsOutParams(
+            recipient, received, burnId,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            proof, settlementData
+        ));
+
+        // The outbound transfer is also taxed, so the recipient nets
+        // `received - feeOn(received)`. The payoff is that the release did NOT
+        // revert and value moved.
+        uint256 delta = s.token.balanceOf(recipient) - recipientBefore;
+        assertGt(delta, 0, 'recipient balance increased');
+        assertEq(delta, received - s.token.feeOn(received), 'recipient nets received minus outbound fee');
+        assertEq(s.bridge.lockedLiquidity(RGB_CHAIN_ID), 0, 'lockedLiquidity fully released');
+    }
+
+    // --- Received < tokenCommission reverts InsufficientReceived ---
+    //
+    // Fee = 9000 bps (90%) → received = 10% of AMOUNT = 10e18. The fee-shape
+    // guard caps the commission fraction at `stablePercent / multiplier^2`
+    // (stablePercent ≤ 9000, stablePercent ≤ multiplier^2). Choosing
+    // multiplier = 95, stablePercent = 9000 yields a fraction 9000/9025 ≈ 99.7%,
+    // so the commission quote on the NOMINAL AMOUNT (~99.7e18) far exceeds the
+    // actual received (10e18) — configurable within the guard, so no boundary
+    // compromise is needed.
+    function test_fundsIn_feeToken_revertsWhenFeeExceedsCommission() public {
+        FeeStack memory s = _deployFeeStack(9000); // 90% transfer fee
+        _setFeeStackFundsInTokenRule(s, 9000, 95); // ~99.7% commission on nominal
+
+        uint256 received        = AMOUNT - s.token.feeOn(AMOUNT);
+        uint256 tokenCommission = s.cm.calculateStableFee(AMOUNT, 9000, 95);
+
+        assertEq(received, AMOUNT / 10, 'sanity: received == 10% of nominal');
+        assertGt(tokenCommission, received, 'sanity: commission exceeds actual received');
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IBridge.InsufficientReceived.selector, received, tokenCommission
+        ));
+        vm.prank(user);
+        s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 }

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -81,14 +81,20 @@ contract BridgeTest is Test {
     uint256 constant BURN_ID         = 9_001;
 
     // BtcRelay test data
-    uint256 constant BLOCK_HEIGHT     = 850_000;
-    bytes32 constant COMMITMENT_HASH  = keccak256('test-btc-block-commitment');
-    uint256 constant CONFIRMATIONS    = 6;
+    // RGB proof = two (height, commit) pairs. The source block (RGB burn/lock)
+    // is deep; the latest block is fresh (relay head). gap = 6 - 1 = 5.
+    uint256 constant BLOCK_HEIGHT         = 850_000;   // source block
+    bytes32 constant COMMITMENT_HASH      = keccak256('test-btc-block-commitment');
+    uint256 constant CONFIRMATIONS        = 6;         // source confirmations
+    uint256 constant LATEST_HEIGHT        = 850_005;
+    bytes32 constant LATEST_COMMIT        = keccak256('test-btc-latest-commitment');
+    uint256 constant LATEST_CONFIRMATIONS = 1;
 
     function setUp() public {
         usdt0    = new MockERC20('Mock USDT0', 'USDT0');
         btcRelay = new MockBtcRelay();
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, CONFIRMATIONS);
+        btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONFIRMATIONS);
 
         // DeployAll-style deploy with predicted Bridge address:
         //   nonce n      → CommissionManager (uses predicted Bridge)
@@ -112,7 +118,7 @@ contract BridgeTest is Test {
             1 // minFundsInAmount: smallest non-zero floor; cases that need a higher floor deploy their own Bridge
         );
 
-        rgbVerifier = new RGBVerifier(address(btcRelay));
+        rgbVerifier = new RGBVerifier(address(btcRelay), 6, 1, 5);
         rgbModule   = new RgbSettlementModule(address(routeRegistry));
 
         // Both directions of the RGB route share the same verifier + module.
@@ -163,7 +169,7 @@ contract BridgeTest is Test {
     }
 
     function _proof() internal pure returns (bytes memory) {
-        return abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
+        return abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT);
     }
 
     /// @dev Build `settlementData` for the reworked RgbSettlementModule, which
@@ -854,7 +860,9 @@ contract BridgeTest is Test {
         vm.prank(user);
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
 
-        bytes memory badProof = abi.encode(uint256(999_999), keccak256('unknown-block'));
+        // Well-formed two-pair proof, but the source block is unknown to the relay.
+        bytes memory badProof =
+            abi.encode(uint256(999_999), keccak256('unknown-block'), LATEST_HEIGHT, LATEST_COMMIT);
 
         // RGBVerifier → BtcRelay reverts with the relay's string message.
         vm.expectRevert('verify: block commitment');
@@ -1886,7 +1894,9 @@ contract BridgeTest is Test {
         vm.prank(user);
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
 
-        bytes memory badProof = abi.encode(uint256(999_999), keccak256('unknown-block'));
+        // Well-formed two-pair proof, but the source block is unknown to the relay.
+        bytes memory badProof =
+            abi.encode(uint256(999_999), keccak256('unknown-block'), LATEST_HEIGHT, LATEST_COMMIT);
 
         uint256 bridgeBefore     = usdt0.balanceOf(address(bridge));
         uint256 recipientBefore  = usdt0.balanceOf(recipient);

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -45,6 +45,8 @@ contract CommissionManagerTest is Test {
     );
     event EthUsdFeedUpdated(address indexed feed, uint256 heartbeat);
     event TokenCommissionReceived(address indexed token, uint256 amount);
+    event SequencerUptimeFeedUpdated(address indexed feed);
+    event EthUsdPriceBoundsUpdated(uint256 minPrice, uint256 maxPrice);
 
     function setUp() public {
         // Anvil starts at timestamp 1; warp past the heartbeat so staleness
@@ -144,16 +146,17 @@ contract CommissionManagerTest is Test {
         cm.convertTokenFeeToNative(1, 19);
     }
 
-    // Current behavior: native quote validation only requires a fresh positive
-    // Chainlink answer. There is no sequencer uptime feed or min/max bound, so
-    // a fresh outlier price is still used for conversion.
-    function test_nativeQuoteDoesNotCheckSequencerUptime_currentBehavior() public {
-        ethUsdFeed.setAnswer(1);
+    // With the min/max band UNSET (the default), a fresh positive answer is
+    // accepted no matter how extreme — which is exactly why an Arbitrum
+    // deployment configures `setEthUsdPriceBounds`. Band-enabled rejection is
+    // covered by test_convertTokenFeeToNative_revertsWhenPriceBelowMin/AboveMax.
+    function test_convertTokenFeeToNative_allowsOutlierWhenBandUnset() public {
+        ethUsdFeed.setAnswer(1); // $1e-8 — an extreme outlier
         ethUsdFeed.setUpdatedAt(block.timestamp);
 
         uint256 nativeFee = cm.convertTokenFeeToNative(1e18, 18);
 
-        assertEq(nativeFee, 1e26, 'fresh positive outlier accepted');
+        assertEq(nativeFee, 1e26, 'fresh outlier accepted while band is unset');
     }
 
     function test_buildRouteKey_matchesEncodeHash() public view {
@@ -693,62 +696,63 @@ contract CommissionManagerTest is Test {
 
         vm.prank(user);
         vm.expectRevert(ICommissionManager.OnlyBridge.selector);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
         assertEq(cm.tokenCommissionPool(address(token)), amt);
     }
 
     function test_receiveTokenCommission_revertsNothingReceived() public {
         vm.prank(BRIDGE);
         vm.expectRevert(ICommissionManager.NothingReceived.selector);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), 0);
     }
 
-    function test_receiveTokenCommission_revertsNothingReceived_whenNoNewTokens() public {
-        uint256 amt = 10 ether;
-        token.mint(address(cm), amt);
-        vm.startPrank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
-        vm.expectRevert(ICommissionManager.NothingReceived.selector);
-        cm.receiveTokenCommission(address(token));
-        vm.stopPrank();
+    // After the R-I-04 fix the pool is credited by the passed `credited`, not by
+    // balanceOf - pool. Crediting more than the on-chain balance can back reverts
+    // BalanceBelowRecordedPool (guards against over-crediting).
+    function test_receiveTokenCommission_revertsWhenCreditExceedsBalance() public {
+        token.mint(address(cm), 5 ether);
+        vm.prank(BRIDGE);
+        vm.expectRevert(ICommissionManager.BalanceBelowRecordedPool.selector);
+        cm.receiveTokenCommission(address(token), 6 ether);
     }
 
-    // Current behavior: token commission accounting records the whole balance
-    // delta since the last pool update, so unsolicited tokens already sitting
-    // in the CommissionManager are credited with the next bridge commission.
-    function test_unsolicitedTokenBalanceIncludedInNextCommissionCredit_currentBehavior() public {
+    // R-I-04 after-fix: an unsolicited direct transfer already sitting in the CM
+    // is NOT folded into the pool. The Bridge measures only its own transfer and
+    // passes that as `credited`; the donation stays as a stray balance.
+    function test_receiveTokenCommission_doesNotAbsorbUnsolicitedBalance_afterFix() public {
         uint256 unsolicitedAmount = 3 ether;
         uint256 legitimateAmount  = 7 ether;
-        uint256 expectedCredit    = unsolicitedAmount + legitimateAmount;
 
         token.mint(user, unsolicitedAmount);
         vm.prank(user);
-        token.transfer(address(cm), unsolicitedAmount);
+        token.transfer(address(cm), unsolicitedAmount); // donation
 
         token.mint(BRIDGE, legitimateAmount);
         vm.prank(BRIDGE);
-        token.transfer(address(cm), legitimateAmount);
+        token.transfer(address(cm), legitimateAmount); // the Bridge's transfer
 
-        assertEq(token.balanceOf(address(cm)), expectedCredit, 'pre cm token balance');
+        assertEq(token.balanceOf(address(cm)), unsolicitedAmount + legitimateAmount, 'pre cm token balance');
         assertEq(cm.tokenCommissionPool(address(token)), 0, 'pre cm pool');
 
+        // Bridge credits ONLY the amount its transfer actually delivered.
         vm.expectEmit(true, false, false, true, address(cm));
-        emit TokenCommissionReceived(address(token), expectedCredit);
+        emit TokenCommissionReceived(address(token), legitimateAmount);
 
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), legitimateAmount);
 
-        assertEq(cm.tokenCommissionPool(address(token)), expectedCredit, 'pool includes unsolicited balance');
+        assertEq(cm.tokenCommissionPool(address(token)), legitimateAmount, 'pool credited only the legit commission');
+        assertEq(token.balanceOf(address(cm)), unsolicitedAmount + legitimateAmount, 'donation stays as stray balance');
     }
 
     function test_withdrawTokenCommission_transfersAndUpdatesPool() public {
         uint256 amt = 50 ether;
         token.mint(address(cm), amt);
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(owner);
         cm.withdrawTokenCommission(address(token), recipient, amt);
@@ -761,7 +765,7 @@ contract CommissionManagerTest is Test {
         uint256 amt = 30 ether;
         token.mint(address(cm), amt);
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(owner);
         cm.withdrawAllTokenCommission(address(token), recipient);
@@ -873,5 +877,156 @@ contract CommissionManagerTest is Test {
                 'native fee formula'
             );
         }
+    }
+
+    // =========================================================================
+    // L2 sequencer-uptime gate + min/max price band
+    // =========================================================================
+
+    /// @dev The sequencer uptime feed is a standard AggregatorV3Interface;
+    ///      MockAggregatorV3 reports `startedAt == updatedAt`, so we drive
+    ///      `startedAt` via the constructor's `updatedAt` argument. `status`
+    ///      is the sequencer answer (0 = up, 1 = down).
+    function _sequencerFeed(int256 status, uint256 startedAt_) internal returns (MockAggregatorV3) {
+        return new MockAggregatorV3(0, status, startedAt_);
+    }
+
+    function _setSequencer(int256 status, uint256 startedAt_) internal returns (MockAggregatorV3 seq) {
+        seq = _sequencerFeed(status, startedAt_);
+        vm.prank(owner);
+        cm.setSequencerUptimeFeed(address(seq));
+    }
+
+    // --- sequencer uptime ---
+
+    function test_convertTokenFeeToNative_noSequencerCheckWhenUnset() public view {
+        // No sequencer feed wired (setUp does not set one) → quote works.
+        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    }
+
+    function test_convertTokenFeeToNative_revertsWhenSequencerDown() public {
+        _setSequencer(1, block.timestamp - 2 hours); // answer == 1 => down
+        vm.expectRevert(ICommissionManager.SequencerDown.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_revertsDuringGracePeriod() public {
+        // Up, but restarted this block → within the grace window.
+        _setSequencer(0, block.timestamp);
+        vm.expectRevert(ICommissionManager.GracePeriodNotOver.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_revertsAtGraceBoundary() public {
+        // Exactly at the grace period: `block.timestamp - startedAt == GRACE`,
+        // and the check is `<= GRACE`, so it still reverts.
+        _setSequencer(0, block.timestamp - cm.SEQUENCER_GRACE_PERIOD());
+        vm.expectRevert(ICommissionManager.GracePeriodNotOver.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_passesWhenSequencerUpPastGrace() public {
+        _setSequencer(0, block.timestamp - cm.SEQUENCER_GRACE_PERIOD() - 1);
+        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14); // same as happy path
+    }
+
+    // --- min/max price band ---
+
+    function test_convertTokenFeeToNative_noBandWhenUnset() public view {
+        // No band configured in setUp → any positive fresh answer is accepted.
+        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    }
+
+    function test_convertTokenFeeToNative_revertsWhenPriceBelowMin() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        ethUsdFeed.setAnswer(999e8);              // below min
+        ethUsdFeed.setUpdatedAt(block.timestamp); // keep fresh so StalePrice doesn't mask it
+        vm.expectRevert(ICommissionManager.PriceOutOfBounds.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_revertsWhenPriceAboveMax() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        ethUsdFeed.setAnswer(100_001e8);          // above max
+        ethUsdFeed.setUpdatedAt(block.timestamp);
+        vm.expectRevert(ICommissionManager.PriceOutOfBounds.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_passesWithinBand() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        // DEFAULT_ETH_USD = 2000e8 sits inside the band.
+        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    }
+
+    function test_convertTokenFeeToNative_healthySequencerAndBandTogether() public {
+        _setSequencer(0, block.timestamp - cm.SEQUENCER_GRACE_PERIOD() - 1);
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    }
+
+    // --- setters ---
+
+    function test_setSequencerUptimeFeed_setsAndEmits() public {
+        address seq = makeAddr('seqFeed');
+        vm.expectEmit(true, false, false, false, address(cm));
+        emit SequencerUptimeFeedUpdated(seq);
+        vm.prank(owner);
+        cm.setSequencerUptimeFeed(seq);
+        assertEq(cm.sequencerUptimeFeed(), seq);
+    }
+
+    function test_setSequencerUptimeFeed_canDisableWithZero() public {
+        vm.prank(owner);
+        cm.setSequencerUptimeFeed(makeAddr('seqFeed'));
+        vm.prank(owner);
+        cm.setSequencerUptimeFeed(address(0));
+        assertEq(cm.sequencerUptimeFeed(), address(0));
+    }
+
+    function test_setSequencerUptimeFeed_onlyOwner() public {
+        vm.prank(user);
+        vm.expectRevert();
+        cm.setSequencerUptimeFeed(makeAddr('seqFeed'));
+    }
+
+    function test_setEthUsdPriceBounds_setsAndEmits() public {
+        vm.expectEmit(false, false, false, true, address(cm));
+        emit EthUsdPriceBoundsUpdated(1_000e8, 100_000e8);
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        assertEq(cm.ethUsdMinPrice(), 1_000e8);
+        assertEq(cm.ethUsdMaxPrice(), 100_000e8);
+    }
+
+    function test_setEthUsdPriceBounds_disableWithZeros() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(0, 0);
+        assertEq(cm.ethUsdMinPrice(), 0);
+        assertEq(cm.ethUsdMaxPrice(), 0);
+    }
+
+    function test_setEthUsdPriceBounds_revertsOnZeroMinWithNonZeroMax() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.InvalidPriceBounds.selector);
+        cm.setEthUsdPriceBounds(0, 100e8);
+    }
+
+    function test_setEthUsdPriceBounds_revertsWhenMinNotBelowMax() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.InvalidPriceBounds.selector);
+        cm.setEthUsdPriceBounds(100e8, 100e8);
+    }
+
+    function test_setEthUsdPriceBounds_onlyOwner() public {
+        vm.prank(user);
+        vm.expectRevert();
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
     }
 }

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -85,8 +85,11 @@ contract IntegrationTest is Test {
     uint256 constant FUNDS_OUT_PERCENT = 100;
     uint8   constant FUNDS_OUT_MULT    = 100;
 
-    uint256 constant TX_ID_IN  = 42;
-    uint256 constant BURN_ID   = 9_001;
+    // Non-zero RGB OpId threaded through the RGB-route settlementData on fundsIn.
+    uint256 constant RGB_OP_ID = 0xABCDEF;
+    bytes32 constant FUNDS_OUT_BURN_ID_TYPEHASH = keccak256(
+        'UtexoFundsOutBurnId(address bridge,uint256 chainId,address token,address recipient,uint256 amount,uint256 sourceChainId,uint256 destinationChainId,bytes32 sourceAddressHash,bytes32 proofHash,bytes32 settlementDataHash)'
+    );
 
     // RGB proof = two (height, commit) pairs: a deep source block (RGB
     // burn/lock) and a fresh latest block (relay head). gap = 6 - 1 = 5.
@@ -120,6 +123,30 @@ contract IntegrationTest is Test {
     // =========================================================================
     // Setup
     // =========================================================================
+
+    function _deriveBurnId(
+        address recipient_,
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory sourceAddress,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal view returns (uint256) {
+        return uint256(keccak256(abi.encode(
+            FUNDS_OUT_BURN_ID_TYPEHASH,
+            address(bridge),
+            block.chainid,
+            address(token),
+            recipient_,
+            amount,
+            sourceChainId,
+            destinationChainId,
+            keccak256(bytes(sourceAddress)),
+            keccak256(proof),
+            keccak256(settlementData)
+        )));
+    }
 
     function setUp() public {
         encA1 = vm.addr(encPk1); encA2 = vm.addr(encPk2); encA3 = vm.addr(encPk3);
@@ -181,6 +208,7 @@ contract IntegrationTest is Test {
             address(bridge),
             address(cm),
             enc, 2,
+            RGB_CHAIN_ID,
             fed, 2,
             commissionReceiver,
             TIMELOCK,
@@ -276,12 +304,13 @@ contract IntegrationTest is Test {
         uint256 userBefore = token.balanceOf(user);
 
         vm.prank(user);
-        bridge.fundsIn(
+        // RGB route: settlementData carries the non-zero RGB OpId. The record is
+        // keyed by the bridge-derived operationId returned here.
+        bytes32 opId = bridge.fundsIn(
             USER_DEPOSIT,
             RGB_CHAIN_ID,
             'rgb:asset1qp0y3mq/utxo1abc',
-            TX_ID_IN,
-            ''   // settlementData ignored by RgbSettlementModule on inbound
+            abi.encode(RGB_OP_ID)
         );
 
         uint256 tokenCommissionIn = tInQuote;
@@ -291,7 +320,7 @@ contract IntegrationTest is Test {
         assertEq(token.balanceOf(address(bridge)),       netBridgedIn,              'bridge keeps net');
         assertEq(token.balanceOf(address(cm)),           tokenCommissionIn,         'cm got commission');
         assertEq(cm.tokenCommissionPool(address(token)), tokenCommissionIn,         'cm pool mirrors balance');
-        assertEq(rgbModule.fundsInRecords(TX_ID_IN),     netBridgedIn,              'record stores net');
+        assertEq(rgbModule.fundsInRecords(opId),         netBridgedIn,              'record stores net');
 
         // -------------------------------------------------------------------------
         // 3. TEE-signed fundsOut — RGBVerifier checks the BtcRelay header, the
@@ -299,26 +328,30 @@ contract IntegrationTest is Test {
         //    amount (no consumption), Bridge releases `netBridgedIn` from the
         //    pool. 1% outbound commission to CM, the rest to recipient.
         // -------------------------------------------------------------------------
-        uint256[] memory fundsInIds     = new uint256[](1);
-        fundsInIds[0]     = TX_ID_IN;
+        bytes32[] memory fundsInIds     = new bytes32[](1);
+        fundsInIds[0]     = opId;
         uint256[] memory fundsInAmounts = new uint256[](1);
         fundsInAmounts[0] = netBridgedIn;   // must equal the recorded mint amount
 
         bytes memory proof          = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT);
         bytes memory settlementData = abi.encode(fundsInIds, fundsInAmounts);
+        string memory sourceAddress = 'rgb:sender/utxo1src';
+        uint256 burnId = _deriveBurnId(
+            recipient, netBridgedIn, RGB_CHAIN_ID, SOURCE_CHAIN_ID, sourceAddress, proof, settlementData
+        );
 
         IBridge.FundsOutParams memory params = IBridge.FundsOutParams(
             recipient,
             netBridgedIn,          // amount = full bridged pool from this deposit
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
-            'rgb:sender/utxo1src',
+            sourceAddress,
             proof,
             settlementData
         );
 
-        uint256 outNonce    = proxy.teeNonce();
+        uint256 outNonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 outDeadline = block.timestamp + 1 hours;
         bytes32 outDigest   = MultisigHelper.digestTeeFundsOut(
             domainSep, params, outNonce, outDeadline
@@ -334,10 +367,10 @@ contract IntegrationTest is Test {
             netBridgedIn,
             netOut,
             tokenCommissionOut,
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
-            'rgb:sender/utxo1src'
+            sourceAddress
         );
 
         proxy.fundsOutCall(params, outNonce, outDeadline, 3, teeSigs);
@@ -346,8 +379,8 @@ contract IntegrationTest is Test {
         assertEq(token.balanceOf(recipient),             netOut,                                 'recipient got net');
         assertEq(token.balanceOf(address(cm)),           tokenCommissionIn + tokenCommissionOut, 'cm accrued both fees');
         assertEq(cm.tokenCommissionPool(address(token)), tokenCommissionIn + tokenCommissionOut, 'cm pool mirrors');
-        assertEq(rgbModule.fundsInRecords(TX_ID_IN),     netBridgedIn,                           'fundsIn record unchanged (permanent)');
-        assertTrue(bridge.consumedBurnIds(BURN_ID),                                              'burnId recorded');
+        assertEq(rgbModule.fundsInRecords(opId),         netBridgedIn,                           'fundsIn record unchanged (permanent)');
+        assertTrue(bridge.consumedBurnIds(burnId),                                               'burnId recorded');
 
         // -------------------------------------------------------------------------
         // 4. Federation withdraws ERC-20 commission from CM to commissionReceiver.
@@ -432,19 +465,18 @@ contract IntegrationTest is Test {
         vm.deal(user, nativeQuote);
 
         vm.prank(user);
-        bridge.fundsIn{ value: nativeQuote }(
+        bytes32 opId = bridge.fundsIn{ value: nativeQuote }(
             USER_DEPOSIT,
             RGB_CHAIN_ID,
             'rgb:asset1qp0y3mq/utxo1abc',
-            TX_ID_IN,
-            ''
+            abi.encode(RGB_OP_ID)
         );
 
         assertEq(token.balanceOf(address(bridge)),    USER_DEPOSIT, 'bridge got full token amount');
         assertEq(token.balanceOf(address(cm)),        0,            'cm no token commission');
         assertEq(address(cm).balance,                 nativeQuote,  'cm got native commission');
         assertEq(cm.nativeCommissionPool(),           nativeQuote,  'cm native pool');
-        assertEq(rgbModule.fundsInRecords(TX_ID_IN),  USER_DEPOSIT, 'record stores full amount');
+        assertEq(rgbModule.fundsInRecords(opId),      USER_DEPOSIT, 'record stores full amount');
 
         // Federation withdraws native commission.
         uint256 wdNonce    = proxy.proposalNonce();

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -88,9 +88,14 @@ contract IntegrationTest is Test {
     uint256 constant TX_ID_IN  = 42;
     uint256 constant BURN_ID   = 9_001;
 
-    uint256 constant BLOCK_HEIGHT      = 850_000;
-    bytes32 constant COMMITMENT_HASH   = keccak256('integration-btc-block');
-    uint256 constant BTC_CONFIRMATIONS = 6;
+    // RGB proof = two (height, commit) pairs: a deep source block (RGB
+    // burn/lock) and a fresh latest block (relay head). gap = 6 - 1 = 5.
+    uint256 constant BLOCK_HEIGHT         = 850_000;   // source block
+    bytes32 constant COMMITMENT_HASH      = keccak256('integration-btc-block');
+    uint256 constant BTC_CONFIRMATIONS    = 6;         // source confirmations
+    uint256 constant LATEST_HEIGHT        = 850_005;
+    bytes32 constant LATEST_COMMIT        = keccak256('integration-btc-latest');
+    uint256 constant LATEST_CONFIRMATIONS = 1;
 
     uint256 constant TIMELOCK     = 1 hours;
     uint256 constant MIN_TIMELOCK = 1 hours; // floor passed to the proxy constructor in tests
@@ -123,6 +128,7 @@ contract IntegrationTest is Test {
         token    = new MockERC20('Mock USDT0', 'USDT0');
         btcRelay = new MockBtcRelay();
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, BTC_CONFIRMATIONS);
+        btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONFIRMATIONS);
 
         // DeployAll-style deployment. Deployer tx order:
         //   nonce n      → CommissionManager (uses predicted Bridge)
@@ -151,7 +157,7 @@ contract IntegrationTest is Test {
             1 // minFundsInAmount: smallest non-zero floor for tests
         );
 
-        rgbVerifier = new RGBVerifier(address(btcRelay));
+        rgbVerifier = new RGBVerifier(address(btcRelay), 6, 1, 5);
         rgbModule   = new RgbSettlementModule(address(routeRegistry));
 
         // Register both directions of the RGB route, using the same verifier
@@ -298,7 +304,7 @@ contract IntegrationTest is Test {
         uint256[] memory fundsInAmounts = new uint256[](1);
         fundsInAmounts[0] = netBridgedIn;   // must equal the recorded mint amount
 
-        bytes memory proof          = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH);
+        bytes memory proof          = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT);
         bytes memory settlementData = abi.encode(fundsInIds, fundsInAmounts);
 
         IBridge.FundsOutParams memory params = IBridge.FundsOutParams(

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -166,10 +166,14 @@ contract MultisigProxyTest is Test {
     uint32  constant DST_EID = 30110;
     bytes32 constant LZ_RECIPIENT = bytes32(uint256(uint160(0xBEEF)));
 
-    // BtcRelay test data
-    uint256 constant BLOCK_HEIGHT      = 850_000;
-    bytes32 constant COMMITMENT_HASH   = keccak256('test-btc-block-commitment');
-    uint256 constant BTC_CONFIRMATIONS = 6;
+    // BtcRelay test data. RGB proof = two (height, commit) pairs: a deep
+    // source block (RGB burn/lock) and a fresh latest block. gap = 6 - 1 = 5.
+    uint256 constant BLOCK_HEIGHT         = 850_000;   // source block
+    bytes32 constant COMMITMENT_HASH      = keccak256('test-btc-block-commitment');
+    uint256 constant BTC_CONFIRMATIONS    = 6;         // source confirmations
+    uint256 constant LATEST_HEIGHT        = 850_005;
+    bytes32 constant LATEST_COMMIT        = keccak256('test-btc-latest-commitment');
+    uint256 constant LATEST_CONFIRMATIONS = 1;
 
     function setUp() public {
         encA1 = vm.addr(encPk1);
@@ -182,6 +186,7 @@ contract MultisigProxyTest is Test {
         token    = new MockERC20('Mock USDT0', 'USDT0');
         btcRelay = new MockBtcRelay();
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, BTC_CONFIRMATIONS);
+        btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONFIRMATIONS);
 
         // DeployAll-style with predicted Bridge address. Deployer tx order:
         //   nonce n      → CommissionManager (uses predicted Bridge)
@@ -208,7 +213,7 @@ contract MultisigProxyTest is Test {
             1 // minFundsInAmount: smallest non-zero floor for tests
         );
 
-        rgbVerifier = new RGBVerifier(address(btcRelay));
+        rgbVerifier = new RGBVerifier(address(btcRelay), 6, 1, 5);
         rgbModule   = new RgbSettlementModule(address(routeRegistry));
 
         // Register both directions of the RGB route while deployer still owns
@@ -337,7 +342,7 @@ contract MultisigProxyTest is Test {
             sourceChainId:      RGB_CHAIN_ID,
             destinationChainId: SOURCE_CHAIN_ID,
             sourceAddress:      SRC_ADDR,
-            proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH),
+            proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT),
             settlementData:     _settlement(_fundsInIds())
         });
     }
@@ -356,7 +361,7 @@ contract MultisigProxyTest is Test {
             sourceChainId:      RGB_CHAIN_ID,
             destinationChainId: SOURCE_CHAIN_ID,
             sourceAddress:      SRC_ADDR,
-            proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH),
+            proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT),
             settlementData:     _settlement(ids),
             dstEid:             DST_EID,
             recipient:          LZ_RECIPIENT,
@@ -2205,9 +2210,9 @@ contract MultisigProxyTest is Test {
         _setLzAdapter(address(adapter));
 
         IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
-        // A proof that the verifier rejects, so Bridge.fundsOut reverts before
-        // the adapter send can run.
-        params.proof = abi.encode(uint256(999_999), keccak256('unknown-block'));
+        // Well-formed two-pair proof whose source block is unknown to the relay,
+        // so Bridge.fundsOut reverts before the adapter send can run.
+        params.proof = abi.encode(uint256(999_999), keccak256('unknown-block'), LATEST_HEIGHT, LATEST_COMMIT);
 
         uint256 deadline = block.timestamp + 1 hours;
         (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -68,8 +68,9 @@ contract MultisigProxyTest is Test {
     using MultisigHelper for bytes32;
 
     // ---- Re-declared events ------------------------------------------------
-    event FundsOutExecuted(uint256 indexed nonce, uint256 enclaveBitmap);
+    event FundsOutExecuted(uint256 indexed sourceChainId, uint256 indexed nonce, uint256 enclaveBitmap);
     event LzFundsOutExecuted(
+        uint256 indexed sourceChainId,
         uint256 indexed nonce,
         uint256 enclaveBitmap,
         uint32  dstEid,
@@ -88,7 +89,7 @@ contract MultisigProxyTest is Test {
     );
     event ProposalCancelled(bytes32 indexed proposalId);
     event ProposalExecuted(bytes32 indexed proposalId, IMultisigProxy.OperationType indexed opType);
-    event EnclaveSignersUpdated(address[] newSigners, uint256 newThreshold);
+    event EnclaveSignersUpdated(uint256 indexed sourceChainId, address[] newSigners, uint256 newThreshold);
     event FederationSignersUpdated(address[] newSigners, uint256 newThreshold);
     event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
@@ -128,6 +129,9 @@ contract MultisigProxyTest is Test {
     MockERC20           token;
     MockBtcRelay        btcRelay;
 
+    // Derived operationId of the setUp() seed deposit (returned by fundsIn).
+    bytes32 seedOpId;
+
     // Enclave signers (3-of-N with threshold 2)
     uint256 encPk1 = 0xE1;
     uint256 encPk2 = 0xE2;
@@ -161,7 +165,11 @@ contract MultisigProxyTest is Test {
     string  constant SRC_ADDR        = 'rgb:sender/utxo1src';
     uint256 constant AMOUNT  = 100e18;
     uint256 constant TX_ID   = 42;
+    uint256 constant RGB_OP_ID = 0xABCDEF;
     uint256 constant BURN_ID = 9_001;
+    bytes32 constant FUNDS_OUT_BURN_ID_TYPEHASH = keccak256(
+        'UtexoFundsOutBurnId(address bridge,uint256 chainId,address token,address recipient,uint256 amount,uint256 sourceChainId,uint256 destinationChainId,bytes32 sourceAddressHash,bytes32 proofHash,bytes32 settlementDataHash)'
+    );
     uint256 constant LZ_NATIVE_FEE = 0.01 ether;
     uint32  constant DST_EID = 30110;
     bytes32 constant LZ_RECIPIENT = bytes32(uint256(uint160(0xBEEF)));
@@ -237,6 +245,7 @@ contract MultisigProxyTest is Test {
             address(bridge),
             address(cm),
             enc, 2,
+            RGB_CHAIN_ID,
             fed, 2,
             commissionReceiver,
             TIMELOCK,
@@ -271,7 +280,7 @@ contract MultisigProxyTest is Test {
         vm.prank(user);
         token.approve(address(bridge), type(uint256).max);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT * 5, RGB_CHAIN_ID, DST_ADDR, TX_ID, '');
+        seedOpId = bridge.fundsIn(AMOUNT * 5, RGB_CHAIN_ID, DST_ADDR, abi.encode(RGB_OP_ID));
     }
 
     // ========================================================================
@@ -292,23 +301,47 @@ contract MultisigProxyTest is Test {
         bitmap = 0x3;
     }
 
-    function _fundsInIds() internal pure returns (uint256[] memory ids) {
-        ids = new uint256[](1);
-        ids[0] = TX_ID;
+    function _fundsInIds() internal view returns (bytes32[] memory ids) {
+        ids = new bytes32[](1);
+        ids[0] = seedOpId;
     }
 
     /// @dev Build `settlementData` for the reworked RgbSettlementModule, which
-    ///      expects `(uint256[] operationIds, uint256[] amounts)` and checks
+    ///      expects `(bytes32[] operationIds, uint256[] amounts)` and checks
     ///      each id exists with an EXACTLY matching amount (no consumption).
     ///      The amount is derived from the on-chain mint record so an exact
     ///      match is guaranteed for the common path; ids with no record resolve
     ///      to amount 0 (the module then reverts FundsInNotFound first).
-    function _settlement(uint256[] memory ids) internal view returns (bytes memory) {
+    function _settlement(bytes32[] memory ids) internal view returns (bytes memory) {
         uint256[] memory amounts = new uint256[](ids.length);
         for (uint256 i = 0; i < ids.length; i++) {
             amounts[i] = rgbModule.fundsInRecords(ids[i]);
         }
         return abi.encode(ids, amounts);
+    }
+
+    function _deriveBurnId(
+        address bridgeRecipient,
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory sourceAddress,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal view returns (uint256) {
+        return uint256(keccak256(abi.encode(
+            FUNDS_OUT_BURN_ID_TYPEHASH,
+            address(bridge),
+            block.chainid,
+            address(token),
+            bridgeRecipient,
+            amount,
+            sourceChainId,
+            destinationChainId,
+            keccak256(bytes(sourceAddress)),
+            keccak256(proof),
+            keccak256(settlementData)
+        )));
     }
 
     /// @dev Valid strict-majority signer sets (2-of-2) used as filler in
@@ -325,44 +358,56 @@ contract MultisigProxyTest is Test {
         a[1] = fedA2;
     }
 
-    /// @dev Standard single-release params (recipient = `recipient`, AMOUNT, BURN_ID).
+    /// @dev Standard single-release params (recipient = `recipient`, AMOUNT, canonical burnId).
     function _fundsOutParams() internal view returns (IBridge.FundsOutParams memory) {
         return _fundsOutParams(recipient, AMOUNT, BURN_ID);
     }
 
-    function _fundsOutParams(address payoutRecipient, uint256 amount, uint256 burnId)
+    function _fundsOutParams(address payoutRecipient, uint256 amount, uint256 /* burnId */)
         internal
         view
         returns (IBridge.FundsOutParams memory)
     {
+        bytes memory proof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT);
+        bytes memory settlementData = _settlement(_fundsInIds());
+        uint256 derivedBurnId = _deriveBurnId(
+            payoutRecipient, amount, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+
         return IBridge.FundsOutParams({
             recipient:          payoutRecipient,
             amount:             amount,
-            burnId:             burnId,
+            burnId:             derivedBurnId,
             sourceChainId:      RGB_CHAIN_ID,
             destinationChainId: SOURCE_CHAIN_ID,
             sourceAddress:      SRC_ADDR,
-            proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT),
-            settlementData:     _settlement(_fundsInIds())
+            proof:              proof,
+            settlementData:     settlementData
         });
     }
 
     /// @dev Flow-4 LZ release params. The Bridge recipient is forced to the
     ///      adapter on-chain, so it is not part of these params; `recipient`
     ///      here is the bytes32 destination on the far chain.
-    function _lzFundsOutParams(uint256 amount, uint256 burnId, uint256[] memory ids)
+    function _lzFundsOutParams(uint256 amount, uint256 /* burnId */, bytes32[] memory ids)
         internal
         view
         returns (IMultisigProxy.LzFundsOutParams memory)
     {
+        bytes memory proof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT);
+        bytes memory settlementData = _settlement(ids);
+        uint256 derivedBurnId = _deriveBurnId(
+            proxy.lzAdapter(), amount, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+
         return IMultisigProxy.LzFundsOutParams({
             amount:             amount,
-            burnId:             burnId,
+            burnId:             derivedBurnId,
             sourceChainId:      RGB_CHAIN_ID,
             destinationChainId: SOURCE_CHAIN_ID,
             sourceAddress:      SRC_ADDR,
-            proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT),
-            settlementData:     _settlement(ids),
+            proof:              proof,
+            settlementData:     settlementData,
             dstEid:             DST_EID,
             recipient:          LZ_RECIPIENT,
             minAmountLD:        0,
@@ -378,7 +423,7 @@ contract MultisigProxyTest is Test {
         view
         returns (uint256 nonce, uint256 bitmap, bytes[] memory sigs)
     {
-        nonce = proxy.teeNonce();
+        nonce = proxy.teeNonce(RGB_CHAIN_ID);
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
         uint256[] memory pks;
         (pks, bitmap) = _encSigSet2of3();
@@ -404,14 +449,14 @@ contract MultisigProxyTest is Test {
     function test_constructor_setsState() public view {
         assertEq(proxy.bridge(), address(bridge));
         assertEq(proxy.commissionManager(), address(cm));
-        assertEq(proxy.enclaveThreshold(), 2);
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), 2);
         assertEq(proxy.federationThreshold(), 2);
         assertEq(proxy.commissionRecipient(), commissionReceiver);
         assertEq(proxy.timelockDuration(), TIMELOCK);
         assertEq(proxy.proposalNonce(), 0);
-        assertEq(proxy.teeNonce(),      0);
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),      0);
 
-        address[] memory enc = proxy.getEnclaveSigners();
+        address[] memory enc = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(enc.length, 3);
         assertEq(enc[0], encA1);
 
@@ -423,38 +468,38 @@ contract MultisigProxyTest is Test {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroBridge.selector);
-        new MultisigProxy(address(0), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(0), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommissionManager() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionManager.selector);
-        new MultisigProxy(address(bridge), address(0), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(0), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnNoEnclaveSigners() public {
         address[] memory enc = new address[](0);
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.NoSigners.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnBadEnclaveThreshold() public {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 3, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 3, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommission() public {
         vm.expectRevert(IMultisigProxy.ZeroCommissionRecipient.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, address(0), TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, address(0), TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnTimelockTooLong() public {
         vm.expectRevert(IMultisigProxy.TimelockTooLong.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, 30 days, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, 30 days, MIN_TIMELOCK);
     }
 
     // ---- R-W-11: MIN_TIMELOCK floor (post-fix) ----
@@ -463,19 +508,19 @@ contract MultisigProxyTest is Test {
     function test_constructor_revertsOnTimelockBelowMinTimelock() public {
         // timelock (1h) is below the requested floor (2h) -> TimelockTooShort
         vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, 1 hours, 2 hours);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, 1 hours, 2 hours);
     }
 
     /// @dev A zero floor is rejected — it would defeat the purpose of the fix.
     function test_constructor_revertsOnZeroMinTimelock() public {
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, TIMELOCK, 0);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, 0);
     }
 
     /// @dev A floor at/above the upper bound leaves no valid range — rejected.
     function test_constructor_revertsOnMinTimelockTooLong() public {
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, TIMELOCK, 30 days);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, 30 days);
     }
 
     function test_minTimelock_returnsConfiguredFloor() public view {
@@ -487,7 +532,7 @@ contract MultisigProxyTest is Test {
         // the call clears the threshold guard and reverts in _validateSigners.
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA1;
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroAddressSigner() public {
@@ -496,7 +541,7 @@ contract MultisigProxyTest is Test {
         // _validateSigners.
         address[] memory enc = new address[](2); enc[0] = address(0); enc[1] = encA2;
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     // ========================================================================
@@ -531,41 +576,41 @@ contract MultisigProxyTest is Test {
 
     function test_constructor_rejectsOneOfThree_enclave() public {
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _signers(3), 1, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _signers(3), 1, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_rejectsOneOfOne_enclave() public {
         // n < 2 — single-key set, rejected even though 2*1 > 1.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _signers(1), 1, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _signers(1), 1, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_rejectsSubMajority_enclave() public {
         // 2-of-4: 2*2 == 4, not a strict majority.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _signers(4), 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _signers(4), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_rejectsOneOfThree_federation() public {
         // Enclave valid, federation 1-of-3 — the floor applies to both sets.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _signers(3), 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _signers(3), 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_acceptsTwoOfTwo() public {
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(2), 2, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(2), 2, RGB_CHAIN_ID, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.enclaveThreshold(),    2);
+        assertEq(p.enclaveThreshold(RGB_CHAIN_ID),    2);
         assertEq(p.federationThreshold(), 2);
     }
 
     function test_constructor_acceptsThreeOfFour() public {
         // Strict majority with a non-trivial set (2*3 > 4).
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(4), 3, _signersB(4), 3, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(4), 3, RGB_CHAIN_ID, _signersB(4), 3, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.enclaveThreshold(),    3);
+        assertEq(p.enclaveThreshold(RGB_CHAIN_ID),    3);
         assertEq(p.federationThreshold(), 3);
     }
 
@@ -578,14 +623,14 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, badThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, badThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         // Threshold validity is now enforced up front, at propose time.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, badThreshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, badThreshold, nonce, deadline, bitmap, sigs);
     }
 
     // ---- Intrinsic set validation runs at propose time ----
@@ -600,13 +645,13 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, threshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, threshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.NoSigners.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, threshold, nonce, deadline, bitmap, sigs);
     }
 
     function test_proposeUpdateEnclaveSigners_rejectsZeroAddressSignerAtPropose() public {
@@ -617,13 +662,13 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, threshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, threshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, threshold, nonce, deadline, bitmap, sigs);
     }
 
     function test_proposeUpdateEnclaveSigners_rejectsDuplicateSignerAtPropose() public {
@@ -634,13 +679,13 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, threshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, threshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, threshold, nonce, deadline, bitmap, sigs);
     }
 
     function test_proposeUpdateFederationSigners_rejectsEmptySetAtPropose() public {
@@ -709,14 +754,14 @@ contract MultisigProxyTest is Test {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
         address[] memory fed = new address[](2); fed[0] = encA1; fed[1] = fedA2;
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, encA1));
-        new MultisigProxy(address(bridge), address(cm), enc, 2, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_acceptsDisjointSignerSets() public {
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(2), 2, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(2), 2, RGB_CHAIN_ID, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.getEnclaveSigners().length,    2);
+        assertEq(p.getEnclaveSigners(RGB_CHAIN_ID).length,    2);
         assertEq(p.getFederationSigners().length, 2);
     }
 
@@ -728,16 +773,16 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, fedA1));
-        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        proxy.executeProposal(id, abi.encode(RGB_CHAIN_ID, newSigners, newThreshold));
     }
 
     function test_proposeUpdateFederationSigners_rejectsOverlapWithEnclaveAtExecute() public {
@@ -775,7 +820,7 @@ contract MultisigProxyTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
         new MultisigProxy(
-            address(bridge), address(cm), enc, encThreshold, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), enc, encThreshold, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
     }
 
@@ -784,9 +829,9 @@ contract MultisigProxyTest is Test {
         uint256 threshold = max / 2 + 1; // 11-of-20 strict majority
 
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(max), threshold, _signersB(max), threshold, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(max), threshold, RGB_CHAIN_ID, _signersB(max), threshold, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.getEnclaveSigners().length,    max);
+        assertEq(p.getEnclaveSigners(RGB_CHAIN_ID).length,    max);
         assertEq(p.getFederationSigners().length, max);
     }
 
@@ -798,14 +843,14 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         // Signer-set size is now enforced up front, at propose time.
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
-        proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
     }
 
     // ========================================================================
@@ -814,25 +859,25 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_releasesViaBridge() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        vm.expectEmit(true, false, false, true);
-        emit FundsOutExecuted(nonce, bitmap);
+        vm.expectEmit(true, true, false, true);
+        emit FundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap);
 
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
         assertEq(token.balanceOf(recipient), AMOUNT);
-        assertEq(proxy.teeNonce(), nonce + 1);
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1);
     }
 
     function test_fundsOutCall_revertsOnExpired() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp - 1;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -854,7 +899,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnDeadlineTooFar() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE() + 1;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -867,7 +912,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_acceptsDeadlineAtMaxBoundary() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE(); // exact boundary, strict `>` lets it through
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -885,7 +930,7 @@ contract MultisigProxyTest is Test {
         _setLzAdapter(address(adapter));
 
         IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE() + 1;
 
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
@@ -904,7 +949,7 @@ contract MultisigProxyTest is Test {
         _setLzAdapter(address(adapter));
 
         IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE(); // exact boundary
 
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
@@ -914,7 +959,7 @@ contract MultisigProxyTest is Test {
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
         assertEq(token.balanceOf(mockOft), AMOUNT, 'lz release executes at the exact deadline ceiling');
-        assertEq(proxy.teeNonce(),         nonce + 1, 'teeNonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),         nonce + 1, 'teeNonce incremented');
     }
 
     function test_fundsOutCall_revertsOnWrongNonce() public {
@@ -936,7 +981,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnBelowThreshold() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -949,7 +994,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnBadSignature() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -964,7 +1009,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnSigCountMismatch() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -978,7 +1023,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnBitmapOutOfRange() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -991,7 +1036,7 @@ contract MultisigProxyTest is Test {
 
     function test_lzFundsOutCall_revertsIfAdapterUnset() public {
         IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
@@ -1007,7 +1052,7 @@ contract MultisigProxyTest is Test {
     // ========================================================================
 
     function test_emergencyPause_works() public {
-        uint256 nonce = proxy.proposalNonce();
+        uint256 nonce = proxy.emergencyNonce();
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
@@ -1020,11 +1065,12 @@ contract MultisigProxyTest is Test {
         proxy.emergencyPause(nonce, deadline, bitmap, sigs);
 
         assertTrue(bridge.paused());
-        assertEq(proxy.proposalNonce(), nonce + 1);
+        assertEq(proxy.emergencyNonce(), nonce + 1, 'emergency lane advanced');
+        assertEq(proxy.proposalNonce(), 0, 'proposal lane untouched by emergency');
     }
 
     function test_emergencyPause_revertsOnExpired() public {
-        uint256 nonce = proxy.proposalNonce();
+        uint256 nonce = proxy.emergencyNonce();
         uint256 deadline = block.timestamp - 1;
 
         bytes32 digest = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
@@ -1050,7 +1096,7 @@ contract MultisigProxyTest is Test {
     function test_emergencyUnpause_works() public {
         test_emergencyPause_works();
 
-        uint256 nonce = proxy.proposalNonce();
+        uint256 nonce = proxy.emergencyNonce();
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestEmergencyUnpause(domainSep, nonce, deadline);
@@ -1075,7 +1121,7 @@ contract MultisigProxyTest is Test {
     ///      must be frozen as well.
     function test_emergencyPause_freezesEnclaveFundsOut() public {
         // Federation triggers the emergency freeze (both paths).
-        uint256 nonce    = proxy.proposalNonce();
+        uint256 nonce    = proxy.emergencyNonce();
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 digest   = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
         (uint256[] memory fpks, uint256 fbitmap) = _fedSigSet2of3();
@@ -1087,12 +1133,12 @@ contract MultisigProxyTest is Test {
         // Inbound deposits are frozen.
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, abi.encode(RGB_OP_ID));
 
         // Enclave-signed release is frozen too — the revert propagates from
         // Bridge.fundsOut through proxy.fundsOutCall.
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 encNonce      = proxy.teeNonce();
+        uint256 encNonce      = proxy.teeNonce(RGB_CHAIN_ID);
         bytes32 encDigest     = MultisigHelper.digestTeeFundsOut(domainSep, params, encNonce, deadline);
         (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
         bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
@@ -1124,11 +1170,11 @@ contract MultisigProxyTest is Test {
         // Deposits are frozen...
         vm.expectRevert(Pausable.EnforcedPause.selector);
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, abi.encode(RGB_OP_ID));
 
         // ...but the enclave release still executes.
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 encNonce      = proxy.teeNonce();
+        uint256 encNonce      = proxy.teeNonce(RGB_CHAIN_ID);
         bytes32 encDigest     = MultisigHelper.digestTeeFundsOut(domainSep, params, encNonce, t + 1 days);
         (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
         bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
@@ -1251,20 +1297,20 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
-        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        proxy.executeProposal(id, abi.encode(RGB_CHAIN_ID, newSigners, newThreshold));
 
-        address[] memory after_ = proxy.getEnclaveSigners();
+        address[] memory after_ = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(after_.length, 2);
         assertEq(after_[1], newSigner);
-        assertEq(proxy.enclaveThreshold(), newThreshold);
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), newThreshold);
     }
 
     // ========================================================================
@@ -1393,7 +1439,7 @@ contract MultisigProxyTest is Test {
 
         uint256 depositAmount = 100e18;
         vm.prank(user);
-        bridge.fundsIn(depositAmount, RGB_CHAIN_ID, DST_ADDR, TX_ID + 1, '');
+        bridge.fundsIn(depositAmount, RGB_CHAIN_ID, DST_ADDR, abi.encode(RGB_OP_ID));
 
         uint256 expectedCommission = (depositAmount * 400) / 100 / 100;
         assertEq(cm.tokenCommissionPool(address(token)), expectedCommission);
@@ -1514,8 +1560,8 @@ contract MultisigProxyTest is Test {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(encPk1, digest);
         bytes memory sig = abi.encodePacked(r, s, v);
 
-        assertTrue(proxy.verifyEnclaveSignature(digest, sig, 0));
-        assertFalse(proxy.verifyEnclaveSignature(digest, sig, 1));
+        assertTrue(proxy.verifyEnclaveSignature(RGB_CHAIN_ID, digest, sig, 0));
+        assertFalse(proxy.verifyEnclaveSignature(RGB_CHAIN_ID, digest, sig, 1));
     }
 
     function test_verifyEnclaveSignature_revertsOutOfRange() public {
@@ -1524,7 +1570,7 @@ contract MultisigProxyTest is Test {
         bytes memory sig = abi.encodePacked(r, s, v);
 
         vm.expectRevert(IMultisigProxy.IndexOutOfRange.selector);
-        proxy.verifyEnclaveSignature(digest, sig, 99);
+        proxy.verifyEnclaveSignature(RGB_CHAIN_ID, digest, sig, 99);
     }
 
     // ========================================================================
@@ -1909,7 +1955,7 @@ contract MultisigProxyTest is Test {
         // Sign a valid TEE fundsOut on the original chain (domainSep was cached
         // at setUp for block.chainid).
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -1952,7 +1998,7 @@ contract MultisigProxyTest is Test {
 
         // Prepare signed TEE execution and snapshot proxy + Bridge accounting.
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
@@ -1963,7 +2009,7 @@ contract MultisigProxyTest is Test {
         uint256 cmBefore        = token.balanceOf(address(cm));
         uint256 cmPoolBefore    = cm.tokenCommissionPool(address(token));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
-        uint256 recordBefore    = rgbModule.fundsInRecords(TX_ID);
+        uint256 recordBefore    = rgbModule.fundsInRecords(seedOpId);
 
         assertEq(bridgeBefore,     AMOUNT * 5, 'pre bridge pool');
         assertEq(recipientBefore,  0,          'pre recipient token');
@@ -1971,7 +2017,7 @@ contract MultisigProxyTest is Test {
         assertEq(cmPoolBefore,     0,          'pre cm pool');
         assertEq(nativePoolBefore, 0,          'pre native pool');
         assertEq(recordBefore,     AMOUNT * 5, 'pre record');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         vm.expectEmit(true, true, false, true);
         emit BridgeFundsOut(
@@ -1979,18 +2025,18 @@ contract MultisigProxyTest is Test {
             AMOUNT,
             netAmount,
             tokenCommission,
-            BURN_ID,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
         );
-        vm.expectEmit(true, false, false, true);
-        emit FundsOutExecuted(nonce, bitmap);
+        vm.expectEmit(true, true, false, true);
+        emit FundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap);
 
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(), nonce + 1, 'nonce incremented');
-        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'nonce incremented');
+        assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT,        'bridge gross debit');
         assertEq(token.balanceOf(recipient),       recipientBefore + netAmount, 'recipient net delta');
         assertEq(token.balanceOf(address(cm)),     cmBefore + tokenCommission,  'cm fee delta');
@@ -2000,7 +2046,7 @@ contract MultisigProxyTest is Test {
             'cm pool delta'
         );
         assertEq(cm.nativeCommissionPool(),        nativePoolBefore,             'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID),  recordBefore,                 'record unchanged (proof-of-mint permanent)');
+        assertEq(rgbModule.fundsInRecords(seedOpId),  recordBefore,                 'record unchanged (proof-of-mint permanent)');
 
         // The signed Bridge gross debit splits into recipient net payout and CM token commission.
         assertEq(
@@ -2051,7 +2097,7 @@ contract MultisigProxyTest is Test {
         uint256 oftBefore       = token.balanceOf(mockOft);
         uint256 cmBefore        = token.balanceOf(address(cm));
         uint256 cmPoolBefore    = cm.tokenCommissionPool(address(token));
-        uint256 recordBefore    = rgbModule.fundsInRecords(TX_ID);
+        uint256 recordBefore    = rgbModule.fundsInRecords(seedOpId);
         uint256 proxyEthBefore  = address(proxy).balance;
         uint256 adapterEthBefore = address(adapter).balance;
         uint256 oftEthBefore    = mockOft.balance;
@@ -2064,7 +2110,7 @@ contract MultisigProxyTest is Test {
         assertEq(recordBefore,   AMOUNT * 5, 'pre record');
         assertEq(adapterEthBefore, 0,        'pre adapter native');
         assertEq(oftEthBefore,     0,        'pre oft native');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, netAmount));
 
@@ -2074,25 +2120,25 @@ contract MultisigProxyTest is Test {
             AMOUNT,
             netAmount,
             tokenCommission,
-            BURN_ID,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
         );
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(), nonce + 1, 'tee nonce incremented');
-        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'tee nonce incremented');
+        assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)),  bridgeBefore - AMOUNT,          'bridge gross debit');
         assertEq(token.balanceOf(address(cm)),      cmBefore + tokenCommission,     'cm fee delta');
         assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore + tokenCommission, 'cm pool delta');
-        assertEq(rgbModule.fundsInRecords(TX_ID),   recordBefore,                   'record unchanged (proof-of-mint permanent)');
+        assertEq(rgbModule.fundsInRecords(seedOpId),   recordBefore,                   'record unchanged (proof-of-mint permanent)');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,                  'adapter no residue');
         assertEq(token.balanceOf(mockOft),          oftBefore + netAmount,          'oft receives net');
         assertEq(address(proxy).balance,            proxyEthBefore,                 'proxy native no residue');
@@ -2147,7 +2193,7 @@ contract MultisigProxyTest is Test {
         uint256 cmBefore         = token.balanceOf(address(cm));
         uint256 cmPoolBefore     = cm.tokenCommissionPool(address(token));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
-        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+        uint256 recordBefore     = rgbModule.fundsInRecords(seedOpId);
         uint256 proxyEthBefore   = address(proxy).balance;
         uint256 adapterEthBefore = address(adapter).balance;
         uint256 oftEthBefore     = mockOft.balance;
@@ -2159,7 +2205,7 @@ contract MultisigProxyTest is Test {
         assertEq(cmPoolBefore,     0,          'pre cm pool');
         assertEq(nativePoolBefore, 0,          'pre native pool');
         assertEq(recordBefore,     AMOUNT * 5, 'pre record');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         // An underfunded native fee reverts in sendOut, after Bridge.fundsOut
         // already ran inside the same lzFundsOutCall transaction.
@@ -2167,15 +2213,15 @@ contract MultisigProxyTest is Test {
         vm.expectRevert(bytes('native fee'));
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE - 1 }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce,            'tee nonce unchanged');
-        assertFalse(bridge.consumedBurnIds(BURN_ID),                'burn id unchanged');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce,            'tee nonce unchanged');
+        assertFalse(bridge.consumedBurnIds(params.burnId),          'burn id unchanged');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter token unchanged');
         assertEq(token.balanceOf(mockOft),          oftBefore,      'oft token unchanged');
         assertEq(token.balanceOf(address(cm)),      cmBefore,       'cm token unchanged');
         assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore, 'cm pool unchanged');
         assertEq(cm.nativeCommissionPool(),         nativePoolBefore,  'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID),   recordBefore,      'record unchanged');
+        assertEq(rgbModule.fundsInRecords(seedOpId),   recordBefore,      'record unchanged');
         assertEq(address(proxy).balance,            proxyEthBefore,    'proxy native unchanged');
         assertEq(address(adapter).balance,          adapterEthBefore,  'adapter native unchanged');
         assertEq(mockOft.balance,                   oftEthBefore,      'oft native unchanged');
@@ -2199,7 +2245,7 @@ contract MultisigProxyTest is Test {
             })
         );
 
-        (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount) =
+        (uint256 tokenCommission, uint256 nativeCommission,) =
             cm.calculateFundsOutCommission(RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token), AMOUNT);
         assertGt(tokenCommission, 0, 'token fee quoted');
         assertEq(nativeCommission, 0, 'native fee is zero');
@@ -2213,6 +2259,15 @@ contract MultisigProxyTest is Test {
         // Well-formed two-pair proof whose source block is unknown to the relay,
         // so Bridge.fundsOut reverts before the adapter send can run.
         params.proof = abi.encode(uint256(999_999), keccak256('unknown-block'), LATEST_HEIGHT, LATEST_COMMIT);
+        params.burnId = _deriveBurnId(
+            address(adapter),
+            params.amount,
+            params.sourceChainId,
+            params.destinationChainId,
+            params.sourceAddress,
+            params.proof,
+            params.settlementData
+        );
 
         uint256 deadline = block.timestamp + 1 hours;
         (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
@@ -2224,7 +2279,7 @@ contract MultisigProxyTest is Test {
         uint256 cmBefore         = token.balanceOf(address(cm));
         uint256 cmPoolBefore     = cm.tokenCommissionPool(address(token));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
-        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+        uint256 recordBefore     = rgbModule.fundsInRecords(seedOpId);
         uint256 proxyEthBefore   = address(proxy).balance;
         uint256 adapterEthBefore = address(adapter).balance;
         uint256 oftEthBefore     = mockOft.balance;
@@ -2237,14 +2292,14 @@ contract MultisigProxyTest is Test {
         assertEq(nativePoolBefore, 0,          'pre native pool');
         assertEq(recordBefore,     AMOUNT * 5, 'pre record');
         assertEq(adapter.sendOutCalls(), 0,    'pre adapter calls');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         vm.expectRevert(bytes('verify: block commitment'));
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce,            'tee nonce unchanged');
-        assertFalse(bridge.consumedBurnIds(BURN_ID),                'burn id unchanged');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce,            'tee nonce unchanged');
+        assertFalse(bridge.consumedBurnIds(params.burnId),          'burn id unchanged');
         assertEq(adapter.sendOutCalls(),           0,               'adapter not called');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter token unchanged');
@@ -2252,7 +2307,7 @@ contract MultisigProxyTest is Test {
         assertEq(token.balanceOf(address(cm)),      cmBefore,       'cm token unchanged');
         assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore, 'cm pool unchanged');
         assertEq(cm.nativeCommissionPool(),         nativePoolBefore,  'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID),   recordBefore,      'record unchanged');
+        assertEq(rgbModule.fundsInRecords(seedOpId),   recordBefore,      'record unchanged');
         assertEq(address(proxy).balance,            proxyEthBefore,    'proxy native unchanged');
         assertEq(address(adapter).balance,          adapterEthBefore,  'adapter native unchanged');
         assertEq(mockOft.balance,                   oftEthBefore,      'oft native unchanged');
@@ -2286,9 +2341,9 @@ contract MultisigProxyTest is Test {
             new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
         _setLzAdapter(address(adapter));
 
-        uint256[] memory duplicateIds = new uint256[](2);
-        duplicateIds[0] = TX_ID;
-        duplicateIds[1] = TX_ID;
+        bytes32[] memory duplicateIds = new bytes32[](2);
+        duplicateIds[0] = seedOpId;
+        duplicateIds[1] = seedOpId;
 
         IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, duplicateIds);
 
@@ -2305,7 +2360,7 @@ contract MultisigProxyTest is Test {
         uint256 cmBefore         = token.balanceOf(address(cm));
         uint256 cmPoolBefore     = cm.tokenCommissionPool(address(token));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
-        uint256 recordBefore     = rgbModule.fundsInRecords(TX_ID);
+        uint256 recordBefore     = rgbModule.fundsInRecords(seedOpId);
         uint256 proxyEthBefore   = address(proxy).balance;
         uint256 adapterEthBefore = address(adapter).balance;
         uint256 oftEthBefore     = mockOft.balance;
@@ -2318,7 +2373,7 @@ contract MultisigProxyTest is Test {
         assertEq(nativePoolBefore, 0,          'pre native pool');
         assertEq(recordBefore,     AMOUNT * 5, 'pre record');
         assertEq(adapter.sendOutCalls(), 0,    'pre adapter calls');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, netAmount));
 
@@ -2328,21 +2383,21 @@ contract MultisigProxyTest is Test {
             AMOUNT,
             netAmount,
             tokenCommission,
-            BURN_ID,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
         );
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce + 1,        'tee nonce incremented');
-        assertTrue(bridge.consumedBurnIds(BURN_ID),                  'burn id consumed');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce + 1,        'tee nonce incremented');
+        assertTrue(bridge.consumedBurnIds(params.burnId),            'burn id consumed');
         assertEq(adapter.sendOutCalls(),           1,               'adapter called once');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge token debit');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter no residue');
@@ -2350,7 +2405,7 @@ contract MultisigProxyTest is Test {
         assertEq(token.balanceOf(address(cm)),      cmBefore + tokenCommission, 'cm token delta');
         assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore + tokenCommission, 'cm pool delta');
         assertEq(cm.nativeCommissionPool(),         nativePoolBefore,  'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(TX_ID),   recordBefore, 'record unchanged (proof-of-mint permanent)');
+        assertEq(rgbModule.fundsInRecords(seedOpId),   recordBefore, 'record unchanged (proof-of-mint permanent)');
         assertEq(address(proxy).balance,            proxyEthBefore,  'proxy native unchanged');
         assertEq(address(adapter).balance,          adapterEthBefore, 'adapter native unchanged');
         assertEq(mockOft.balance,                   oftEthBefore + LZ_NATIVE_FEE, 'oft native fee');
@@ -2359,11 +2414,8 @@ contract MultisigProxyTest is Test {
     // Flow-4 success coverage for duplicate RGB settlement ids: the reworked
     // module verifies each (id, amount) pair by pure read, so duplicates pass.
     function test_lzFundsOutCall_duplicateSettlementIdsFullConsume_succeedsAndIgnoresDuplicate() public {
-        uint256 duplicateRecordId = TX_ID + 1;
-        uint256 burnId = BURN_ID + 1;
-
         vm.prank(user);
-        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, duplicateRecordId, '');
+        bytes32 secondOpId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, abi.encode(RGB_OP_ID));
 
         uint256 percent = 500; // 5%
         vm.prank(address(proxy));
@@ -2390,11 +2442,11 @@ contract MultisigProxyTest is Test {
             new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
         _setLzAdapter(address(adapter));
 
-        uint256[] memory duplicateIds = new uint256[](2);
-        duplicateIds[0] = duplicateRecordId;
-        duplicateIds[1] = duplicateRecordId;
+        bytes32[] memory duplicateIds = new bytes32[](2);
+        duplicateIds[0] = secondOpId;
+        duplicateIds[1] = secondOpId;
 
-        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, burnId, duplicateIds);
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID + 1, duplicateIds);
 
         uint256 deadline = block.timestamp + 1 hours;
         (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
@@ -2406,8 +2458,8 @@ contract MultisigProxyTest is Test {
         uint256 oftBefore        = token.balanceOf(mockOft);
         uint256 cmBefore         = token.balanceOf(address(cm));
         uint256 cmPoolBefore     = cm.tokenCommissionPool(address(token));
-        uint256 originalRecordBefore  = rgbModule.fundsInRecords(TX_ID);
-        uint256 duplicateRecordBefore = rgbModule.fundsInRecords(duplicateRecordId);
+        uint256 originalRecordBefore  = rgbModule.fundsInRecords(seedOpId);
+        uint256 duplicateRecordBefore = rgbModule.fundsInRecords(secondOpId);
         uint256 proxyEthBefore   = address(proxy).balance;
         uint256 adapterEthBefore = address(adapter).balance;
         uint256 oftEthBefore     = mockOft.balance;
@@ -2420,7 +2472,7 @@ contract MultisigProxyTest is Test {
         assertEq(originalRecordBefore,    AMOUNT * 5, 'pre original record');
         assertEq(duplicateRecordBefore,   AMOUNT,     'pre duplicate record');
         assertEq(adapter.sendOutCalls(),  0,          'pre adapter calls');
-        assertFalse(bridge.consumedBurnIds(burnId), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, netAmount));
 
@@ -2430,29 +2482,29 @@ contract MultisigProxyTest is Test {
             AMOUNT,
             netAmount,
             tokenCommission,
-            burnId,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
         );
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce + 1,        'tee nonce incremented');
-        assertTrue(bridge.consumedBurnIds(burnId),                  'burn id consumed');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce + 1,        'tee nonce incremented');
+        assertTrue(bridge.consumedBurnIds(params.burnId),            'burn id consumed');
         assertEq(adapter.sendOutCalls(),           1,               'adapter called once');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge token debit');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter no residue');
         assertEq(token.balanceOf(mockOft),          oftBefore + netAmount, 'oft token delta');
         assertEq(token.balanceOf(address(cm)),      cmBefore + tokenCommission, 'cm token delta');
         assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore + tokenCommission, 'cm pool delta');
-        assertEq(rgbModule.fundsInRecords(TX_ID),   originalRecordBefore, 'original record untouched');
-        assertEq(rgbModule.fundsInRecords(duplicateRecordId), duplicateRecordBefore, 'duplicate record unchanged');
+        assertEq(rgbModule.fundsInRecords(seedOpId),   originalRecordBefore, 'original record untouched');
+        assertEq(rgbModule.fundsInRecords(secondOpId), duplicateRecordBefore, 'duplicate record unchanged');
         assertEq(address(proxy).balance,            proxyEthBefore,  'proxy native unchanged');
         assertEq(address(adapter).balance,          adapterEthBefore, 'adapter native unchanged');
         assertEq(mockOft.balance,                   oftEthBefore + LZ_NATIVE_FEE, 'oft native fee');
@@ -2538,7 +2590,7 @@ contract MultisigProxyTest is Test {
             AMOUNT,
             netAmount,
             tokenCommission,
-            BURN_ID,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
@@ -2569,17 +2621,16 @@ contract MultisigProxyTest is Test {
         // amount cap on the signed Bridge fundsOut.
         uint256 bridgeBefore    = token.balanceOf(address(bridge));
         uint256 recipientBefore = token.balanceOf(drainRecipient);
-        uint256 recordBefore    = rgbModule.fundsInRecords(TX_ID);
+        uint256 recordBefore    = rgbModule.fundsInRecords(seedOpId);
 
         assertEq(bridgeBefore,    AMOUNT * 5, 'pre bridge pool');
         assertEq(recipientBefore, 0,          'pre recipient token');
         assertEq(recordBefore,    bridgeBefore, 'pre record backs full pool');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
-
         // Current behavior: if an on-chain amount cap or rate limit is added
         // later, this test should be inverted to expect a revert.
         IBridge.FundsOutParams memory params = _fundsOutParams(drainRecipient, bridgeBefore, BURN_ID);
-        uint256 nonce = proxy.teeNonce();
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
@@ -2591,21 +2642,21 @@ contract MultisigProxyTest is Test {
             bridgeBefore,
             bridgeBefore,
             0,
-            BURN_ID,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
         );
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit FundsOutExecuted(nonce, bitmap);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit FundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap);
 
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(), nonce + 1, 'nonce incremented');
-        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'nonce incremented');
+        assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)), 0, 'bridge pool drained');
         assertEq(token.balanceOf(drainRecipient), recipientBefore + bridgeBefore, 'recipient got full pool');
-        assertEq(rgbModule.fundsInRecords(TX_ID), recordBefore, 'record unchanged (proof-of-mint permanent)');
+        assertEq(rgbModule.fundsInRecords(seedOpId), recordBefore, 'record unchanged (proof-of-mint permanent)');
     }
 
     function test_governanceCanRotateEnclaveToUnattestedEOA_currentBehavior() public {
@@ -2615,22 +2666,22 @@ contract MultisigProxyTest is Test {
         newSigners[2] = makeAddr('unattestedEnc3');
         uint256 newThreshold = 2;
 
-        address[] memory before_ = proxy.getEnclaveSigners();
+        address[] memory before_ = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(before_.length, 3, 'pre enclave count');
         assertEq(before_[0], encA1, 'pre signer 0');
         assertEq(before_[1], encA2, 'pre signer 1');
         assertEq(before_[2], encA3, 'pre signer 2');
-        assertEq(proxy.enclaveThreshold(), 2, 'pre enclave threshold');
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), 2, 'pre enclave threshold');
 
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
 
@@ -2638,19 +2689,19 @@ contract MultisigProxyTest is Test {
         // this case documents that only address shape and threshold are checked,
         // with no on-chain enclave attestation evidence. If attestation is
         // enforced later, this test should be inverted to expect a revert.
-        vm.expectEmit(false, false, false, true, address(proxy));
-        emit EnclaveSignersUpdated(newSigners, newThreshold);
+        vm.expectEmit(true, false, false, true, address(proxy));
+        emit EnclaveSignersUpdated(RGB_CHAIN_ID, newSigners, newThreshold);
         vm.expectEmit(true, true, false, true, address(proxy));
         emit ProposalExecuted(id, IMultisigProxy.OperationType.UpdateEnclaveSigners);
 
-        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        proxy.executeProposal(id, abi.encode(RGB_CHAIN_ID, newSigners, newThreshold));
 
-        address[] memory after_ = proxy.getEnclaveSigners();
+        address[] memory after_ = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(after_.length, 3, 'post enclave count');
         assertEq(after_[0], newSigners[0], 'post signer 0');
         assertEq(after_[1], newSigners[1], 'post signer 1');
         assertEq(after_[2], newSigners[2], 'post signer 2');
-        assertEq(proxy.enclaveThreshold(), newThreshold, 'post enclave threshold');
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), newThreshold, 'post enclave threshold');
     }
 
     function test_proposalUsesSnapshottedTimelock_afterFix() public {
@@ -2701,42 +2752,38 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.bridge(), newBridge, 'snapshotted proposal executes despite the live timelock raise');
     }
 
-    // Current behavior: emergency actions and regular proposals share
-    // proposalNonce, so an emergency pause can stale an already signed regular
-    // proposal before it is submitted on-chain.
-    function test_emergencyAndRegularProposalNonceCollide_currentBehavior() public {
+    // R-I-09 after-fix: emergency actions run on a separate `emergencyNonce`, so
+    // an emergency pause does NOT stale an already-signed regular proposal — the
+    // pre-signed proposal still submits.
+    function test_emergencyDoesNotStaleRegularProposal_afterFix() public {
         address newBridge = makeAddr('nonceCollisionBridge');
         uint256 regularNonce = proxy.proposalNonce();
         uint256 regularDeadline = block.timestamp + 1 days;
 
+        // Pre-sign a regular proposal at the current proposal-lane nonce.
         bytes32 regularDigest = MultisigHelper.digestProposeUpdateBridge(
             domainSep, newBridge, regularNonce, regularDeadline
         );
         (uint256[] memory regularPks, uint256 regularBitmap) = _fedSigSet2of3();
         bytes[] memory regularSigs = MultisigHelper.signAll(vm, regularDigest, regularPks);
 
-        uint256 emergencyDeadline = block.timestamp + 1 hours;
-        bytes32 emergencyDigest = MultisigHelper.digestEmergencyPause(domainSep, regularNonce, emergencyDeadline);
+        // An emergency pause runs on its own lane nonce.
+        uint256 emergencyLaneNonce = proxy.emergencyNonce();
+        uint256 emergencyDeadline  = block.timestamp + 1 hours;
+        bytes32 emergencyDigest = MultisigHelper.digestEmergencyPause(domainSep, emergencyLaneNonce, emergencyDeadline);
         (uint256[] memory emergencyPks, uint256 emergencyBitmap) = _fedSigSet2of3();
         bytes[] memory emergencySigs = MultisigHelper.signAll(vm, emergencyDigest, emergencyPks);
 
-        assertFalse(bridge.paused(), 'pre bridge active');
-        assertEq(proxy.proposalNonce(), regularNonce, 'pre proposal nonce');
-        assertEq(proxy.bridge(), address(bridge), 'pre bridge target');
-
-        vm.expectEmit(false, false, false, true, address(proxy));
-        emit EmergencyPaused(regularNonce, emergencyBitmap);
-
-        proxy.emergencyPause(regularNonce, emergencyDeadline, emergencyBitmap, emergencySigs);
+        proxy.emergencyPause(emergencyLaneNonce, emergencyDeadline, emergencyBitmap, emergencySigs);
 
         assertTrue(bridge.paused(), 'bridge paused by emergency action');
-        assertEq(proxy.proposalNonce(), regularNonce + 1, 'emergency consumed proposal nonce');
+        assertEq(proxy.emergencyNonce(), emergencyLaneNonce + 1, 'emergency advanced only its own lane');
+        assertEq(proxy.proposalNonce(), regularNonce, 'proposal lane untouched by emergency');
 
-        vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
-        proxy.proposeUpdateBridge(newBridge, regularNonce, regularDeadline, regularBitmap, regularSigs);
-
-        assertEq(proxy.proposalNonce(), regularNonce + 1, 'stale proposal leaves nonce unchanged');
-        assertEq(proxy.bridge(), address(bridge), 'stale proposal leaves bridge unchanged');
+        // The pre-signed regular proposal is still valid and submits successfully.
+        bytes32 id = proxy.proposeUpdateBridge(newBridge, regularNonce, regularDeadline, regularBitmap, regularSigs);
+        assertTrue(id != bytes32(0), 'regular proposal created despite the emergency action');
+        assertEq(proxy.proposalNonce(), regularNonce + 1, 'regular proposal consumed its lane nonce');
     }
 
     // Generic Bridge admin execution can still call
@@ -2836,72 +2883,483 @@ contract MultisigProxyTest is Test {
     // The typed commission-withdraw path pins the recipient to
     // commissionRecipient, while generic CM admin execution forwards arbitrary
     // calldata and lets the encoded withdrawal recipient win.
-    function test_adminExecuteCommissionManagerBypassesRecipientPin_currentBehavior() public {
-        address arbitraryRecipient = makeAddr('arbitraryCommissionRecipient');
+    // R-W-15 after-fix: the generic AdminExecuteCommissionManager path can no
+    // longer reach a commission-withdrawal selector, so it cannot re-point
+    // commission away from the pinned `commissionRecipient`. The guard fires at
+    // propose time (before signature verification), so no valid federation
+    // signatures are needed to observe it.
+    function test_adminExecuteCommissionManager_rejectsWithdrawSelectors_afterFix() public {
+        bytes[] memory callDatas = new bytes[](4);
+        callDatas[0] = abi.encodeWithSignature(
+            'withdrawTokenCommission(address,address,uint256)', address(token), user, uint256(1));
+        callDatas[1] = abi.encodeWithSignature(
+            'withdrawNativeCommission(address,uint256)', user, uint256(1));
+        callDatas[2] = abi.encodeWithSignature(
+            'withdrawAllTokenCommission(address,address)', address(token), user);
+        callDatas[3] = abi.encodeWithSignature(
+            'withdrawAllNativeCommission(address)', user);
 
-        vm.prank(address(proxy));
-        cm.setCommissionRule(
-            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token),
-            CommissionConfig({
-                stablePercent: 400, // 4%
-                multiplier: 100,
-                side: CommissionSide.FUNDS_IN,
-                currency: CommissionCurrency.TOKEN,
-                isSet: true
-            })
-        );
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes[] memory noSigs = new bytes[](0); // guard reverts before sig checks
 
-        uint256 depositAmount = 100e18;
-        vm.prank(user);
-        bridge.fundsIn(depositAmount, RGB_CHAIN_ID, DST_ADDR, TX_ID + 777, '');
+        for (uint256 i = 0; i < callDatas.length; i++) {
+            vm.expectRevert(abi.encodeWithSelector(
+                IMultisigProxy.ForbiddenCommissionManagerSelector.selector, bytes4(callDatas[i])
+            ));
+            proxy.proposeAdminExecuteCommissionManager(callDatas[i], nonce, deadline, 0, noSigs);
+        }
+    }
 
-        uint256 expectedCommission = (depositAmount * 400) / 100 / 100;
-        uint256 poolBefore = cm.tokenCommissionPool(address(token));
-        uint256 pinnedRecipientBefore = token.balanceOf(commissionReceiver);
-        uint256 arbitraryRecipientBefore = token.balanceOf(arbitraryRecipient);
-
-        assertEq(poolBefore, expectedCommission, 'pre cm pool');
-        assertEq(pinnedRecipientBefore, 0, 'pre pinned recipient');
-        assertEq(arbitraryRecipientBefore, 0, 'pre arbitrary recipient');
-
+    // The generic path stays open for non-withdrawal CommissionManager setters.
+    function test_adminExecuteCommissionManager_allowsNonWithdrawSelector() public {
         bytes memory callData = abi.encodeWithSignature(
-            'withdrawTokenCommission(address,address,uint256)',
-            address(token),
-            arbitraryRecipient,
-            expectedCommission
+            'setGlobalDefaults(uint256,uint8,uint8,uint8)', uint256(0), uint8(100), uint8(0), uint8(0)
         );
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
         bytes32 digest = MultisigHelper.digestProposeAdminExecuteCM(
-            domainSep,
-            bytes4(callData),
-            callData,
-            nonce,
-            deadline
+            domainSep, bytes4(callData), callData, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         bytes32 id = proxy.proposeAdminExecuteCommissionManager(callData, nonce, deadline, bitmap, sigs);
+        assertTrue(id != bytes32(0), 'non-withdrawal CM selector accepted on the generic path');
+    }
 
-        vm.warp(block.timestamp + TIMELOCK + 1);
+    // ========================================================================
+    // Per-source-chain enclave signer sets
+    // ========================================================================
+    //
+    // NOTE: these tests run multiple propose -> warp -> execute cycles. Time is
+    // read via `vm.getBlockTimestamp()` rather than the `block.timestamp` opcode:
+    // under via_ir the optimizer caches `block.timestamp` across the `vm.warp`
+    // staticcall, so a later cycle would otherwise reuse a stale timestamp.
 
-        // Current behavior: generic CM admin execution emits only the
-        // CommissionManager withdrawal event and sends funds to the calldata
-        // recipient, not to the proxy's pinned commissionRecipient.
-        vm.expectEmit(true, true, false, true, address(cm));
-        emit TokenCommissionWithdrawn(address(token), arbitraryRecipient, expectedCommission);
-        vm.expectEmit(true, true, false, true, address(proxy));
-        emit ProposalExecuted(id, IMultisigProxy.OperationType.AdminExecuteCommissionManager);
+    /// @dev `n` deterministic, globally-unique signer addresses for `chainId`,
+    ///      in a keccak namespace disjoint from the setUp enclave/federation
+    ///      addresses and from every other chain's generated set.
+    function _encSetFor(uint256 chainId, uint256 n) internal pure returns (address[] memory a) {
+        a = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            a[i] = address(uint160(uint256(keccak256(abi.encode('enc-set', chainId, i)))));
+        }
+    }
 
-        proxy.executeProposal(id, callData);
-
-        assertEq(cm.tokenCommissionPool(address(token)), 0, 'cm pool drained');
-        assertEq(token.balanceOf(commissionReceiver), pinnedRecipientBefore, 'pinned recipient unchanged');
-        assertEq(
-            token.balanceOf(arbitraryRecipient),
-            arbitraryRecipientBefore + expectedCommission,
-            'arbitrary recipient credited'
+    /// @dev Register (or rotate) an enclave set for `chainId` via the federation
+    ///      propose -> timelock -> execute path (signed by the original 2-of-3
+    ///      federation, which is left untouched by these helpers).
+    function _govUpdateEnclave(uint256 chainId, address[] memory signers, uint256 threshold) internal {
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, chainId, signers, threshold, nonce, deadline
         );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(chainId, signers, threshold, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(chainId, signers, threshold));
+    }
+
+    function _slice(uint256[] memory a, uint256 k) internal pure returns (uint256[] memory r) {
+        r = new uint256[](k);
+        for (uint256 i = 0; i < k; i++) r[i] = a[i];
+    }
+
+    function _bitmapFor(uint256 k) internal pure returns (uint256 b) {
+        for (uint256 i = 0; i < k; i++) b |= (uint256(1) << i);
+    }
+
+    /// @dev A federation candidate set derived from sequential private keys so
+    ///      the caller retains the pks to sign the *next* rotation.
+    function _fedFromPks(uint256 base, uint256 n)
+        internal
+        returns (address[] memory addrs, uint256[] memory pks)
+    {
+        addrs = new address[](n);
+        pks   = new uint256[](n);
+        for (uint256 i = 0; i < n; i++) {
+            pks[i]   = base + i;
+            addrs[i] = vm.addr(pks[i]);
+        }
+    }
+
+    /// @dev An enclave candidate set derived from sequential private keys, so a
+    ///      test can register the set AND later sign a real release with it.
+    function _encFromPks(uint256 base, uint256 n)
+        internal
+        returns (address[] memory addrs, uint256[] memory pks)
+    {
+        addrs = new address[](n);
+        pks   = new uint256[](n);
+        for (uint256 i = 0; i < n; i++) {
+            pks[i]   = base + i;
+            addrs[i] = vm.addr(pks[i]);
+        }
+    }
+
+    /// @dev Rotate the federation set, signing with the *current* federation pks,
+    ///      returning the gas consumed by executeProposal (the disjoint-loop leg).
+    function _rotateFedMeasured(
+        address[] memory newAddrs,
+        uint256 newThr,
+        uint256[] memory curPks,
+        uint256 curBitmap
+    ) internal returns (uint256 gasUsed) {
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(
+            domainSep, newAddrs, newThr, nonce, deadline
+        );
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, curPks);
+        bytes32 id = proxy.proposeUpdateFederationSigners(newAddrs, newThr, nonce, deadline, curBitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+        uint256 g0 = gasleft();
+        proxy.executeProposal(id, abi.encode(newAddrs, newThr));
+        gasUsed = g0 - gasleft();
+    }
+
+    // ---- release-path behaviour -------------------------------------------
+
+    /// @dev `fundsOutCall` for a source chain with no registered enclave set
+    ///      reverts UnknownSourceChain before touching the nonce/signatures.
+    function test_perSourceChain_fundsOutRevertsForUnregisteredSourceChain() public {
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        p.sourceChainId = 424_242; // not registered
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(424_242)));
+        proxy.fundsOutCall(p, 0, vm.getBlockTimestamp() + 1 hours, 0, new bytes[](0));
+    }
+
+    /// @dev A release for chain B signed by chain A's (RGB) enclave keys is
+    ///      rejected: selection by sourceChainId verifies A's signatures against
+    ///      B's set, which does not contain them.
+    function test_perSourceChain_signatureFromAnotherChainRejected() public {
+        uint256 chainB = 7_000_001;
+        _govUpdateEnclave(chainB, _encSetFor(chainB, 3), 2);
+
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        p.sourceChainId = chainB;
+        uint256 nonce    = proxy.teeNonce(chainB); // 0
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, p, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3(); // RGB signers
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        // Must fail at the signer check (recovered RGB signer != chainB's set),
+        // NOT downstream in the Bridge — that is what proves signer-set isolation.
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.fundsOutCall(p, nonce, deadline, bitmap, sigs);
+    }
+
+    /// @dev Each source chain has an independent teeNonce lane: an RGB release
+    ///      advances only RGB's nonce, not another registered chain's.
+    function test_perSourceChain_teeNonceLanesIndependent() public {
+        uint256 chainB = 7_000_002;
+        _govUpdateEnclave(chainB, _encSetFor(chainB, 3), 2);
+
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), 0, 'RGB nonce starts at 0');
+        assertEq(proxy.teeNonce(chainB), 0, 'chainB nonce starts at 0');
+
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, p, proxy.teeNonce(RGB_CHAIN_ID), deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        proxy.fundsOutCall(p, 0, deadline, bitmap, sigs);
+
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), 1, 'RGB lane advanced');
+        assertEq(proxy.teeNonce(chainB), 0, 'chainB lane untouched');
+    }
+
+    // ---- registration / rotation ------------------------------------------
+
+    function test_perSourceChain_registerNewChain() public {
+        uint256 chainB = 8_000_001;
+        address[] memory sB = _encSetFor(chainB, 4);
+        _govUpdateEnclave(chainB, sB, 3); // 2*3 > 4
+
+        assertEq(proxy.enclaveThreshold(chainB), 3);
+        address[] memory got = proxy.getEnclaveSigners(chainB);
+        assertEq(got.length, 4);
+        assertEq(got[0], sB[0]);
+
+        uint256[] memory chains = proxy.getEnclaveSourceChains();
+        assertEq(chains.length, 2, 'RGB + chainB');
+        assertEq(chains[0], RGB_CHAIN_ID);
+        assertEq(chains[1], chainB);
+    }
+
+    /// @dev Federation rotation must be disjoint from *every* enclave chain.
+    function test_perSourceChain_federationRotationRejectsEnclaveOverlap() public {
+        uint256 chainB = 8_000_002;
+        address[] memory sB = _encSetFor(chainB, 3);
+        _govUpdateEnclave(chainB, sB, 2);
+
+        address[] memory newFed = new address[](3);
+        newFed[0] = sB[0]; // overlaps chainB
+        newFed[1] = fedA2;
+        newFed[2] = fedA3;
+
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(domainSep, newFed, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateFederationSigners(newFed, 2, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, sB[0]));
+        proxy.executeProposal(id, abi.encode(newFed, 2));
+    }
+
+    /// @dev An enclave rotation for chain C must be disjoint from other enclave
+    ///      chains (here chain B).
+    function test_perSourceChain_enclaveRotationRejectsOtherChainOverlap() public {
+        uint256 chainB = 8_000_003;
+        address[] memory sB = _encSetFor(chainB, 3);
+        _govUpdateEnclave(chainB, sB, 2);
+
+        uint256 chainC = 8_000_004;
+        address[] memory sC = _encSetFor(chainC, 3);
+        sC[1] = sB[2]; // inject overlap with chainB
+
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, chainC, sC, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(chainC, sC, 2, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, sB[2]));
+        proxy.executeProposal(id, abi.encode(chainC, sC, 2));
+    }
+
+    /// @dev A partial rotation may keep some of the chain's own keys — the
+    ///      disjoint check self-excludes the chain being rotated.
+    function test_perSourceChain_partialRotationSelfExclusionAllowed() public {
+        address[] memory newRgb = new address[](2);
+        newRgb[0] = encA1; // keep an existing RGB signer
+        newRgb[1] = makeAddr('rgbFresh');
+        uint256 chainsBefore = proxy.getEnclaveSourceChains().length;
+        _govUpdateEnclave(RGB_CHAIN_ID, newRgb, 2);
+
+        address[] memory got = proxy.getEnclaveSigners(RGB_CHAIN_ID);
+        assertEq(got.length, 2);
+        assertEq(got[0], encA1, 'kept its own key via self-exclusion');
+        // Rotating an existing chain must not add a duplicate registry entry.
+        assertEq(proxy.getEnclaveSourceChains().length, chainsBefore, 'no duplicate source-chain entry on rotation');
+    }
+
+    /// @dev Registering more than MAX_ENCLAVE_SOURCE_CHAINS source chains is
+    ///      rejected at execute (bounds the cross-set disjoint loop).
+    function test_perSourceChain_maxEnclaveSourceChainsCap() public {
+        uint256 maxChains = proxy.MAX_ENCLAVE_SOURCE_CHAINS();
+        // RGB already occupies slot 1 — fill the rest.
+        for (uint256 k = 0; k < maxChains - 1; k++) {
+            uint256 chainId = 6_000_000 + k;
+            _govUpdateEnclave(chainId, _encSetFor(chainId, 2), 2);
+        }
+        assertEq(proxy.getEnclaveSourceChains().length, maxChains);
+
+        uint256 overflowChain = 6_999_999;
+        address[] memory s = _encSetFor(overflowChain, 2);
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, overflowChain, s, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(overflowChain, s, 2, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IMultisigProxy.TooManyEnclaveSourceChains.selector, maxChains + 1, maxChains
+        ));
+        proxy.executeProposal(id, abi.encode(overflowChain, s, 2));
+    }
+
+    // ---- positive per-source authorization --------------------------------
+
+    /// @dev A per-source set's OWN keys authorize a release for that chain, and
+    ///      the correct nonce lane advances. RGB is rotated to keys we control
+    ///      so the full release (reusing RGB's configured route/liquidity) runs.
+    function test_perSourceChain_ownKeysAuthorizeRelease() public {
+        (address[] memory encAddrs, uint256[] memory encPks) = _encFromPks(0xEEE0000, 3);
+        _govUpdateEnclave(RGB_CHAIN_ID, encAddrs, 2);
+
+        uint256 balBefore = token.balanceOf(recipient);
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, p, nonce, deadline);
+        uint256[] memory signPks = new uint256[](2);
+        signPks[0] = encPks[0]; signPks[1] = encPks[1];
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, signPks);
+
+        proxy.fundsOutCall(p, nonce, deadline, 0x3, sigs);
+
+        assertGt(token.balanceOf(recipient), balBefore, 'chain-owned keys authorized the release');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'RGB nonce advanced');
+    }
+
+    /// @dev The LZ branch selects the enclave set + nonce lane by source chain:
+    ///      an RGB LZ release advances only RGB's lane and emits sourceChainId.
+    function test_perSourceChain_lz_selectsPerSourceLane() public {
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));                          // fresh ts (first gov action)
+        _govUpdateEnclave(7_100_001, _encSetFor(7_100_001, 3), 2); // second registered chain
+
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        vm.expectEmit(true, true, false, false);
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, params.dstEid, params.recipient, AMOUNT);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
+
+        assertEq(token.balanceOf(mockOft), AMOUNT, 'LZ release forwarded to OFT');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'RGB LZ lane advanced');
+        assertEq(proxy.teeNonce(7_100_001), 0, 'other chain LZ lane untouched');
+    }
+
+    /// @dev lzFundsOutCall for an unregistered source chain reverts UnknownSourceChain.
+    function test_perSourceChain_lz_unregisteredSourceReverts() public {
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        params.sourceChainId = 424_242; // unregistered (checked before adapter/signatures)
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(424_242)));
+        proxy.lzFundsOutCall(params, 0, vm.getBlockTimestamp() + 1 hours, 0, new bytes[](0));
+    }
+
+    /// @dev An LZ release for chain B signed by RGB keys is rejected at the
+    ///      signer check (per-source selection), not downstream.
+    function test_perSourceChain_lz_signatureFromAnotherChainRejected() public {
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));
+        uint256 chainB = 7_200_001;
+        _govUpdateEnclave(chainB, _encSetFor(chainB, 3), 2);
+
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        params.sourceChainId = chainB;
+        uint256 nonce    = proxy.teeNonce(chainB); // 0
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3(); // RGB signers
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
+    }
+
+    // ---- governance binding / validation -----------------------------------
+
+    /// @dev The enclave-rotation proposal digest is bound to sourceChainId:
+    ///      a digest signed for RGB cannot authorize a rotation of chain B.
+    ///      Guards against regressing the sourceChainId out of the typehash.
+    function test_perSourceChain_proposeUpdateEnclaveDigestBoundToSourceChain() public {
+        uint256 chainB = 7_300_001;
+        address[] memory sB = _encSetFor(chainB, 2);
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        // Federation signs the digest for RGB_CHAIN_ID...
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, RGB_CHAIN_ID, sB, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        // ...but the proposal is submitted for chainB -> digest mismatch.
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.proposeUpdateEnclaveSigners(chainB, sB, 2, nonce, deadline, bitmap, sigs);
+    }
+
+    /// @dev sourceChainId == 0 is reserved (threshold 0 is the "unregistered"
+    ///      sentinel), so it is rejected at construction.
+    function test_perSourceChain_constructorRejectsZeroSourceChain() public {
+        address[] memory enc = _validEnc();
+        address[] memory fed = _validFed();
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(0)));
+        new MultisigProxy(address(bridge), address(cm), enc, 2, 0, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    /// @dev ...and rejected up front by proposeUpdateEnclaveSigners (before sigs).
+    function test_perSourceChain_proposeRejectsZeroSourceChain() public {
+        address[] memory sB = _encSetFor(1, 2);
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes[] memory noSigs = new bytes[](0);
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(0)));
+        proxy.proposeUpdateEnclaveSigners(0, sB, 2, nonce, deadline, 0, noSigs);
+    }
+
+    // ---- gas boundary ------------------------------------------------------
+
+    /// @dev Boundary/gas: fill the registry to MAX_ENCLAVE_SOURCE_CHAINS (32),
+    ///      each with the maximum MAX_SIGNERS (20) enclave signers, then confirm
+    ///      an enclave rotation and federation rotations (3/5/10 signers) still
+    ///      execute well under a conservative block gas limit — the cross-set
+    ///      disjoint loop is the worst case. Thresholds must be a strict majority
+    ///      (2*t > n), so 20-signer sets use t=11 (t=3 would be rejected as
+    ///      sub-majority); the disjoint-loop gas is independent of the threshold.
+    function test_perSourceChain_gas_updateSignersAtMaxChainsAndMaxSigners() public {
+        uint256 BLOCK_GAS_LIMIT = 30_000_000; // conservative; Arbitrum allows far more
+        uint256 nChains  = proxy.MAX_ENCLAVE_SOURCE_CHAINS(); // 32
+        uint256 nSigners = proxy.MAX_SIGNERS();               // 20
+        uint256 t20      = 11;                                 // strict majority of 20
+
+        // Rotate RGB to 20 signers, then register (nChains - 1) more 20-signer
+        // chains so all 32 chains carry the maximum set.
+        _govUpdateEnclave(RGB_CHAIN_ID, _encSetFor(RGB_CHAIN_ID, nSigners), t20);
+        for (uint256 k = 0; k < nChains - 1; k++) {
+            uint256 chainId = 5_000_000 + k;
+            _govUpdateEnclave(chainId, _encSetFor(chainId, nSigners), t20);
+        }
+        assertEq(proxy.getEnclaveSourceChains().length, nChains, 'registry filled to the cap');
+
+        // --- enclave rotation of an existing 20-signer chain: disjoint runs
+        //     over the other 31 sets (~20 * 31 * 20 comparisons) + federation.
+        {
+            uint256 rotChain = 5_000_000;
+            address[] memory fresh = _encSetFor(9_999_999, nSigners); // disjoint namespace
+            uint256 nonce    = proxy.proposalNonce();
+            uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+            bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, rotChain, fresh, t20, nonce, deadline);
+            (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+            bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+            bytes32 id = proxy.proposeUpdateEnclaveSigners(rotChain, fresh, t20, nonce, deadline, bitmap, sigs);
+            vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+            uint256 g0 = gasleft();
+            proxy.executeProposal(id, abi.encode(rotChain, fresh, t20));
+            uint256 gEnc = g0 - gasleft();
+            emit log_named_uint('gas: updateEnclaveSigners @32chains x20 (rotate)', gEnc);
+            assertLt(gEnc, BLOCK_GAS_LIMIT, 'enclave rotation exceeds block gas limit');
+        }
+
+        // --- federation rotations for sizes 3, 5, 10: disjoint runs over all
+        //     32 enclave sets. Each rotation is signed by the current federation,
+        //     so we thread the pks forward.
+        (uint256[] memory origPks, uint256 origBitmap) = _fedSigSet2of3();
+
+        (address[] memory f3, uint256[] memory p3) = _fedFromPks(0xFED30000, 3);
+        uint256 g3 = _rotateFedMeasured(f3, 2, origPks, origBitmap);
+        emit log_named_uint('gas: updateFederationSigners size=3 @32x20', g3);
+        assertLt(g3, BLOCK_GAS_LIMIT, 'fed(3) rotation exceeds block gas limit');
+
+        (address[] memory f5, uint256[] memory p5) = _fedFromPks(0xFED50000, 5);
+        uint256 g5 = _rotateFedMeasured(f5, 3, _slice(p3, 2), _bitmapFor(2)); // signed by f3 (t=2)
+        emit log_named_uint('gas: updateFederationSigners size=5 @32x20', g5);
+        assertLt(g5, BLOCK_GAS_LIMIT, 'fed(5) rotation exceeds block gas limit');
+
+        (address[] memory f10, ) = _fedFromPks(0xFED100000, 10);
+        uint256 g10 = _rotateFedMeasured(f10, 6, _slice(p5, 3), _bitmapFor(3)); // signed by f5 (t=3)
+        emit log_named_uint('gas: updateFederationSigners size=10 @32x20', g10);
+        assertLt(g10, BLOCK_GAS_LIMIT, 'fed(10) rotation exceeds block gas limit');
     }
 }

--- a/ethereum/test/RGBVerifier.t.sol
+++ b/ethereum/test/RGBVerifier.t.sol
@@ -19,14 +19,25 @@ contract RGBVerifierTest is Test {
     uint256 constant AMOUNT = 100e18;
     uint256 constant BURN_ID = 9_001;
 
-    uint256 constant LOW_CONFIRMATION_HEIGHT = 850_000;
-    bytes32 constant LOW_CONFIRMATION_COMMITMENT = keccak256('low-confirmation-block');
-    uint256 constant HIGH_CONFIRMATION_HEIGHT = 860_000;
-    bytes32 constant HIGH_CONFIRMATION_COMMITMENT = keccak256('high-confirmation-block');
+    // Default verifier thresholds (audit R-W-06 production values).
+    uint256 constant MIN_SOURCE_CONF = 6;
+    uint256 constant MAX_LATEST_CONF = 1;
+    uint256 constant MIN_GAP         = 5;
+
+    // Source block (RGB burn/lock): buried deep. Latest block: fresh, at the
+    // relay head. gap = 6 - 1 = 5 (== MIN_GAP), so the default proof is valid.
+    uint256 constant SOURCE_HEIGHT = 850_000;
+    bytes32 constant SOURCE_COMMIT = keccak256('rgb-source-block');
+    uint256 constant SOURCE_CONF   = 6;
+    uint256 constant LATEST_HEIGHT = 850_005;
+    bytes32 constant LATEST_COMMIT = keccak256('rgb-latest-block');
+    uint256 constant LATEST_CONF   = 1;
 
     function setUp() public {
         btcRelay = new MockBtcRelay();
-        verifier = new RGBVerifier(address(btcRelay));
+        btcRelay.setBlock(SOURCE_HEIGHT, SOURCE_COMMIT, SOURCE_CONF);
+        btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONF);
+        verifier = new RGBVerifier(address(btcRelay), MIN_SOURCE_CONF, MAX_LATEST_CONF, MIN_GAP);
     }
 
     function _ctx() internal view returns (FundsOutContext memory) {
@@ -41,21 +52,106 @@ contract RGBVerifierTest is Test {
         });
     }
 
-    function _proof(uint256 blockHeight, bytes32 commitmentHash) internal pure returns (bytes memory) {
-        return abi.encode(blockHeight, commitmentHash);
+    function _proof(uint256 sourceHeight, bytes32 sourceCommit, uint256 latestHeight, bytes32 latestCommit)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(sourceHeight, sourceCommit, latestHeight, latestCommit);
     }
 
     // =========================================================================
-    // Current behavior reproduction
+    // Constructor
     // =========================================================================
 
-    function test_confirmationsReturnedByRelayAreIgnored_currentBehavior() public {
-        btcRelay.setBlock(LOW_CONFIRMATION_HEIGHT, LOW_CONFIRMATION_COMMITMENT, 1);
-        btcRelay.setBlock(HIGH_CONFIRMATION_HEIGHT, HIGH_CONFIRMATION_COMMITMENT, 100);
+    function test_constructor_storesImmutables() public view {
+        assertEq(verifier.btcRelay(), address(btcRelay));
+        assertEq(verifier.minSourceConfirmations(), MIN_SOURCE_CONF);
+        assertEq(verifier.maxLatestConfirmations(), MAX_LATEST_CONF);
+        assertEq(verifier.minConfirmationGap(), MIN_GAP);
+    }
 
-        // Current behavior: RGBVerifier only requires the relay call to succeed;
-        // it does not enforce a minimum confirmation count from the returned value.
-        verifier.verify(_ctx(), _proof(LOW_CONFIRMATION_HEIGHT, LOW_CONFIRMATION_COMMITMENT));
-        verifier.verify(_ctx(), _proof(HIGH_CONFIRMATION_HEIGHT, HIGH_CONFIRMATION_COMMITMENT));
+    function test_constructor_revertsOnZeroRelay() public {
+        vm.expectRevert(RGBVerifier.InvalidBtcRelayAddress.selector);
+        new RGBVerifier(address(0), MIN_SOURCE_CONF, MAX_LATEST_CONF, MIN_GAP);
+    }
+
+    function test_constructor_revertsOnZeroMaxLatest() public {
+        // maxLatestConfirmations == 0 could never accept a proof (a known block
+        // always has >= 1 confirmation), so the constructor rejects it.
+        vm.expectRevert(RGBVerifier.InvalidThresholds.selector);
+        new RGBVerifier(address(btcRelay), MIN_SOURCE_CONF, 0, MIN_GAP);
+    }
+
+    // =========================================================================
+    // verify — happy path
+    // =========================================================================
+
+    function test_verify_acceptsDeepSourceWithFreshLatest() public view {
+        // Does not revert.
+        verifier.verify(_ctx(), _proof(SOURCE_HEIGHT, SOURCE_COMMIT, LATEST_HEIGHT, LATEST_COMMIT));
+    }
+
+    // =========================================================================
+    // verify — confirmation-depth invariants (the R-W-06 fix)
+    // =========================================================================
+
+    function test_verify_revertsWhenSourceTooShallow() public {
+        // A source block only 5 deep is below the 6-confirmation floor.
+        uint256 shallowHeight = 851_000;
+        bytes32 shallowCommit = keccak256('shallow-source');
+        btcRelay.setBlock(shallowHeight, shallowCommit, 5);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(RGBVerifier.InsufficientSourceConfirmations.selector, 5, MIN_SOURCE_CONF)
+        );
+        verifier.verify(_ctx(), _proof(shallowHeight, shallowCommit, LATEST_HEIGHT, LATEST_COMMIT));
+    }
+
+    function test_verify_revertsWhenLatestNotFresh() public {
+        // A "latest" block 2 deep means the relay head has moved on — stale.
+        uint256 staleHeight = 850_004;
+        bytes32 staleCommit = keccak256('stale-latest');
+        btcRelay.setBlock(staleHeight, staleCommit, 2);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(RGBVerifier.RelayNotFresh.selector, 2, MAX_LATEST_CONF)
+        );
+        verifier.verify(_ctx(), _proof(SOURCE_HEIGHT, SOURCE_COMMIT, staleHeight, staleCommit));
+    }
+
+    function test_verify_revertsWhenGapTooSmall() public {
+        // Thresholds chosen so source and latest each pass their own bound, but
+        // the source is not buried MIN_GAP beneath the fresh latest:
+        //   min source = 2, max latest = 10, gap = 5.
+        RGBVerifier gapVerifier = new RGBVerifier(address(btcRelay), 2, 10, 5);
+
+        uint256 srcHeight = 852_000;
+        bytes32 srcCommit = keccak256('gap-source');
+        uint256 latHeight = 852_002;
+        bytes32 latCommit = keccak256('gap-latest');
+        btcRelay.setBlock(srcHeight, srcCommit, 6); // >= 2, <= no upper bound
+        btcRelay.setBlock(latHeight, latCommit, 4); // <= 10 (fresh)
+        // gap: 6 < 4 + 5 == 9 -> revert.
+
+        vm.expectRevert(
+            abi.encodeWithSelector(RGBVerifier.InsufficientConfirmationGap.selector, 6, 4, 5)
+        );
+        gapVerifier.verify(_ctx(), _proof(srcHeight, srcCommit, latHeight, latCommit));
+    }
+
+    // =========================================================================
+    // verify — relay-level failures propagate
+    // =========================================================================
+
+    function test_verify_revertsOnUnknownSourceBlock() public {
+        // Unconfigured source height -> the relay itself reverts.
+        vm.expectRevert(bytes('verify: block commitment'));
+        verifier.verify(_ctx(), _proof(999_999, keccak256('unknown-source'), LATEST_HEIGHT, LATEST_COMMIT));
+    }
+
+    function test_verify_revertsOnUnknownLatestBlock() public {
+        vm.expectRevert(bytes('verify: block commitment'));
+        verifier.verify(_ctx(), _proof(SOURCE_HEIGHT, SOURCE_COMMIT, 999_999, keccak256('unknown-latest')));
     }
 }

--- a/ethereum/test/RgbSettlementModule.t.sol
+++ b/ethereum/test/RgbSettlementModule.t.sol
@@ -28,12 +28,15 @@ contract RgbSettlementModuleTest is Test {
     uint256 constant SOURCE_CHAIN_ID = 1_000_001;  // RGB
     uint256 constant DEST_CHAIN_ID   = 42161;      // arbitrum
 
-    uint256 constant TX_ID_1 = 100;
-    uint256 constant TX_ID_2 = 101;
-    uint256 constant TX_ID_3 = 102;
+    bytes32 constant TX_ID_1 = bytes32(uint256(100));
+    bytes32 constant TX_ID_2 = bytes32(uint256(101));
+    bytes32 constant TX_ID_3 = bytes32(uint256(102));
 
     uint256 constant AMOUNT      = 100e18;
     uint256 constant BURN_ID     = 9_001;
+
+    /// @dev Non-zero RGB OpId threaded through `onFundsIn`'s settlementData.
+    uint256 constant RGB_OP_ID = 0xABCDEF;
 
     function setUp() public {
         module = new RgbSettlementModule(routeRegistry);
@@ -43,7 +46,7 @@ contract RgbSettlementModuleTest is Test {
     // Helpers
     // ========================================================================
 
-    function _fundsInCtx(uint256 operationId, uint256 netAmount)
+    function _fundsInCtx(bytes32 operationId, uint256 netAmount)
         internal
         view
         returns (FundsInContext memory)
@@ -51,9 +54,11 @@ contract RgbSettlementModuleTest is Test {
         return FundsInContext({
             token:         token,
             sender:        user,
+            sourceSender:  bytes32(uint256(uint160(user))),
             grossAmount:   netAmount,           // gross == net for these tests
             netAmount:     netAmount,
             operationId:   operationId,
+            senderNonce:   0,
             sourceChainId: SOURCE_CHAIN_ID,
             destChainId:   DEST_CHAIN_ID,
             destAddress:   'rgb:asset/utxo1abc'
@@ -75,8 +80,9 @@ contract RgbSettlementModuleTest is Test {
         });
     }
 
-    /// @dev Encodes the two parallel arrays the reworked module expects.
-    function _settlementData(uint256[] memory ids, uint256[] memory amounts)
+    /// @dev Encodes the two parallel arrays the reworked module expects
+    ///      (`(bytes32[] operationIds, uint256[] amounts)`).
+    function _settlementData(bytes32[] memory ids, uint256[] memory amounts)
         internal
         pure
         returns (bytes memory)
@@ -84,20 +90,32 @@ contract RgbSettlementModuleTest is Test {
         return abi.encode(ids, amounts);
     }
 
-    function _single(uint256 value) internal pure returns (uint256[] memory arr) {
+    function _single(bytes32 value) internal pure returns (bytes32[] memory arr) {
+        arr = new bytes32[](1);
+        arr[0] = value;
+    }
+
+    function _amt(uint256 value) internal pure returns (uint256[] memory arr) {
         arr = new uint256[](1);
         arr[0] = value;
     }
 
-    function _pair(uint256 a, uint256 b) internal pure returns (uint256[] memory arr) {
+    function _pair(bytes32 a, bytes32 b) internal pure returns (bytes32[] memory arr) {
+        arr = new bytes32[](2);
+        arr[0] = a;
+        arr[1] = b;
+    }
+
+    function _amtPair(uint256 a, uint256 b) internal pure returns (uint256[] memory arr) {
         arr = new uint256[](2);
         arr[0] = a;
         arr[1] = b;
     }
 
-    function _record(uint256 operationId, uint256 netAmount) internal {
+    /// @dev `onFundsIn` settlementData must decode to a non-zero RGB OpId.
+    function _record(bytes32 operationId, uint256 netAmount) internal {
         vm.prank(routeRegistry);
-        module.onFundsIn(_fundsInCtx(operationId, netAmount), '');
+        module.onFundsIn(_fundsInCtx(operationId, netAmount), abi.encode(RGB_OP_ID));
     }
 
     // ========================================================================
@@ -122,18 +140,30 @@ contract RgbSettlementModuleTest is Test {
         assertEq(module.fundsInRecords(TX_ID_1), AMOUNT);
     }
 
+    function test_onFundsIn_returnsRgbOpId() public {
+        vm.prank(routeRegistry);
+        uint256 returned = module.onFundsIn(_fundsInCtx(TX_ID_1, AMOUNT), abi.encode(RGB_OP_ID));
+        assertEq(returned, RGB_OP_ID, 'returns decoded rgb op id');
+    }
+
+    function test_onFundsIn_revertsOnZeroRgbOpId() public {
+        vm.prank(routeRegistry);
+        vm.expectRevert(RgbSettlementModule.InvalidRgbOpId.selector);
+        module.onFundsIn(_fundsInCtx(TX_ID_1, AMOUNT), abi.encode(uint256(0)));
+    }
+
     function test_onFundsIn_revertsOnDuplicateOperationId() public {
         _record(TX_ID_1, AMOUNT);
 
         vm.prank(routeRegistry);
         vm.expectRevert(RgbSettlementModule.DuplicateOperationId.selector);
-        module.onFundsIn(_fundsInCtx(TX_ID_1, AMOUNT), '');
+        module.onFundsIn(_fundsInCtx(TX_ID_1, AMOUNT), abi.encode(RGB_OP_ID));
     }
 
     function test_onFundsIn_revertsIfNotRouteRegistry() public {
         vm.prank(attacker);
         vm.expectRevert(RgbSettlementModule.NotRouteRegistry.selector);
-        module.onFundsIn(_fundsInCtx(TX_ID_1, AMOUNT), '');
+        module.onFundsIn(_fundsInCtx(TX_ID_1, AMOUNT), abi.encode(RGB_OP_ID));
     }
 
     // ========================================================================
@@ -144,7 +174,7 @@ contract RgbSettlementModuleTest is Test {
         _record(TX_ID_1, AMOUNT);
 
         vm.prank(routeRegistry);
-        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT)));
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _amt(AMOUNT)));
 
         // Proof-of-mint ledger is permanent: the check must not mutate it.
         assertEq(module.fundsInRecords(TX_ID_1), AMOUNT, 'record left intact (no consumption)');
@@ -159,7 +189,7 @@ contract RgbSettlementModuleTest is Test {
         vm.prank(routeRegistry);
         module.beforeFundsOut(
             _fundsOutCtx(),
-            _settlementData(_pair(TX_ID_1, TX_ID_2), _pair(amount1, amount2))
+            _settlementData(_pair(TX_ID_1, TX_ID_2), _amtPair(amount1, amount2))
         );
 
         assertEq(module.fundsInRecords(TX_ID_1), amount1, 'record 1 intact');
@@ -171,7 +201,7 @@ contract RgbSettlementModuleTest is Test {
         vm.prank(routeRegistry);
         module.beforeFundsOut(
             _fundsOutCtx(),
-            _settlementData(new uint256[](0), new uint256[](0))
+            _settlementData(new bytes32[](0), new uint256[](0))
         );
     }
 
@@ -184,7 +214,7 @@ contract RgbSettlementModuleTest is Test {
         vm.prank(routeRegistry);
         module.beforeFundsOut(
             _fundsOutCtx(),
-            _settlementData(_pair(TX_ID_1, TX_ID_1), _pair(AMOUNT, AMOUNT))
+            _settlementData(_pair(TX_ID_1, TX_ID_1), _amtPair(AMOUNT, AMOUNT))
         );
 
         assertEq(module.fundsInRecords(TX_ID_1), AMOUNT, 'record intact');
@@ -196,7 +226,7 @@ contract RgbSettlementModuleTest is Test {
 
         for (uint256 i = 0; i < 3; i++) {
             vm.prank(routeRegistry);
-            module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT)));
+            module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _amt(AMOUNT)));
         }
 
         assertEq(module.fundsInRecords(TX_ID_1), AMOUNT, 'record never consumed');
@@ -212,7 +242,7 @@ contract RgbSettlementModuleTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, TX_ID_1)
         );
-        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT)));
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _amt(AMOUNT)));
     }
 
     function test_beforeFundsOut_revertsWhenAmountAboveRecord() public {
@@ -224,7 +254,7 @@ contract RgbSettlementModuleTest is Test {
                 RgbSettlementModule.AmountMismatch.selector, TX_ID_1, AMOUNT + 1, AMOUNT
             )
         );
-        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT + 1)));
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _amt(AMOUNT + 1)));
     }
 
     function test_beforeFundsOut_revertsWhenAmountBelowRecord() public {
@@ -238,7 +268,7 @@ contract RgbSettlementModuleTest is Test {
                 RgbSettlementModule.AmountMismatch.selector, TX_ID_1, AMOUNT - 1, AMOUNT
             )
         );
-        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT - 1)));
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _amt(AMOUNT - 1)));
     }
 
     function test_beforeFundsOut_revertsOnLengthMismatch() public {
@@ -249,7 +279,7 @@ contract RgbSettlementModuleTest is Test {
         vm.expectRevert(RgbSettlementModule.SettlementDataLengthMismatch.selector);
         module.beforeFundsOut(
             _fundsOutCtx(),
-            _settlementData(_pair(TX_ID_1, TX_ID_2), _single(AMOUNT))
+            _settlementData(_pair(TX_ID_1, TX_ID_2), _amt(AMOUNT))
         );
     }
 
@@ -266,7 +296,7 @@ contract RgbSettlementModuleTest is Test {
         );
         module.beforeFundsOut(
             _fundsOutCtx(),
-            _settlementData(_pair(TX_ID_1, TX_ID_2), _pair(AMOUNT, AMOUNT + 5))
+            _settlementData(_pair(TX_ID_1, TX_ID_2), _amtPair(AMOUNT, AMOUNT + 5))
         );
     }
 
@@ -275,7 +305,7 @@ contract RgbSettlementModuleTest is Test {
 
         vm.prank(attacker);
         vm.expectRevert(RgbSettlementModule.NotRouteRegistry.selector);
-        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(AMOUNT)));
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _amt(AMOUNT)));
     }
 
     // ========================================================================
@@ -291,7 +321,7 @@ contract RgbSettlementModuleTest is Test {
 
         if (provided == recorded) {
             vm.prank(routeRegistry);
-            module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(provided)));
+            module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _amt(provided)));
         } else {
             vm.prank(routeRegistry);
             vm.expectRevert(
@@ -299,7 +329,7 @@ contract RgbSettlementModuleTest is Test {
                     RgbSettlementModule.AmountMismatch.selector, TX_ID_1, provided, recorded
                 )
             );
-            module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _single(provided)));
+            module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _amt(provided)));
         }
 
         assertEq(module.fundsInRecords(TX_ID_1), recorded, 'record never mutated');

--- a/ethereum/test/RouteRegistry.t.sol
+++ b/ethereum/test/RouteRegistry.t.sol
@@ -69,9 +69,11 @@ contract RouteRegistryTest is Test {
         return FundsInContext({
             token:         token,
             sender:        user,
+            sourceSender:  bytes32(uint256(uint160(user))),
             grossAmount:   100e18,
             netAmount:     95e18,
-            operationId:   42,
+            operationId:   bytes32(uint256(42)),
+            senderNonce:   0,
             sourceChainId: SOURCE_CHAIN_ID,
             destChainId:   DEST_CHAIN_ID,
             destAddress:   'rgb:asset/utxo1abc'
@@ -208,7 +210,7 @@ contract RouteRegistryTest is Test {
 
         assertEq(module.onFundsInCount(),     1, 'module called once');
         assertEq(module.lastSender(),         user);
-        assertEq(module.lastOperationId(),    42);
+        assertEq(module.lastOperationId(),    bytes32(uint256(42)));
         assertEq(module.lastNetAmount(),      95e18);
         assertEq(module.lastSettlementData(), abi.encode('hello'));
     }

--- a/ethereum/test/mocks/FeeOnTransferERC20.sol
+++ b/ethereum/test/mocks/FeeOnTransferERC20.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import { ERC20 } from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+
+/// @title FeeOnTransferERC20
+/// @notice Mintable ERC-20 that charges a fee (in basis points) on every
+///         movement between two non-zero addresses — i.e. both `transfer` and
+///         `transferFrom`. The recipient receives `amount - fee`; the `fee`
+///         is burned (total supply drops), so the recipient's balance delta is
+///         `amount - fee`.
+/// @dev    Mint (`from == address(0)`) and burn (`to == address(0)`) are NOT
+///         taxed, so `mint(addr, x)` credits exactly `x`. OZ v5 routes every
+///         balance change through `_update`, so overriding it taxes transfer and
+///         transferFrom uniformly.
+contract FeeOnTransferERC20 is ERC20 {
+    /// @notice Fee charged on transfers, in basis points (1% == 100 bps).
+    uint256 public feeBps;
+
+    uint256 private constant _BPS_DENOMINATOR = 10_000;
+
+    constructor(string memory name_, string memory symbol_, uint256 feeBps_)
+        ERC20(name_, symbol_)
+    {
+        feeBps = feeBps_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    /// @notice Fee that would be charged on a movement of `amount`.
+    function feeOn(uint256 amount) public view returns (uint256) {
+        return (amount * feeBps) / _BPS_DENOMINATOR;
+    }
+
+    /// @dev Tax only movements between two non-zero addresses (transfer /
+    ///      transferFrom). The fee is burned: credit the recipient
+    ///      `amount - fee` and remove `fee` from total supply.
+    function _update(address from, address to, uint256 value) internal override {
+        if (from != address(0) && to != address(0) && feeBps != 0) {
+            uint256 fee = feeOn(value);
+            if (fee != 0) {
+                // Debit `from` fully, credit `to` net, burn the fee.
+                super._update(from, to, value - fee);
+                super._update(from, address(0), fee);
+                return;
+            }
+        }
+        super._update(from, to, value);
+    }
+}

--- a/ethereum/test/mocks/MockSettlementModule.sol
+++ b/ethereum/test/mocks/MockSettlementModule.sol
@@ -22,9 +22,13 @@ contract MockSettlementModule is ISettlementModule {
     uint256 public onFundsInCount;
     uint256 public beforeFundsOutCount;
 
+    /// @notice Correlation id returned from `onFundsIn` (mirrors the RGB OpId a
+    ///         real settlement module would surface). Defaults to 0.
+    uint256 public externalIdToReturn;
+
     // Last-call recordings — kept minimal; we don't need every field.
     address public lastSender;
-    uint256 public lastOperationId;
+    bytes32 public lastOperationId;
     uint256 public lastNetAmount;
     address public lastRecipient;
     uint256 public lastAmount;
@@ -48,10 +52,15 @@ contract MockSettlementModule is ISettlementModule {
         balanceProbeTarget = target;
     }
 
+    function setExternalIdToReturn(uint256 v) external {
+        externalIdToReturn = v;
+    }
+
     /// @inheritdoc ISettlementModule
     function onFundsIn(FundsInContext calldata ctx, bytes calldata settlementData)
         external
         override
+        returns (uint256)
     {
         if (shouldRevertOnFundsIn) revert MockModuleForcedRevert();
         onFundsInCount     += 1;
@@ -62,6 +71,7 @@ contract MockSettlementModule is ISettlementModule {
         if (balanceProbeToken != address(0)) {
             lastObservedBalanceOnFundsIn = IERC20(balanceProbeToken).balanceOf(balanceProbeTarget);
         }
+        return externalIdToReturn;
     }
 
     /// @inheritdoc ISettlementModule

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -42,7 +42,7 @@ library MultisigHelper {
     );
 
     bytes32 internal constant PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH = keccak256(
-        'ProposeUpdateEnclaveSigners(address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
+        'ProposeUpdateEnclaveSigners(uint256 sourceChainId,address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
     );
 
     bytes32 internal constant PROPOSE_UPDATE_FEDERATION_SIGNERS_TYPEHASH = keccak256(
@@ -220,6 +220,7 @@ library MultisigHelper {
 
     function digestProposeUpdateEnclaveSigners(
         bytes32 domainSep,
+        uint256 sourceChainId,
         address[] memory newSigners,
         uint256 newThreshold,
         uint256 nonce,
@@ -227,7 +228,7 @@ library MultisigHelper {
     ) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(
             PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH,
-            hashAddressArray(newSigners), newThreshold, nonce, deadline
+            sourceChainId, hashAddressArray(newSigners), newThreshold, nonce, deadline
         )));
     }
 


### PR DESCRIPTION
### Summary
Test coverage for the R-W-06 RGBVerifier fix.
RGBVerifier now decodes a two-pair proof — a deep source block (RGB
burn/lock) and a fresh latest block — and enforces three deploy-time
depth thresholds. This updates the suite accordingly:
- Dedicated RGBVerifier unit tests for constructor validation, the happy
  path, each of the three depth checks, and relay-level reverts.
- Bridge / MultisigProxy / Integration setUps configure both blocks and
  build two-pair proofs.