### PR TITLE
test(R-M-01): cover derived burnId validation

### DIFF
--- a/ethereum/.env.deploy.example
+++ b/ethereum/.env.deploy.example
@@ -68,6 +68,25 @@ ETH_USD_FEED=
 # 87000 leaves ~10 min slack).
 ETH_USD_HEARTBEAT=87000
 
+# --- Arbitrum Chainlink robustness (optional) ---
+
+# Chainlink L2 Sequencer Uptime feed. When set, NATIVE quotes are rejected while
+# the sequencer is down and for the 3600 s grace period after a restart. Set on
+# Arbitrum whenever NATIVE commission is used; leave blank on non-L2 / tests.
+#   Arbitrum One  Sequencer Uptime  0xFdB631F5EE196F0ed6FAa767959853A9F217697D
+SEQUENCER_UPTIME_FEED=
+
+# Optional ETH/USD sanity band (circuit breaker), in the feed's decimals
+# (ETH/USD = 8). Set BOTH or NEITHER (else the deploy reverts); 0 < min < max.
+# Example for an 8-decimal feed: $100 = 10000000000, $100k = 10000000000000.
+ETH_USD_MIN_PRICE=
+ETH_USD_MAX_PRICE=
+
+# When true, the deploy reverts unless ETH_USD_FEED, SEQUENCER_UPTIME_FEED, and
+# the price band are ALL set. Recommend =true for Arbitrum production so the
+# R-I-14 guards can never be silently absent; leave false for non-L2 / tests.
+REQUIRE_CHAINLINK_HARDENING=false
+
 # -----------------------------------------------------------------------------
 # MultisigProxy
 # -----------------------------------------------------------------------------

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -24,10 +24,13 @@ import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.so
 ///   n + 3  → RGBVerifier        (wraps the BtcRelay)
 ///   n + 4  → RgbSettlementModule (paired with RouteRegistry)
 ///   n + 5  → MultisigProxy
-///   n + 6  → (optional) CommissionManager.setEthUsdFeed
-///   n + 7  → CommissionManager.transferOwnership (starts two-step handoff)
-///   n + 8  → Bridge.transferOwnership (starts two-step handoff)
-///   n + 9  → RouteRegistry.transferOwnership (starts two-step handoff)
+///          → (optional) CommissionManager config txs, each present only when
+///            its env is set: setEthUsdFeed, setSequencerUptimeFeed,
+///            setEthUsdPriceBounds. These shift the transferOwnership nonces
+///            below by however many are emitted (0–3).
+///          → CommissionManager.transferOwnership (starts two-step handoff)
+///          → Bridge.transferOwnership (starts two-step handoff)
+///          → RouteRegistry.transferOwnership (starts two-step handoff)
 ///
 /// Ownership is Ownable2Step: the transferOwnership calls only set
 /// pendingOwner = MultisigProxy. The federation MUST accept post-deploy via
@@ -40,7 +43,7 @@ import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.so
 ///
 /// Env (required):
 ///   PRIVATE_KEY, USDT0_ADDRESS, BTC_RELAY_ADDRESS,
-///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD,
+///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD, INITIAL_ENCLAVE_SOURCE_CHAIN_ID,
 ///   FEDERATION_SIGNERS, FEDERATION_THRESHOLD,
 ///   COMMISSION_RECIPIENT, TIMELOCK_DURATION, MIN_TIMELOCK,
 ///   MIN_FUNDS_IN_AMOUNT
@@ -57,6 +60,17 @@ import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.so
 ///                       (freshness) block; must be >= 1.
 ///   MIN_CONFIRMATION_GAP     (5) — RGBVerifier: min depth gap between the
 ///                       source and latest blocks.
+///   SEQUENCER_UPTIME_FEED — (Arbitrum, R-I-14) Chainlink L2 Sequencer Uptime
+///                       feed. When set, NATIVE quotes reject prices during
+///                       sequencer downtime and the post-restart grace period.
+///                       SHOULD be set on Arbitrum when NATIVE commission is used.
+///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — (R-I-14) optional ETH/USD sanity
+///                       band in feed decimals (e.g. 100e8 / 100000e8). Set both
+///                       or neither; else 0 < min < max.
+///   REQUIRE_CHAINLINK_HARDENING (false) — when true, the deploy reverts unless
+///                       ETH_USD_FEED, SEQUENCER_UPTIME_FEED, and the price band
+///                       are all set. Recommended for Arbitrum production so the
+///                       R-I-14 guards can never be silently absent.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployAll.s.sol \
@@ -79,6 +93,7 @@ contract DeployAll is Script {
         address btcRelay       = vm.envAddress('BTC_RELAY_ADDRESS');
         address[] memory enc   = vm.envAddress('ENCLAVE_SIGNERS', ',');
         uint256 encThr         = vm.envUint('ENCLAVE_THRESHOLD');
+        uint256 initialSrcChain = vm.envUint('INITIAL_ENCLAVE_SOURCE_CHAIN_ID');
         address[] memory fed   = vm.envAddress('FEDERATION_SIGNERS', ',');
         uint256 fedThr         = vm.envUint('FEDERATION_THRESHOLD');
         address commission     = vm.envAddress('COMMISSION_RECIPIENT');
@@ -90,6 +105,24 @@ contract DeployAll is Script {
         uint256 minSourceConf  = vm.envOr('MIN_SOURCE_CONFIRMATIONS', uint256(6));
         uint256 maxLatestConf  = vm.envOr('MAX_LATEST_CONFIRMATIONS', uint256(1));
         uint256 minConfGap     = vm.envOr('MIN_CONFIRMATION_GAP',     uint256(5));
+        address seqFeed        = vm.envOr('SEQUENCER_UPTIME_FEED', address(0));
+        uint256 ethUsdMinPrice = vm.envOr('ETH_USD_MIN_PRICE', uint256(0));
+        uint256 ethUsdMaxPrice = vm.envOr('ETH_USD_MAX_PRICE', uint256(0));
+        bool    reqHardening   = vm.envOr('REQUIRE_CHAINLINK_HARDENING', false);
+
+        // ---- 1a. Misconfiguration checks (fail-fast, before any broadcast) ---
+        // Price band is all-or-nothing: a half-set band would otherwise be
+        // silently ignored (setter only runs when max != 0).
+        require((ethUsdMinPrice == 0) == (ethUsdMaxPrice == 0),
+            'set both ETH_USD_MIN_PRICE and ETH_USD_MAX_PRICE, or neither');
+        // Opt-in prod guard (set REQUIRE_CHAINLINK_HARDENING=true for Arbitrum):
+        // when NATIVE commission is enabled, the sequencer feed and price band
+        // must be wired too, so the R-I-14 protections are not silently absent.
+        if (reqHardening) {
+            require(ethUsdFeed != address(0), 'hardening: ETH_USD_FEED must be set');
+            require(seqFeed != address(0),    'hardening: SEQUENCER_UPTIME_FEED must be set');
+            require(ethUsdMaxPrice != 0,      'hardening: ETH_USD_MIN/MAX_PRICE must be set');
+        }
 
         address deployer    = vm.addr(pk);
         uint64  startNonce  = vm.getNonce(deployer);
@@ -124,7 +157,7 @@ contract DeployAll is Script {
         proxy = new MultisigProxy(
             address(bridge),
             address(cm),
-            enc, encThr,
+            enc, encThr, initialSrcChain,
             fed, fedThr,
             commission,
             timelock,
@@ -135,6 +168,17 @@ contract DeployAll is Script {
         if (ethUsdFeed != address(0)) {
             require(ethUsdHb != 0, 'ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided');
             cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
+        }
+
+        // ---- 7b. Wire optional R-I-14 Arbitrum hardening (owner-only, before
+        //          the ownership transfer): the L2 sequencer-uptime feed and the
+        //          ETH/USD sanity band. On Arbitrum these SHOULD be set whenever
+        //          the NATIVE commission path (ETH_USD_FEED) is used.
+        if (seqFeed != address(0)) {
+            cm.setSequencerUptimeFeed(seqFeed);
+        }
+        if (ethUsdMaxPrice != 0) {
+            cm.setEthUsdPriceBounds(ethUsdMinPrice, ethUsdMaxPrice);
         }
 
         // ---- 8. Start two-step ownership handover to federation ----------
@@ -164,6 +208,15 @@ contract DeployAll is Script {
         } else {
             console2.log('ETH/USD feed:                   ', 'UNSET (NATIVE quotes will revert until governance wires one)');
         }
+        if (seqFeed != address(0)) {
+            console2.log('Sequencer uptime feed wired:    ', seqFeed);
+        } else {
+            console2.log('Sequencer uptime feed:          ', 'UNSET (set on Arbitrum when NATIVE commission is used)');
+        }
+        if (ethUsdMaxPrice != 0) {
+            console2.log('ETH/USD price band min:         ', ethUsdMinPrice);
+            console2.log('ETH/USD price band max:         ', ethUsdMaxPrice);
+        }
 
         // ---- 10. Invariant checks ---------------------------------------
         require(address(bridge) == predictedBridge,         'Bridge address prediction mismatch');
@@ -182,6 +235,13 @@ contract DeployAll is Script {
         if (ethUsdFeed != address(0)) {
             require(cm.ethUsdFeed() == ethUsdFeed,          'CM.ethUsdFeed mismatch');
             require(cm.ethUsdHeartbeat() == ethUsdHb,       'CM.ethUsdHeartbeat mismatch');
+        }
+        if (seqFeed != address(0)) {
+            require(cm.sequencerUptimeFeed() == seqFeed,    'CM.sequencerUptimeFeed mismatch');
+        }
+        if (ethUsdMaxPrice != 0) {
+            require(cm.ethUsdMinPrice() == ethUsdMinPrice && cm.ethUsdMaxPrice() == ethUsdMaxPrice,
+                'CM.ethUsdPriceBounds mismatch');
         }
 
         // ---- 11. Post-deploy reminder -----------------------------------

--- a/ethereum/script/deploy/DeployCommissionManager.s.sol
+++ b/ethereum/script/deploy/DeployCommissionManager.s.sol
@@ -21,6 +21,14 @@ import { CommissionManager } from '../../src/CommissionManager.sol';
 ///                       the feed answer is considered stale. Arbitrum One
 ///                       ETH/USD heartbeats at 86400 s — use ~87000 with a
 ///                       small buffer.
+///   SEQUENCER_UPTIME_FEED — Optional (Arbitrum, R-I-14) Chainlink L2 Sequencer
+///                       Uptime feed. When set, NATIVE quotes reject prices
+///                       during sequencer downtime + the post-restart grace.
+///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — Optional (R-I-14) ETH/USD sanity
+///                       band in feed decimals; set both or neither.
+///   REQUIRE_CHAINLINK_HARDENING (false) — when true, revert unless ETH_USD_FEED,
+///                       SEQUENCER_UPTIME_FEED, and the price band are all set
+///                       (recommended for Arbitrum production).
 ///
 /// Usage:
 ///   forge script script/deploy/DeployCommissionManager.s.sol \
@@ -31,12 +39,34 @@ contract DeployCommissionManager is Script {
         address bridgeAddress = vm.envAddress('BRIDGE_ADDRESS');
         address ethUsdFeed    = vm.envOr('ETH_USD_FEED', address(0));
         uint256 ethUsdHb      = vm.envOr('ETH_USD_HEARTBEAT', uint256(0));
+        address seqFeed        = vm.envOr('SEQUENCER_UPTIME_FEED', address(0));
+        uint256 ethUsdMinPrice = vm.envOr('ETH_USD_MIN_PRICE', uint256(0));
+        uint256 ethUsdMaxPrice = vm.envOr('ETH_USD_MAX_PRICE', uint256(0));
+        bool    reqHardening   = vm.envOr('REQUIRE_CHAINLINK_HARDENING', false);
+
+        // Misconfiguration checks (fail-fast, before broadcast). Price band is
+        // all-or-nothing (a half-set band would be silently ignored). The opt-in
+        // prod guard enforces the full R-I-14 config when NATIVE is enabled.
+        require((ethUsdMinPrice == 0) == (ethUsdMaxPrice == 0),
+            'set both ETH_USD_MIN_PRICE and ETH_USD_MAX_PRICE, or neither');
+        if (reqHardening) {
+            require(ethUsdFeed != address(0), 'hardening: ETH_USD_FEED must be set');
+            require(seqFeed != address(0),    'hardening: SEQUENCER_UPTIME_FEED must be set');
+            require(ethUsdMaxPrice != 0,      'hardening: ETH_USD_MIN/MAX_PRICE must be set');
+        }
 
         vm.startBroadcast(pk);
         cm = new CommissionManager(bridgeAddress);
         if (ethUsdFeed != address(0)) {
             require(ethUsdHb != 0, 'ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided');
             cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
+        }
+        // R-I-14 Arbitrum hardening (owner-only; deployer is owner here).
+        if (seqFeed != address(0)) {
+            cm.setSequencerUptimeFeed(seqFeed);
+        }
+        if (ethUsdMaxPrice != 0) {
+            cm.setEthUsdPriceBounds(ethUsdMinPrice, ethUsdMaxPrice);
         }
         vm.stopBroadcast();
 
@@ -48,6 +78,13 @@ contract DeployCommissionManager is Script {
             console2.log('ETH/USD heartbeat (s):        ', ethUsdHb);
         } else {
             console2.log('ETH/USD feed:                 ', 'UNSET (NATIVE quotes will revert until configured)');
+        }
+        if (seqFeed != address(0)) {
+            console2.log('Sequencer uptime feed wired:  ', seqFeed);
+        }
+        if (ethUsdMaxPrice != 0) {
+            console2.log('ETH/USD price band min:       ', ethUsdMinPrice);
+            console2.log('ETH/USD price band max:       ', ethUsdMaxPrice);
         }
     }
 }

--- a/ethereum/script/deploy/DeployMultisigProxy.s.sol
+++ b/ethereum/script/deploy/DeployMultisigProxy.s.sol
@@ -14,6 +14,7 @@ import { MultisigProxy } from '../../src/MultisigProxy.sol';
 ///   COMMISSION_MANAGER    — existing CommissionManager deployment
 ///   ENCLAVE_SIGNERS       — comma-separated TEE signer addresses
 ///   ENCLAVE_THRESHOLD     — M for enclave M-of-N
+///   INITIAL_ENCLAVE_SOURCE_CHAIN_ID — source chain id the initial enclave set authorises (non-zero)
 ///   FEDERATION_SIGNERS    — comma-separated governance signer addresses
 ///   FEDERATION_THRESHOLD  — M for federation M-of-N
 ///   COMMISSION_RECIPIENT  — destination for commission withdrawals
@@ -30,6 +31,7 @@ contract DeployMultisigProxy is Script {
         address commissionManager  = vm.envAddress('COMMISSION_MANAGER');
         address[] memory enc       = vm.envAddress('ENCLAVE_SIGNERS', ',');
         uint256 encThr             = vm.envUint('ENCLAVE_THRESHOLD');
+        uint256 initialSrcChain    = vm.envUint('INITIAL_ENCLAVE_SOURCE_CHAIN_ID');
         address[] memory fed       = vm.envAddress('FEDERATION_SIGNERS', ',');
         uint256 fedThr             = vm.envUint('FEDERATION_THRESHOLD');
         address commission         = vm.envAddress('COMMISSION_RECIPIENT');
@@ -40,7 +42,7 @@ contract DeployMultisigProxy is Script {
         proxy = new MultisigProxy(
             bridgeAddr,
             commissionManager,
-            enc, encThr,
+            enc, encThr, initialSrcChain,
             fed, fedThr,
             commission,
             timelock,
@@ -51,7 +53,8 @@ contract DeployMultisigProxy is Script {
         console2.log('MultisigProxy deployed at:', address(proxy));
         console2.log('Bridge:                   ', proxy.bridge());
         console2.log('CommissionManager:        ', proxy.commissionManager());
-        console2.log('Enclave threshold:        ', proxy.enclaveThreshold());
+        console2.log('Initial enclave srcChain: ', initialSrcChain);
+        console2.log('Enclave threshold:        ', proxy.enclaveThreshold(initialSrcChain));
         console2.log('Federation threshold:     ', proxy.federationThreshold());
         console2.log('Commission recipient:     ', proxy.commissionRecipient());
         console2.log('Timelock duration (sec):  ', proxy.timelockDuration());

--- a/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
+++ b/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
@@ -56,7 +56,7 @@ contract MultisigExecuteFundsOut is Script {
 
         IBridge.FundsOutParams memory params = _loadParams();
 
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(params.sourceChainId);
         uint256 deadline = block.timestamp + vm.envUint('DEADLINE_OFFSET');
         uint256 bitmap   = vm.envUint('ENCLAVE_BITMAP');
 
@@ -73,6 +73,6 @@ contract MultisigExecuteFundsOut is Script {
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
         vm.stopBroadcast();
 
-        console2.log('fundsOutCall() succeeded. New nonce:', proxy.teeNonce());
+        console2.log('fundsOutCall() succeeded. New nonce:', proxy.teeNonce(params.sourceChainId));
     }
 }

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -19,7 +19,7 @@ import { OutflowRateLimiter } from './libraries/OutflowRateLimiter.sol';
 ///         protocol fees are held separately from bridge liquidity.
 ///
 /// @dev - Owner is `MultisigProxy`. `fundsOut` is called via
-///        `MultisigProxy.execute()` (TEE M-of-N).
+///        `MultisigProxy.fundsOutCall()` (TEE M-of-N).
 ///      - Route-specific finality verification and per-route settlement
 ///        accounting (RGB `fundsInRecords` etc.) live behind the
 ///        `RouteRegistry` dispatcher in dedicated plugin contracts. Bridge
@@ -371,10 +371,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         );
 
         // Forward token commission to the CommissionManager pool.
-        if (tokenCommission != 0) {
-            IERC20(TOKEN).safeTransfer(address(commissionManager), tokenCommission);
-            commissionManager.receiveTokenCommission(TOKEN);
-        }
+        if (tokenCommission != 0) _forwardTokenCommission(tokenCommission);
 
         // Deliver the net amount to the recipient.
         IERC20(TOKEN).safeTransfer(fundsOutParams.recipient, netAmount);
@@ -462,19 +459,25 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (sourceChainId      == 0)               revert InvalidSourceChainId();
         if (destinationChainId == 0)               revert InvalidDestinationChainId();
 
-        (
-            uint256 tokenCommission,
-            uint256 nativeCommission,
-            uint256 netAmount
-        ) = commissionManager.calculateFundsInCommission(
-            sourceChainId,
-            destinationChainId,
-            TOKEN,
-            amount
-        );
+        // Commission is quoted from the nominal `amount` so the native-commission
+        // quote (and the lower-bound `msg.value` check below) stays predictable
+        // for the caller. The nominal net is intentionally discarded — the
+        // credited net is derived from the ACTUAL received amount after the transfer.
+        (uint256 tokenCommission, uint256 nativeCommission, ) =
+            commissionManager.calculateFundsInCommission(
+                sourceChainId,
+                destinationChainId,
+                TOKEN,
+                amount
+            );
 
-        // Native payment must match the quote exactly (includes the zero-native case).
-        if (msg.value != nativeCommission) revert NativeValueMismatch();
+        // Native payment: require at least the freshly-quoted commission
+        // — an oracle move up between quote and execution reverts here. Any
+        // overpayment from a favorable move is collected as commission below
+        // (not refunded), so the rule is uniform for direct and LZ deposits.
+        // TOKEN-commission routes (nativeCommission == 0) accept no native.
+        if (msg.value < nativeCommission) revert NativeValueMismatch();
+        if (nativeCommission == 0 && msg.value != 0) revert NativeValueMismatch();
 
         // Build the canonical context. The per-`(sourceChainId, sourceSender)`
         // nonce is consumed here — before any external call, so a downstream
@@ -487,17 +490,40 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             sender:        from,
             sourceSender:  sourceSender,
             grossAmount:   amount,
-            netAmount:     netAmount,
+            netAmount:     0, // set below from the ACTUAL received amount
             operationId:   bytes32(0), // filled in on the next line
             senderNonce:   sourceSenderNonces[sourceChainId][sourceSender]++,
             sourceChainId: sourceChainId,
             destChainId:   destinationChainId,
             destAddress:   destinationAddress
         });
+        // operationId binds grossAmount (not netAmount), so it is stable
+        // regardless of any token transfer fee.
         ctx.operationId = _deriveOperationId(ctx, settlementData);
 
-        // Pull the full gross amount from `from` into this contract.
+        // Pull the gross amount and measure what ACTUALLY arrived. A
+        // fee-on-transfer token can deliver less than `amount`; crediting the
+        // nominal amount would overstate custody and could brick release of the
+        // recorded balance. Everything downstream — records, isolated
+        // liquidity, event — is built from `received`, never from `amount`.
+        uint256 balanceBefore = IERC20(TOKEN).balanceOf(address(this));
         IERC20(TOKEN).safeTransferFrom(from, address(this), amount);
+        uint256 received = IERC20(TOKEN).balanceOf(address(this)) - balanceBefore;
+
+        // The token commission is forwarded out of `received`; guard the
+        // subtraction so a token fee that eats more than the commission reverts
+        // cleanly instead of underflowing. A zero net (received == commission) is
+        // left to the existing zero-amount / dust handling, unchanged here.
+        if (received < tokenCommission) revert InsufficientReceived(received, tokenCommission);
+        ctx.netAmount = received - tokenCommission;
+
+        // Forward token commission BEFORE the settlement hook so that any
+        // external call the hook makes (or a contract reading `getContractBalance`
+        // during it) observes only the net amount the Bridge actually retains,
+        // never the in-flight commission about to leave. `netAmount` is
+        // already fixed above, so the hook does not depend on the tokens still
+        // being held here.
+        if (tokenCommission != 0) _forwardTokenCommission(tokenCommission);
 
         // Delegate per-route inbound bookkeeping. The module returns an optional
         // correlation id (the RGB OpId for the RGB route; 0 otherwise) to surface
@@ -506,18 +532,16 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
 
         // Isolated liquidity: credit the net deposit to its destination
         // chain's bucket. A later `fundsOut` from that chain can release at most
-        // the accumulated locked liquidity.
-        lockedLiquidity[destinationChainId] += netAmount;
+        // the accumulated locked liquidity. Credited from the ACTUAL received
+        // amount so the ledger can never exceed real custody.
+        lockedLiquidity[destinationChainId] += ctx.netAmount;
 
-        // Forward token commission, if any, to the CommissionManager pool.
-        if (tokenCommission != 0) {
-            IERC20(TOKEN).safeTransfer(address(commissionManager), tokenCommission);
-            commissionManager.receiveTokenCommission(TOKEN);
-        }
-
-        // Forward native commission, if any, to the CommissionManager pool.
-        if (nativeCommission != 0) {
-            (bool ok, ) = address(commissionManager).call{ value: nativeCommission }('');
+        // Forward the FULL native value to the CommissionManager pool. Any
+        // surplus over the quoted `nativeCommission` (favorable oracle drift) is
+        // collected as commission rather than refunded, so no native is
+        // ever left stranded in the Bridge.
+        if (msg.value != 0) {
+            (bool ok, ) = address(commissionManager).call{ value: msg.value }('');
             if (!ok) revert NativeValueMismatch();
         }
 
@@ -532,7 +556,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             ctx.grossAmount,
             ctx.netAmount,
             tokenCommission,
-            nativeCommission,
+            msg.value, // actual native collected (== nativeCommission + any drift surplus)
             ctx.sourceChainId,
             ctx.destChainId,
             ctx.destAddress
@@ -545,6 +569,19 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     ///      used by `operationId` derivation and the LZ overload.
     function _toSourceSender(address account) private pure returns (bytes32) {
         return bytes32(uint256(uint160(account)));
+    }
+
+    /// @dev Transfer `amount` of TOKEN to the CommissionManager and credit the
+    ///      commission pool by the ACTUAL balance increase this transfer caused.
+    ///      Measuring the delta here (rather than in CM from `balanceOf - pool`)
+    ///      keeps the credit fee-on-transfer safe and prevents any pre-existing /
+    ///      unsolicited direct transfer to CM from being absorbed as commission.
+    function _forwardTokenCommission(uint256 amount) private {
+        address cm = address(commissionManager);
+        uint256 balBefore = IERC20(TOKEN).balanceOf(cm);
+        IERC20(TOKEN).safeTransfer(cm, amount);
+        uint256 credited = IERC20(TOKEN).balanceOf(cm) - balBefore;
+        commissionManager.receiveTokenCommission(TOKEN, credited);
     }
 
     /// @dev Canonical `operationId` = domain-separated hash of the deposit

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -77,6 +77,24 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     ///         in seconds. Quotes revert `StalePrice` when the answer is older.
     uint256 public ethUsdHeartbeat;
 
+    /// @notice Chainlink L2 Sequencer Uptime feed (Arbitrum). `address(0)`
+    ///         (default) disables the check for non-L2 / test environments;
+    ///         an Arbitrum deployment MUST wire it via `setSequencerUptimeFeed`.
+    address public sequencerUptimeFeed;
+
+    /// @notice Seconds after a sequencer restart during which NATIVE quotes are
+    ///         rejected — the L2-published price can lag the market right after
+    ///         recovery. Chainlink's recommended grace period is 3600s.
+    uint256 public constant SEQUENCER_GRACE_PERIOD = 3600;
+
+    /// @notice Optional [min, max] sanity band on the ETH/USD answer (in feed
+    ///         decimals). `ethUsdMaxPrice == 0` (default) disables the band; when
+    ///         set, an answer outside it (e.g. an aggregator floored/capped to
+    ///         `minAnswer`/`maxAnswer` during an extreme move) reverts
+    ///         `PriceOutOfBounds`.
+    uint256 public ethUsdMinPrice;
+    uint256 public ethUsdMaxPrice;
+
     // ============ Modifiers ============
 
     /// @dev Restricts call to `bridgeAddress`.
@@ -252,14 +270,38 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
 
         address feedAddr = ethUsdFeed;
         if (feedAddr == address(0)) revert EthUsdFeedNotSet();
+
+        // L2 sequencer liveness (Arbitrum). Skipped when unset so non-L2 / test
+        // environments are unaffected; an Arbitrum deployment wires it.
+        if (sequencerUptimeFeed != address(0)) _requireSequencerUp();
+
         AggregatorV3Interface feed = AggregatorV3Interface(feedAddr);
 
         (, int256 answer, , uint256 updatedAt, ) = feed.latestRoundData();
         if (answer <= 0) revert InvalidPrice();
         if (block.timestamp - updatedAt > ethUsdHeartbeat) revert StalePrice();
+        // Optional circuit-breaker band (disabled when ethUsdMaxPrice == 0):
+        // rejects a floored/capped aggregator answer that `answer > 0` misses.
+        if (ethUsdMaxPrice != 0 &&
+            (uint256(answer) < ethUsdMinPrice || uint256(answer) > ethUsdMaxPrice)) {
+            revert PriceOutOfBounds();
+        }
 
         uint256 scale = 10 ** (18 - tokenDecimals + uint256(feed.decimals()));
         nativeFee = (tokenFee * scale) / uint256(answer);
+    }
+
+    /// @dev Reverts unless the Arbitrum L2 sequencer is up and past the grace
+    ///      period. Only invoked when `sequencerUptimeFeed` is configured. The
+    ///      uptime feed is a standard `AggregatorV3Interface`: `answer == 0`
+    ///      means the sequencer is up, `answer == 1` means down; `startedAt` is
+    ///      when the current status round began (i.e. the last restart when it
+    ///      transitions back to up).
+    function _requireSequencerUp() internal view {
+        (, int256 answer, uint256 startedAt, , ) =
+            AggregatorV3Interface(sequencerUptimeFeed).latestRoundData();
+        if (answer != 0) revert SequencerDown();
+        if (block.timestamp - startedAt <= SEQUENCER_GRACE_PERIOD) revert GracePeriodNotOver();
     }
 
     /**
@@ -334,6 +376,33 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         ethUsdFeed = feed;
         ethUsdHeartbeat = heartbeat;
         emit EthUsdFeedUpdated(feed, heartbeat);
+    }
+
+    /// @inheritdoc ICommissionManager
+    /// @dev `address(0)` disables the sequencer-uptime gate (non-L2 / test
+    ///      environments). On Arbitrum, federation MUST set the Chainlink
+    ///      Sequencer Uptime feed so NATIVE quotes reject prices during
+    ///      downtime and the post-restart grace period.
+    function setSequencerUptimeFeed(address feed) external onlyOwner {
+        sequencerUptimeFeed = feed;
+        emit SequencerUptimeFeedUpdated(feed);
+    }
+
+    /// @inheritdoc ICommissionManager
+    /// @dev Pass `(0, 0)` to disable the band; otherwise require
+    ///      `0 < minPrice < maxPrice` (values in the feed's decimals, e.g.
+    ///      `100e8` / `100_000e8` for an 8-decimal ETH/USD feed).
+    function setEthUsdPriceBounds(uint256 minPrice, uint256 maxPrice) external onlyOwner {
+        if (minPrice == 0 && maxPrice == 0) {
+            ethUsdMinPrice = 0;
+            ethUsdMaxPrice = 0;
+            emit EthUsdPriceBoundsUpdated(0, 0);
+            return;
+        }
+        if (minPrice == 0 || minPrice >= maxPrice) revert InvalidPriceBounds();
+        ethUsdMinPrice = minPrice;
+        ethUsdMaxPrice = maxPrice;
+        emit EthUsdPriceBoundsUpdated(minPrice, maxPrice);
     }
 
     /**
@@ -490,19 +559,22 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     // ============ Commission Collection Functions ============
 
     /**
-     * @notice Credits token commission: increases `tokenCommissionPool[token]` by the actual balance delta.
+     * @notice Credits `credited` token units to `tokenCommissionPool[token]`.
      * @param token ERC-20 token (non-zero). Bridge must transfer tokens before this call.
-     * @dev Pool tracks on-chain balance; no calldata amount (supports fee-on-transfer tokens).
+     * @param credited The Bridge-measured balance increase of THIS contract from
+     *        its `safeTransfer` (fee-on-transfer safe). Credited as-is rather than
+     *        recomputed from `balanceOf - pool`, so a pre-existing/unsolicited
+     *        direct transfer is never folded into the pool.
+     * @dev Reverts if the resulting pool would exceed the on-chain balance —
+     *      guards against a caller crediting more than actually arrived.
      */
-    function receiveTokenCommission(address token) external onlyBridge {
+    function receiveTokenCommission(address token, uint256 credited) external onlyBridge {
         if (token == address(0)) revert InvalidToken();
-        uint256 newBalance = IERC20(token).balanceOf(address(this));
-        uint256 priorPool = tokenCommissionPool[token];
-        if (newBalance < priorPool) revert BalanceBelowRecordedPool();
-        uint256 recorded = newBalance - priorPool;
-        if (recorded == 0) revert NothingReceived();
-        tokenCommissionPool[token] = newBalance;
-        emit TokenCommissionReceived(token, recorded);
+        if (credited == 0) revert NothingReceived();
+        uint256 newPool = tokenCommissionPool[token] + credited;
+        if (IERC20(token).balanceOf(address(this)) < newPool) revert BalanceBelowRecordedPool();
+        tokenCommissionPool[token] = newPool;
+        emit TokenCommissionReceived(token, credited);
     }
 
     /**

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -43,25 +43,48 @@ contract MultisigProxy is IMultisigProxy {
     ///         until then (closes adapter-execute by default).
     address public lzAdapter;
 
-    address[] private _enclaveSigners;
-    uint256 public enclaveThreshold;
+    /// @notice Per-source-chain enclave signer sets. Each source network (RGB,
+    ///         Concordium/Arch, …) is validated by its own TEE code and therefore
+    ///         has its own key set; a release for `sourceChainId` is authorised
+    ///         only by the set registered for that chain. Selected on the release
+    ///         path via `params.sourceChainId`, which is already committed to in
+    ///         the enclave EIP-712 digest — so a signature for one source chain
+    ///         cannot be replayed against another.
+    mapping(uint256 sourceChainId => address[]) private _enclaveSigners;
+
+    /// @notice Per-source-chain enclave quorum. `0` means the source chain is
+    ///         not registered — used as the existence guard on the release path.
+    mapping(uint256 sourceChainId => uint256) public enclaveThreshold;
+
+    /// @notice Registered enclave source chains, for enumeration and the
+    ///         cross-set disjointness checks. Bounded by `MAX_ENCLAVE_SOURCE_CHAINS`.
+    uint256[] private _enclaveSourceChains;
 
     address[] private _federationSigners;
     uint256 public federationThreshold;
 
     address public commissionRecipient;
 
-    /// @notice Sequential nonce shared by the typed TEE methods (`fundsOut` /
-    ///         `lzFundsOut`). Each successful call must match the current value
-    ///         and then increments it, giving all enclave releases a single
-    ///         total order and one-shot replay protection.
-    uint256 public teeNonce;
+    /// @notice Per-source-chain nonce for the typed TEE methods (`fundsOutCall`
+    ///         / `lzFundsOutCall`). Each source chain has its own lane, so the
+    ///         TEE operating one network cannot invalidate another network's
+    ///         pre-signed release. Each successful call must match the current
+    ///         value for its `sourceChainId` and then increments it.
+    mapping(uint256 sourceChainId => uint256) public teeNonce;
 
     /// @notice Federation proposals.
     mapping(bytes32 => Proposal) private _proposals;
 
-    /// @notice Sequential nonce for all federation operations (propose, cancel, emergency).
+    /// @notice Sequential nonce for the regular federation lane: `_propose`
+    ///         (all typed proposals) and `cancelProposal`.
     uint256 public proposalNonce;
+
+    /// @notice Sequential nonce for the emergency lane: `emergencyPause` /
+    ///         `emergencyUnpause`. Kept separate from `proposalNonce` so an
+    ///         emergency action cannot invalidate an already-signed regular
+    ///         proposal. Cross-lane replay is independently prevented by
+    ///         each operation's distinct EIP-712 typehash.
+    uint256 public emergencyNonce;
 
     /// @notice Minimum delay (seconds) between proposal creation and execution.
     uint256 public timelockDuration;
@@ -93,10 +116,26 @@ contract MultisigProxy is IMultisigProxy {
     ///         unreachable). 20 is ample for an enclave/federation committee.
     uint256 public constant MAX_SIGNERS = 20;
 
+    /// @notice Hard upper bound on the number of registered enclave source
+    ///         chains. Bounds the cross-set disjointness loop (run on every
+    ///         signer rotation), keeping governance updates gas-predictable.
+    uint256 public constant MAX_ENCLAVE_SOURCE_CHAINS = 32;
+
     /// @notice Length of a Solidity function selector (`bytes4`) in bytes. Used
     ///         to guard `callData` against payloads too short to even carry a
     ///         selector before it is sliced via `calldataload`.
     uint256 public constant SELECTOR_LENGTH = 4;
+
+    /// @notice CommissionManager withdrawal selectors that the generic
+    ///         `AdminExecuteCommissionManager` path is NOT allowed to call —
+    ///         they take a free recipient and would bypass the pinned
+    ///         `commissionRecipient`. Withdrawals must go through the
+    ///         dedicated WithdrawTokenCommissionCM / WithdrawNativeCommissionCM
+    ///         ops, which force the recipient to `commissionRecipient`.
+    bytes4 private constant _SEL_WITHDRAW_TOKEN      = bytes4(keccak256('withdrawTokenCommission(address,address,uint256)'));
+    bytes4 private constant _SEL_WITHDRAW_NATIVE     = bytes4(keccak256('withdrawNativeCommission(address,uint256)'));
+    bytes4 private constant _SEL_WITHDRAW_ALL_TOKEN  = bytes4(keccak256('withdrawAllTokenCommission(address,address)'));
+    bytes4 private constant _SEL_WITHDRAW_ALL_NATIVE = bytes4(keccak256('withdrawAllNativeCommission(address)'));
 
     uint256 private immutable _cachedChainId;
     bytes32 private immutable _cachedDomainSeparator;
@@ -118,7 +157,7 @@ contract MultisigProxy is IMultisigProxy {
         'ProposeAdminExecute(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
     );
     bytes32 private constant _PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH = keccak256(
-        'ProposeUpdateEnclaveSigners(address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
+        'ProposeUpdateEnclaveSigners(uint256 sourceChainId,address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
     );
     bytes32 private constant _PROPOSE_UPDATE_FEDERATION_SIGNERS_TYPEHASH = keccak256(
         'ProposeUpdateFederationSigners(address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
@@ -199,6 +238,7 @@ contract MultisigProxy is IMultisigProxy {
         address commissionManager_,
         address[] memory enclaveSigners_,
         uint256 enclaveThreshold_,
+        uint256 initialEnclaveSourceChain_,
         address[] memory federationSigners_,
         uint256 federationThreshold_,
         address commissionRecipient_,
@@ -208,6 +248,7 @@ contract MultisigProxy is IMultisigProxy {
         if (bridge_ == address(0)) revert ZeroBridge();
         if (commissionManager_ == address(0)) revert ZeroCommissionManager();
         if (enclaveSigners_.length == 0) revert NoSigners();
+        if (initialEnclaveSourceChain_ == 0) revert UnknownSourceChain(0);
         _requireValidThreshold(enclaveThreshold_, enclaveSigners_.length);
         if (federationSigners_.length == 0) revert NoSigners();
         _requireValidThreshold(federationThreshold_, federationSigners_.length);
@@ -224,8 +265,9 @@ contract MultisigProxy is IMultisigProxy {
 
         bridge = bridge_;
         commissionManager = commissionManager_;
-        _enclaveSigners = enclaveSigners_;
-        enclaveThreshold = enclaveThreshold_;
+        _enclaveSigners[initialEnclaveSourceChain_] = enclaveSigners_;
+        enclaveThreshold[initialEnclaveSourceChain_] = enclaveThreshold_;
+        _enclaveSourceChains.push(initialEnclaveSourceChain_);
         _federationSigners = federationSigners_;
         federationThreshold = federationThreshold_;
         commissionRecipient = commissionRecipient_;
@@ -250,18 +292,22 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata enclaveSigs
     ) external {
         _checkTeeTiming(deadline);
-        if (nonce != teeNonce) revert InvalidNonce();
+        // Select the enclave set by the release's source chain. `sourceChainId`
+        // is committed to in the digest below, so a signature is bound to the
+        // set of exactly one source chain. A zero threshold = unregistered.
+        if (enclaveThreshold[params.sourceChainId] == 0) revert UnknownSourceChain(params.sourceChainId);
+        if (nonce != teeNonce[params.sourceChainId]) revert InvalidNonce();
 
         _verifySignatures(
             _hashTypedData(_fundsOutStructHash(params, nonce, deadline)),
-            enclaveBitmap, enclaveSigs, _enclaveSigners, enclaveThreshold
+            enclaveBitmap, enclaveSigs, _enclaveSigners[params.sourceChainId], enclaveThreshold[params.sourceChainId]
         );
 
-        teeNonce++;
+        teeNonce[params.sourceChainId]++;
 
         IBridge(bridge).fundsOut(params);
 
-        emit FundsOutExecuted(nonce, enclaveBitmap);
+        emit FundsOutExecuted(params.sourceChainId, nonce, enclaveBitmap);
     }
 
     /// @dev EIP-712 struct hash for `TeeFundsOut`. Isolated in its own frame to
@@ -300,17 +346,18 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata enclaveSigs
     ) external payable {
         _checkTeeTiming(deadline);
-        if (nonce != teeNonce) revert InvalidNonce();
+        if (enclaveThreshold[params.sourceChainId] == 0) revert UnknownSourceChain(params.sourceChainId);
+        if (nonce != teeNonce[params.sourceChainId]) revert InvalidNonce();
 
         address adapter = lzAdapter;
         if (adapter == address(0)) revert LZAdapterNotSet();
 
         _verifySignatures(
             _hashTypedData(_lzFundsOutStructHash(params, nonce, deadline)),
-            enclaveBitmap, enclaveSigs, _enclaveSigners, enclaveThreshold
+            enclaveBitmap, enclaveSigs, _enclaveSigners[params.sourceChainId], enclaveThreshold[params.sourceChainId]
         );
 
-        teeNonce++;
+        teeNonce[params.sourceChainId]++;
 
         // Release to the adapter, then bridge exactly what the adapter received,
         // so the release and the cross-chain send are bound on-chain. The Bridge
@@ -336,7 +383,7 @@ contract MultisigProxy is IMultisigProxy {
             params.dstEid, params.recipient, delivered, params.minAmountLD, params.extraOptions
         );
 
-        emit LzFundsOutExecuted(nonce, enclaveBitmap, params.dstEid, params.recipient, delivered);
+        emit LzFundsOutExecuted(params.sourceChainId, nonce, enclaveBitmap, params.dstEid, params.recipient, delivered);
     }
 
     /// @dev EIP-712 struct hash for `TeeLzFundsOut`. Isolated in its own frame
@@ -391,14 +438,14 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata fedSigs
     ) external {
         if (block.timestamp > deadline) revert Expired();
-        if (nonce != proposalNonce) revert InvalidNonce();
+        if (nonce != emergencyNonce) revert InvalidNonce();
 
         bytes32 digest = _hashTypedData(
             keccak256(abi.encode(_EMERGENCY_PAUSE_TYPEHASH, nonce, deadline))
         );
         _verifySignatures(digest, fedBitmap, fedSigs, _federationSigners, federationThreshold);
 
-        proposalNonce++;
+        emergencyNonce++;
 
         // Emergency freeze of BOTH inflow and outflow — no timelock, federation
         // signatures only. Also halts the enclave/TEE release path (it routes
@@ -417,14 +464,14 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata fedSigs
     ) external {
         if (block.timestamp > deadline) revert Expired();
-        if (nonce != proposalNonce) revert InvalidNonce();
+        if (nonce != emergencyNonce) revert InvalidNonce();
 
         bytes32 digest = _hashTypedData(
             keccak256(abi.encode(_EMERGENCY_UNPAUSE_TYPEHASH, nonce, deadline))
         );
         _verifySignatures(digest, fedBitmap, fedSigs, _federationSigners, federationThreshold);
 
-        proposalNonce++;
+        emergencyNonce++;
 
         // Lift the emergency freeze on BOTH inflow and outflow.
         (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('emergencyUnpauseAll()'));
@@ -459,6 +506,7 @@ contract MultisigProxy is IMultisigProxy {
 
     /// @inheritdoc IMultisigProxy
     function proposeUpdateEnclaveSigners(
+        uint256 sourceChainId,
         address[] calldata newSigners,
         uint256 newThreshold,
         uint256 nonce,
@@ -469,19 +517,21 @@ contract MultisigProxy is IMultisigProxy {
         // Validate the proposed set up front so a malformed rotation reverts
         // here instead of consuming a nonce + timelock slot and failing only at
         // execution. Disjointness is intentionally left to execute time: it
-        // depends on the live counterpart set, which may change before then.
+        // depends on the live federation and other enclave sets, which may
+        // change before then.
+        if (sourceChainId == 0) revert UnknownSourceChain(0);
         if (newSigners.length == 0) revert NoSigners();
         _requireValidThreshold(newThreshold, newSigners.length);
         _validateSigners(newSigners);
 
         bytes32 structHash = keccak256(abi.encode(
             _PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH,
-            _hashAddressArray(newSigners), newThreshold, nonce, deadline
+            sourceChainId, _hashAddressArray(newSigners), newThreshold, nonce, deadline
         ));
 
         return _propose(
             OperationType.UpdateEnclaveSigners,
-            abi.encode(newSigners, newThreshold),
+            abi.encode(sourceChainId, newSigners, newThreshold),
             nonce, deadline, structHash, fedBitmap, fedSigs
         );
     }
@@ -586,6 +636,10 @@ contract MultisigProxy is IMultisigProxy {
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
+
+        // Commission withdrawals must use the pinned-recipient ops; reject them
+        // on the generic path up front (fail-fast, no wasted proposal slot).
+        _requireNotCommissionWithdrawSelector(selector);
 
         bytes32 structHash = keccak256(abi.encode(
             _PROPOSE_ADMIN_EXECUTE_CM_TYPEHASH, selector, keccak256(callData), nonce, deadline
@@ -891,19 +945,26 @@ contract MultisigProxy is IMultisigProxy {
 
     /// @inheritdoc IMultisigProxy
     function verifyEnclaveSignature(
+        uint256 sourceChainId,
         bytes32 digest,
         bytes calldata signature,
         uint256 signerIndex
     ) external view returns (bool) {
-        if (signerIndex >= _enclaveSigners.length) revert IndexOutOfRange();
+        address[] storage set = _enclaveSigners[sourceChainId];
+        if (signerIndex >= set.length) revert IndexOutOfRange();
         address recovered = ECDSA.recover(digest, signature);
-        return recovered == _enclaveSigners[signerIndex];
+        return recovered == set[signerIndex];
     }
 
 
     /// @inheritdoc IMultisigProxy
-    function getEnclaveSigners() external view returns (address[] memory) {
-        return _enclaveSigners;
+    function getEnclaveSigners(uint256 sourceChainId) external view returns (address[] memory) {
+        return _enclaveSigners[sourceChainId];
+    }
+
+    /// @inheritdoc IMultisigProxy
+    function getEnclaveSourceChains() external view returns (uint256[] memory) {
+        return _enclaveSourceChains;
     }
 
     /// @inheritdoc IMultisigProxy
@@ -969,21 +1030,37 @@ contract MultisigProxy is IMultisigProxy {
             _propagateRevert(ok, ret);
 
         } else if (opType == OperationType.UpdateEnclaveSigners) {
-            (address[] memory newSigners, uint256 newThreshold) = abi.decode(opData, (address[], uint256));
+            (uint256 sourceChainId, address[] memory newSigners, uint256 newThreshold) =
+                abi.decode(opData, (uint256, address[], uint256));
+            if (sourceChainId == 0) revert UnknownSourceChain(0);
             if (newSigners.length == 0) revert NoSigners();
             _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
+            // Keep every trust domain independent: disjoint from the federation
+            // and from every *other* enclave source chain (skip this chain, so a
+            // partial rotation that keeps some of its own keys is allowed).
             _requireDisjoint(newSigners, _federationSigners);
-            _enclaveSigners = newSigners;
-            enclaveThreshold = newThreshold;
-            emit EnclaveSignersUpdated(newSigners, newThreshold);
+            _requireDisjointFromAllEnclaveSets(newSigners, sourceChainId);
+
+            // Register a brand-new source chain (bounded); existing ones just
+            // overwrite their set/threshold.
+            if (enclaveThreshold[sourceChainId] == 0) {
+                if (_enclaveSourceChains.length >= MAX_ENCLAVE_SOURCE_CHAINS) {
+                    revert TooManyEnclaveSourceChains(_enclaveSourceChains.length + 1, MAX_ENCLAVE_SOURCE_CHAINS);
+                }
+                _enclaveSourceChains.push(sourceChainId);
+            }
+            _enclaveSigners[sourceChainId] = newSigners;
+            enclaveThreshold[sourceChainId] = newThreshold;
+            emit EnclaveSignersUpdated(sourceChainId, newSigners, newThreshold);
 
         } else if (opType == OperationType.UpdateFederationSigners) {
             (address[] memory newSigners, uint256 newThreshold) = abi.decode(opData, (address[], uint256));
             if (newSigners.length == 0) revert NoSigners();
             _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
-            _requireDisjoint(newSigners, _enclaveSigners);
+            // Federation must stay disjoint from every enclave source-chain set.
+            _requireDisjointFromAllEnclaveSets(newSigners, 0);
             _federationSigners = newSigners;
             federationThreshold = newThreshold;
             emit FederationSignersUpdated(newSigners, newThreshold);
@@ -1010,7 +1087,11 @@ contract MultisigProxy is IMultisigProxy {
             emit TimelockDurationUpdated(newDuration);
 
         } else if (opType == OperationType.AdminExecuteCommissionManager) {
-            // opData = raw CommissionManager callData
+            // opData = raw CommissionManager callData. Enforce (again, at the
+            // execution boundary) that this generic path cannot call a
+            // withdrawal selector and re-point commission away from the pinned
+            // `commissionRecipient`.
+            _requireNotCommissionWithdrawSelector(_firstSelector(opData));
             (bool ok, bytes memory ret) = commissionManager.call(opData);
             _propagateRevert(ok, ret);
 
@@ -1205,6 +1286,19 @@ contract MultisigProxy is IMultisigProxy {
         }
     }
 
+    /// @dev Reverts if `candidate` overlaps any registered enclave source-chain
+    ///      set, skipping `exceptSourceChain` (pass `0` to skip none). Used to
+    ///      keep every enclave set disjoint from the others and from the
+    ///      federation. Cost is bounded by `MAX_ENCLAVE_SOURCE_CHAINS` *
+    ///      `MAX_SIGNERS` * candidate length.
+    function _requireDisjointFromAllEnclaveSets(address[] memory candidate, uint256 exceptSourceChain) private view {
+        uint256[] memory chains = _enclaveSourceChains;
+        for (uint256 i = 0; i < chains.length; i++) {
+            if (chains[i] == exceptSourceChain) continue;
+            _requireDisjoint(candidate, _enclaveSigners[chains[i]]);
+        }
+    }
+
     function _validateSigners(address[] memory signers) private pure {
         // Bound the set before the O(N^2) duplicate scan below, and keep every
         // signer index within the uint256 signature bitmap (R-I-06).
@@ -1241,6 +1335,29 @@ contract MultisigProxy is IMultisigProxy {
             } else {
                 revert CallFailed();
             }
+        }
+    }
+
+    /// @dev First 4 bytes of `data` as a selector, or `0x00000000` if `data` is
+    ///      shorter than a selector (such a payload can never be a withdrawal
+    ///      call and the downstream raw call rejects it anyway).
+    function _firstSelector(bytes memory data) private pure returns (bytes4 selector) {
+        if (data.length >= SELECTOR_LENGTH) {
+            assembly { selector := mload(add(data, 0x20)) }
+        }
+    }
+
+    /// @dev Reverts if `selector` is one of the CommissionManager withdrawal
+    ///      selectors, which the generic AdminExecuteCommissionManager path must
+    ///      not reach (they bypass the pinned `commissionRecipient`).
+    function _requireNotCommissionWithdrawSelector(bytes4 selector) private pure {
+        if (
+            selector == _SEL_WITHDRAW_TOKEN ||
+            selector == _SEL_WITHDRAW_NATIVE ||
+            selector == _SEL_WITHDRAW_ALL_TOKEN ||
+            selector == _SEL_WITHDRAW_ALL_NATIVE
+        ) {
+            revert ForbiddenCommissionManagerSelector(selector);
         }
     }
 }

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -11,6 +11,7 @@ interface IBridge {
     error InvalidSourceChainId();
     error ZeroAmount();
     error AmountBelowMinimum(uint256 amount, uint256 minimum);
+    error InsufficientReceived(uint256 received, uint256 tokenCommission);
     error InvalidMinFundsInAmount();
     error AddressTooLong(uint256 length, uint256 maxLength);
     error ProofTooLong(uint256 length, uint256 maxLength);
@@ -140,7 +141,10 @@ interface IBridge {
     ///         `sourceChainId` half of the commission route key is filled with
     ///         `block.chainid` — non-spoofable by the caller.
     /// @dev Payable: if the active route uses NATIVE commission currency, `msg.value`
-    ///      must equal the quoted native commission; otherwise `msg.value` must be 0.
+    ///      must be at least the quoted native commission — any surplus (from
+    ///      favorable ETH/USD drift between quote and execution) is collected as
+    ///      commission, not refunded (R-I-03). If the route takes no native
+    ///      commission (TOKEN currency), `msg.value` must be 0.
     /// @dev `settlementData` is an opaque per-route blob forwarded into the
     ///      route's `ISettlementModule.onFundsIn`. Routes whose module does not
     ///      consume any extra data (e.g. RGB) accept an empty bytes string.

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -63,6 +63,10 @@ interface ICommissionManager {
     error StalePrice();
     error TokenDecimalsTooLarge();
     error InvalidHeartbeat();
+    error SequencerDown();
+    error GracePeriodNotOver();
+    error PriceOutOfBounds();
+    error InvalidPriceBounds();
 
     // ============ Events ============
 
@@ -93,6 +97,12 @@ interface ICommissionManager {
 
     event EthUsdFeedUpdated(address indexed feed, uint256 heartbeat);
 
+    /// @notice Emitted on `setSequencerUptimeFeed` (`address(0)` disables the check).
+    event SequencerUptimeFeedUpdated(address indexed feed);
+
+    /// @notice Emitted on `setEthUsdPriceBounds` (both zero disables the band).
+    event EthUsdPriceBoundsUpdated(uint256 minPrice, uint256 maxPrice);
+
     event TokenCommissionWithdrawn(
         address indexed token,
         address indexed to,
@@ -119,6 +129,14 @@ interface ICommissionManager {
     function ethUsdFeed() external view returns (address);
 
     function ethUsdHeartbeat() external view returns (uint256);
+
+    function sequencerUptimeFeed() external view returns (address);
+
+    function SEQUENCER_GRACE_PERIOD() external view returns (uint256);
+
+    function ethUsdMinPrice() external view returns (uint256);
+
+    function ethUsdMaxPrice() external view returns (uint256);
 
     // ============ Core calculations ============
 
@@ -175,6 +193,16 @@ interface ICommissionManager {
     ///         disable NATIVE quoting until a new feed is set.
     function setEthUsdFeed(address feed, uint256 heartbeat) external;
 
+    /// @notice Configure (or rotate) the Chainlink L2 Sequencer Uptime feed used
+    ///         to gate NATIVE quotes on Arbitrum. Pass `address(0)` to disable
+    ///         the check (non-L2 / test environments).
+    function setSequencerUptimeFeed(address feed) external;
+
+    /// @notice Configure the optional [min, max] sanity band on the ETH/USD
+    ///         answer (feed decimals). Pass `(0, 0)` to disable; otherwise
+    ///         `0 < minPrice < maxPrice`.
+    function setEthUsdPriceBounds(uint256 minPrice, uint256 maxPrice) external;
+
     function setCommissionRule(
         uint256 sourceChainId,
         uint256 destChainId,
@@ -214,7 +242,13 @@ interface ICommissionManager {
 
     // ============ Commission ingress (bridge) ============
 
-    function receiveTokenCommission(address token) external;
+    /// @notice Credit `credited` token units to the commission pool. The Bridge
+    ///         measures `credited` as the actual balance increase of this
+    ///         contract around its `safeTransfer` (so a fee-on-transfer token is
+    ///         handled and no pre-existing/unsolicited balance is absorbed,
+    ///         R-I-04). Reverts if the resulting pool would exceed the on-chain
+    ///         balance. Callable only by the Bridge.
+    function receiveTokenCommission(address token, uint256 credited) external;
 
     /// @notice Native commission ingress; only `bridgeAddress` may call with non-zero value (see implementation).
     receive() external payable;

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -13,7 +13,8 @@ import { IBridge } from './IBridge.sol';
 ///        - `fundsOutCall`   — a single `Bridge.fundsOut` (RGB → Arbitrum);
 ///        - `lzFundsOutCall`  — `Bridge.fundsOut` to the LZ adapter then
 ///          `adapter.sendOut`, with the two legs bound on-chain (RGB → non-Arbitrum).
-///      Both share a single sequential `teeNonce` for replay protection.
+///      Each source chain has its own `teeNonce` lane, selected by the
+///      release's `sourceChainId`, for per-network replay protection.
 ///
 ///      FEDERATION SIGNERS (governance / admin nodes)
 ///      All administrative operations go through a two-phase timelock:
@@ -67,10 +68,13 @@ interface IMultisigProxy {
     error DuplicateSigner();
     error SignerSetsOverlap(address signer);
     error TooManySigners(uint256 count, uint256 max);
+    error UnknownSourceChain(uint256 sourceChainId);
+    error TooManyEnclaveSourceChains(uint256 count, uint256 max);
     error CallFailed();
     error UnknownOperationType();
     error ZeroRecipient();
     error ZeroTarget();
+    error ForbiddenCommissionManagerSelector(bytes4 selector);
     error LZAdapterNotSet();
     error InvalidLZAdapter();
 
@@ -132,8 +136,9 @@ interface IMultisigProxy {
     // =========================================================================
 
     // TEE — typed enclave releases
-    event FundsOutExecuted(uint256 indexed nonce, uint256 enclaveBitmap);
+    event FundsOutExecuted(uint256 indexed sourceChainId, uint256 indexed nonce, uint256 enclaveBitmap);
     event LzFundsOutExecuted(
+        uint256 indexed sourceChainId,
         uint256 indexed nonce,
         uint256 enclaveBitmap,
         uint32  dstEid,
@@ -158,7 +163,7 @@ interface IMultisigProxy {
     event EmergencyUnpaused(uint256 nonce, uint256 fedBitmap);
 
     // Emitted when proposals are executed
-    event EnclaveSignersUpdated(address[] newSigners, uint256 newThreshold);
+    event EnclaveSignersUpdated(uint256 indexed sourceChainId, address[] newSigners, uint256 newThreshold);
     event FederationSignersUpdated(address[] newSigners, uint256 newThreshold);
     event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
@@ -232,9 +237,12 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose replacing the enclave signer set.
-    /// @dev opData = abi.encode(address[] newSigners, uint256 newThreshold)
+    /// @notice Propose replacing (or registering) the enclave signer set for a
+    ///         given source chain. A `sourceChainId` with no set yet is
+    ///         registered on execution (bounded by `MAX_ENCLAVE_SOURCE_CHAINS`).
+    /// @dev opData = abi.encode(uint256 sourceChainId, address[] newSigners, uint256 newThreshold)
     function proposeUpdateEnclaveSigners(
+        uint256 sourceChainId,
         address[] calldata newSigners,
         uint256 newThreshold,
         uint256 nonce,
@@ -463,24 +471,29 @@ interface IMultisigProxy {
     // View
     // =========================================================================
 
-    /// @notice Verify that `signature` over `digest` was produced by the enclave signer at `signerIndex`.
+    /// @notice Verify that `signature` over `digest` was produced by the enclave
+    ///         signer at `signerIndex` for the given `sourceChainId` set.
     function verifyEnclaveSignature(
+        uint256 sourceChainId,
         bytes32 digest,
         bytes calldata signature,
         uint256 signerIndex
     ) external view returns (bool);
 
-    function teeNonce() external view returns (uint256);
+    function teeNonce(uint256 sourceChainId) external view returns (uint256);
     function bridge() external view returns (address);
     function commissionManager() external view returns (address);
     function lzAdapter() external view returns (address);
-    function getEnclaveSigners() external view returns (address[] memory);
-    function enclaveThreshold() external view returns (uint256);
+    function getEnclaveSigners(uint256 sourceChainId) external view returns (address[] memory);
+    function getEnclaveSourceChains() external view returns (uint256[] memory);
+    function enclaveThreshold(uint256 sourceChainId) external view returns (uint256);
     function getFederationSigners() external view returns (address[] memory);
     function federationThreshold() external view returns (uint256);
     function commissionRecipient() external view returns (address);
     function DOMAIN_SEPARATOR() external view returns (bytes32);
     function proposalNonce() external view returns (uint256);
+
+    function emergencyNonce() external view returns (uint256);
     function timelockDuration() external view returns (uint256);
     function MIN_TIMELOCK() external view returns (uint256);
     function getProposal(bytes32 proposalId) external view returns (Proposal memory);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -83,6 +83,9 @@ contract BridgeTest is Test {
     uint256 constant BURN_ID         = 9_001;
     /// @notice Non-zero RGB OpId threaded through the RGB-route settlementData.
     uint256 constant RGB_OP_ID       = 0xABCDEF;
+    bytes32 constant FUNDS_OUT_BURN_ID_TYPEHASH = keccak256(
+        'UtexoFundsOutBurnId(address bridge,uint256 chainId,address token,address recipient,uint256 amount,uint256 sourceChainId,uint256 destinationChainId,bytes32 sourceAddressHash,bytes32 proofHash,bytes32 settlementDataHash)'
+    );
 
     // BtcRelay test data
     // RGB proof = two (height, commit) pairs. The source block (RGB burn/lock)
@@ -219,6 +222,33 @@ contract BridgeTest is Test {
         return abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT);
     }
 
+    /// @dev Mirror of `Bridge._deriveBurnId` so tests can build canonical
+    ///      `fundsOut` payloads after.
+    ///      The typehash is an internal formula/domain separator.
+    function _deriveBurnId(
+        address recipient_,
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory sourceAddress,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal view returns (uint256) {
+        return uint256(keccak256(abi.encode(
+            FUNDS_OUT_BURN_ID_TYPEHASH,
+            address(bridge),
+            block.chainid,
+            address(usdt0),
+            recipient_,
+            amount,
+            sourceChainId,
+            destinationChainId,
+            keccak256(bytes(sourceAddress)),
+            keccak256(proof),
+            keccak256(settlementData)
+        )));
+    }
+
     /// @dev Build `settlementData` for the reworked RgbSettlementModule, which
     ///      expects `(uint256[] operationIds, uint256[] amounts)` and checks
     ///      each id exists with an EXACTLY matching amount (no consumption).
@@ -259,6 +289,24 @@ contract BridgeTest is Test {
     ///      and make the external Bridge call. Keeps `vm.prank` / `vm.expectRevert`
     ///      working: the inner `bridge.fundsOut` is the next external call.
     function _fundsOut(
+        address recipient_,
+        uint256 amount,
+        uint256 /* burnId */,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory sourceAddress,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal returns (uint256 burnId) {
+        burnId = _deriveBurnId(
+            recipient_, amount, sourceChainId, destinationChainId, sourceAddress, proof, settlementData
+        );
+        _fundsOutWithBurnId(
+            recipient_, amount, burnId, sourceChainId, destinationChainId, sourceAddress, proof, settlementData
+        );
+    }
+
+    function _fundsOutWithBurnId(
         address recipient_,
         uint256 amount,
         uint256 burnId,
@@ -673,12 +721,16 @@ contract BridgeTest is Test {
         // call reaches the verifier instead.
         uint256 max = bridge.MAX_PROOF_LENGTH();
         bytes memory atMax = _bytesOfLength(max);
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 burnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, atMax, settlementData
+        );
 
         vm.prank(multisig);
         try bridge.fundsOut(IBridge.FundsOutParams(
-            recipient, AMOUNT, BURN_ID,
+            recipient, AMOUNT, burnId,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            atMax, _settlement(_ids(opId))
+            atMax, settlementData
         )) {
             // a decodable proof would succeed; this blob won't, so we don't
             // expect to land here — but if a future verifier accepts it, the
@@ -861,17 +913,23 @@ contract BridgeTest is Test {
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 burnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+
         vm.expectEmit(true, true, false, true);
         emit BridgeFundsOut(
-            recipient, AMOUNT, AMOUNT, 0, BURN_ID,
+            recipient, AMOUNT, AMOUNT, 0, burnId,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR
         );
 
         vm.prank(multisig);
         _fundsOut(
-            recipient, AMOUNT, BURN_ID,
+            recipient, AMOUNT, burnId,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_ids(opId))
+            proof, settlementData
         );
 
         assertEq(usdt0.balanceOf(recipient),       AMOUNT);
@@ -993,26 +1051,130 @@ contract BridgeTest is Test {
         bytes32 opId2 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(2));
 
         bytes32[] memory ids1 = _ids(opId1);
-        bytes32[] memory ids2 = _ids(opId2);
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlement(ids1);
+        uint256 burnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
 
         vm.prank(multisig);
         _fundsOut(
-            recipient, AMOUNT, BURN_ID,
+            recipient, AMOUNT, burnId,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(ids1)
+            proof, settlementData
         );
-        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burnId recorded');
+        assertTrue(bridge.consumedBurnIds(burnId), 'burnId recorded');
 
         // Second fundsOut with the same burnId — must revert before any
         // module mutation, leaving the second record untouched.
-        vm.expectRevert(abi.encodeWithSelector(IBridge.BurnIdAlreadyConsumed.selector, BURN_ID));
+        vm.expectRevert(abi.encodeWithSelector(IBridge.BurnIdAlreadyConsumed.selector, burnId));
         vm.prank(multisig);
         _fundsOut(
-            recipient, AMOUNT, BURN_ID,
+            recipient, AMOUNT, burnId,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(ids2)
+            proof, settlementData
         );
         assertEq(rgbModule.fundsInRecords(opId2), AMOUNT, 'second fundsIn record preserved');
+    }
+
+    function test_fundsOut_revertsOnInvalidDerivedBurnId() public {
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 expectedBurnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+        uint256 invalidBurnId = expectedBurnId ^ 1;
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IBridge.InvalidBurnId.selector, invalidBurnId, expectedBurnId
+        ));
+        vm.prank(multisig);
+        _fundsOutWithBurnId(
+            recipient,
+            AMOUNT,
+            invalidBurnId,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            proof,
+            settlementData
+        );
+
+        assertFalse(bridge.consumedBurnIds(expectedBurnId), 'expected burn id unchanged');
+        assertFalse(bridge.consumedBurnIds(invalidBurnId), 'invalid burn id unchanged');
+    }
+
+    function test_fundsOut_revertsWhenProofChangesAfterBurnIdDerivation() public {
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        bytes memory signedProof = _proof();
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 signedBurnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, signedProof, settlementData
+        );
+
+        bytes memory changedProof =
+            abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, keccak256('changed-proof'));
+        uint256 expectedBurnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, changedProof, settlementData
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IBridge.InvalidBurnId.selector, signedBurnId, expectedBurnId
+        ));
+        vm.prank(multisig);
+        _fundsOutWithBurnId(
+            recipient,
+            AMOUNT,
+            signedBurnId,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            changedProof,
+            settlementData
+        );
+
+        assertFalse(bridge.consumedBurnIds(signedBurnId), 'signed burn id unchanged');
+    }
+
+    function test_fundsOut_revertsWhenSettlementDataChangesAfterBurnIdDerivation() public {
+        vm.prank(user);
+        bytes32 opId1 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(1));
+        vm.prank(user);
+        bytes32 opId2 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(2));
+
+        bytes memory proof = _proof();
+        bytes memory signedSettlementData = _settlement(_ids(opId1));
+        bytes memory changedSettlementData = _settlement(_ids(opId2));
+        uint256 signedBurnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, signedSettlementData
+        );
+        uint256 expectedBurnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, changedSettlementData
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IBridge.InvalidBurnId.selector, signedBurnId, expectedBurnId
+        ));
+        vm.prank(multisig);
+        _fundsOutWithBurnId(
+            recipient,
+            AMOUNT,
+            signedBurnId,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            proof,
+            changedSettlementData
+        );
+
+        assertFalse(bridge.consumedBurnIds(signedBurnId), 'signed burn id unchanged');
+        assertEq(rgbModule.fundsInRecords(opId1), AMOUNT, 'first record unchanged');
+        assertEq(rgbModule.fundsInRecords(opId2), AMOUNT, 'second record unchanged');
     }
 
     function test_fundsOut_revertsOnDoubleSpendsConsumedFundsIn() public {
@@ -1035,6 +1197,10 @@ contract BridgeTest is Test {
         // does). The settlement module no longer consumes records (the mint
         // proof is permanent and would still pass), so the liquidity guard is
         // now the sole backstop against re-releasing a spent deposit.
+        bytes32 altLatestCommit = keccak256('test-btc-alt-latest-commitment');
+        btcRelay.setBlock(LATEST_HEIGHT + 1, altLatestCommit, LATEST_CONFIRMATIONS);
+        bytes memory altProof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT + 1, altLatestCommit);
+
         vm.expectRevert(abi.encodeWithSelector(
             IBridge.InsufficientChainLiquidity.selector, RGB_CHAIN_ID, AMOUNT, uint256(0)
         ));
@@ -1042,7 +1208,7 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient, AMOUNT, BURN_ID + 1,
             RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
-            _proof(), _settlement(_ids(opId))
+            altProof, _settlement(_ids(opId))
         );
     }
 
@@ -1261,8 +1427,18 @@ contract BridgeTest is Test {
         vm.warp(block.timestamp + 1); // one second later
 
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), rate, 'only refillRate accrued, not a fresh cap');
+        bytes32 altLatestCommit = keccak256('test-btc-short-gap-latest-commitment');
+        btcRelay.setBlock(LATEST_HEIGHT + 1, altLatestCommit, LATEST_CONFIRMATIONS);
+        bytes memory altProof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT + 1, altLatestCommit);
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = _seedOpId;
+
         vm.expectPartialRevert(OutflowRateLimiter.TokenOutflowThrottled.selector);
-        _releaseRGB(cap, BURN_ID + 1);
+        vm.prank(multisig);
+        _fundsOut(
+            recipient, cap, BURN_ID + 1, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            altProof, _settlementWithAmounts(ids, _one(_seedAmt))
+        );
     }
 
     function test_outflow_perChainIsolation() public {
@@ -1833,7 +2009,13 @@ contract BridgeTest is Test {
         assertEq(cmPoolBefore,     0,      'pre cm pool');
         assertEq(nativePoolBefore, 0,      'pre native pool');
         assertEq(recordBefore,     AMOUNT, 'pre record');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlement(ids);
+        uint256 burnId = _deriveBurnId(
+            recipient, releaseAmount, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+        assertFalse(bridge.consumedBurnIds(burnId), 'pre burn id');
 
         vm.expectEmit(true, true, false, true);
         emit BridgeFundsOut(
@@ -1841,7 +2023,7 @@ contract BridgeTest is Test {
             releaseAmount,
             netAmount,
             tokenCommission,
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
@@ -1855,15 +2037,15 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient,
             releaseAmount,
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR,
-            _proof(),
-            _settlement(ids)
+            proof,
+            settlementData
         );
 
-        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
+        assertTrue(bridge.consumedBurnIds(burnId), 'burn id consumed');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore - releaseAmount, 'bridge gross debit');
         assertEq(usdt0.balanceOf(recipient),       recipientBefore + netAmount,  'recipient net delta');
         assertEq(usdt0.balanceOf(address(cm)),     cmBefore + tokenCommission,   'cm fee delta');
@@ -1995,8 +2177,12 @@ contract BridgeTest is Test {
         uint256 cmPoolBefore     = cm.tokenCommissionPool(address(usdt0));
         uint256 nativePoolBefore = cm.nativeCommissionPool();
         uint256 recordBefore     = rgbModule.fundsInRecords(opId);
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 burnId = _deriveBurnId(
+            recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, badProof, settlementData
+        );
 
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(burnId), 'pre burn id');
         assertEq(bridgeBefore, AMOUNT, 'pre bridge pool');
         assertEq(recipientBefore, 0, 'pre recipient token');
         assertEq(cmBefore, 0, 'pre cm token');
@@ -2012,15 +2198,15 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient,
             AMOUNT,
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR,
             badProof,
-            _settlement(_ids(opId))
+            settlementData
         );
 
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'burn id unchanged');
+        assertFalse(bridge.consumedBurnIds(burnId), 'burn id unchanged');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, 'bridge token unchanged');
         assertEq(usdt0.balanceOf(recipient),       recipientBefore, 'recipient token unchanged');
         assertEq(usdt0.balanceOf(address(cm)),     cmBefore, 'cm token unchanged');
@@ -2052,8 +2238,13 @@ contract BridgeTest is Test {
         uint256 nativePoolBefore = cm.nativeCommissionPool();
         uint256 record1Before    = rgbModule.fundsInRecords(opId1);
         uint256 record2Before    = rgbModule.fundsInRecords(opId2);
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlementWithAmounts(ids, badAmounts);
+        uint256 burnId = _deriveBurnId(
+            recipient, releaseAmount, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
 
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(burnId), 'pre burn id');
         assertEq(bridgeBefore, amount1 + amount2, 'pre bridge pool');
         assertEq(recipientBefore, 0, 'pre recipient token');
         assertEq(cmBefore, 0, 'pre cm token');
@@ -2072,15 +2263,15 @@ contract BridgeTest is Test {
         _fundsOut(
             recipient,
             releaseAmount,
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR,
-            _proof(),
-            _settlementWithAmounts(ids, badAmounts)
+            proof,
+            settlementData
         );
 
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'burn id unchanged');
+        assertFalse(bridge.consumedBurnIds(burnId), 'burn id unchanged');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, 'bridge token unchanged');
         assertEq(usdt0.balanceOf(recipient),       recipientBefore, 'recipient token unchanged');
         assertEq(usdt0.balanceOf(address(cm)),     cmBefore, 'cm token unchanged');
@@ -2093,15 +2284,15 @@ contract BridgeTest is Test {
     // Current behavior reproduction
     // ========================================================================
 
-    function test_fundsOutAcceptsProofNotBoundToReleaseContext_currentBehavior() public {
+    function test_fundsOutVerifierProofStillNotRouteContextAware_currentBehavior() public {
         address alternateRecipient = makeAddr('alternateRecipient');
         uint256 releaseAmount = 37e18;
-        uint256 alternateBurnId = BURN_ID + 777;
         // R-C-01 (isolated liquidity + outflow limit) gates the `sourceChainId`
         // dimension: a release can only draw from a funded + rate-limited source
-        // chain. So this reproduction keeps the source on the funded RGB chain
-        // and shows the *remaining* unbound dimensions — recipient, amount,
-        // burnId and destinationChainId are still not bound to the verifier proof.
+        // chain. So this reproduction keeps the source on the funded RGB chain.
+        // R-M-01 now binds the release intent and exact proof into burnId, but
+        // RGBVerifier itself still validates only BTC block commitments; it does
+        // not parse route/business context from the proof.
         uint256 alternateSourceChainId = RGB_CHAIN_ID;
         uint256 alternateDestinationChainId = SOURCE_CHAIN_ID + 77;
         string memory alternateSourceAddress = 'rgb:unbound/source/utxo999';
@@ -2125,21 +2316,30 @@ contract BridgeTest is Test {
         assertEq(bridgeBefore, AMOUNT, 'pre bridge pool');
         assertEq(recipientBefore, 0, 'pre recipient token');
         assertEq(recordBefore, AMOUNT, 'pre record');
-        assertFalse(bridge.consumedBurnIds(alternateBurnId), 'pre burn id');
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlement(_ids(opId));
+        uint256 burnId = _deriveBurnId(
+            alternateRecipient,
+            releaseAmount,
+            alternateSourceChainId,
+            alternateDestinationChainId,
+            alternateSourceAddress,
+            proof,
+            settlementData
+        );
+        assertFalse(bridge.consumedBurnIds(burnId), 'pre burn id');
 
-        // Current behavior: this is still an authorized fundsOut call, but the
-        // RGBVerifier checks only the encoded BTC block commitment proof. The
-        // record was created on the default route and the release is accepted on
-        // this alternate enabled route because the proof is not bound to release
-        // context on-chain. If that binding is enforced later, invert this to
-        // expect a revert.
+        // Current verifier behavior: this is an authorized fundsOut call with a
+        // matching Bridge-derived burnId, but RGBVerifier checks only the encoded
+        // BTC block commitments. If the RGB proof later carries enough context
+        // for verifier-level binding, invert this to expect a verifier revert.
         vm.expectEmit(true, true, false, true, address(bridge));
         emit BridgeFundsOut(
             alternateRecipient,
             releaseAmount,
             releaseAmount,
             0,
-            alternateBurnId,
+            burnId,
             alternateSourceChainId,
             alternateDestinationChainId,
             alternateSourceAddress
@@ -2149,15 +2349,15 @@ contract BridgeTest is Test {
         _fundsOut(
             alternateRecipient,
             releaseAmount,
-            alternateBurnId,
+            burnId,
             alternateSourceChainId,
             alternateDestinationChainId,
             alternateSourceAddress,
-            _proof(),
-            _settlement(_ids(opId))
+            proof,
+            settlementData
         );
 
-        assertTrue(bridge.consumedBurnIds(alternateBurnId), 'burn id consumed');
+        assertTrue(bridge.consumedBurnIds(burnId), 'burn id consumed');
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore - releaseAmount, 'bridge debit');
         assertEq(usdt0.balanceOf(alternateRecipient), recipientBefore + releaseAmount, 'recipient credited');
         assertEq(rgbModule.fundsInRecords(opId), recordBefore, 'record unchanged (proof-of-mint permanent)');

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -20,6 +20,7 @@ import {
 } from '../src/interfaces/ICommissionManager.sol';
 
 import { MockERC20 }        from './mocks/MockERC20.sol';
+import { FeeOnTransferERC20 } from './mocks/FeeOnTransferERC20.sol';
 import { MockBtcRelay }     from './mocks/MockBtcRelay.sol';
 import { MockAggregatorV3 } from './mocks/MockAggregatorV3.sol';
 import { MockSettlementModule } from './mocks/MockSettlementModule.sol';
@@ -1662,6 +1663,31 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId),           expectedNet,         'record = net');
     }
 
+    // R-I-04 end-to-end: a token already donated directly to the CommissionManager
+    // is NOT absorbed as commission. Bridge measures the delta of its own transfer,
+    // so the pool grows by exactly the real fee; the donation stays a stray balance.
+    function test_fundsIn_tokenCommission_doesNotAbsorbCmDonation_afterFix() public {
+        _setFundsInTokenRule(400); // 4%
+        uint256 expectedCommission = (AMOUNT * 400) / 100 / 100;
+
+        // Unsolicited direct transfer into the CommissionManager.
+        address donor = makeAddr('cmDonor');
+        uint256 donation = 5e18;
+        usdt0.mint(donor, donation);
+        vm.prank(donor);
+        usdt0.transfer(address(cm), donation);
+
+        assertEq(cm.tokenCommissionPool(address(usdt0)), 0,        'pre pool (donation not counted)');
+        assertEq(usdt0.balanceOf(address(cm)),           donation, 'pre cm balance holds donation');
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        // Pool grew by exactly the real commission — the donation was not folded in.
+        assertEq(cm.tokenCommissionPool(address(usdt0)), expectedCommission,            'pool grew only by real commission');
+        assertEq(usdt0.balanceOf(address(cm)),           donation + expectedCommission, 'donation still present as stray balance');
+    }
+
     // ========================================================================
     // Commission — fundsIn NATIVE
     // ========================================================================
@@ -1742,37 +1768,47 @@ contract BridgeTest is Test {
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
-    function test_nativeValueMismatchRejectsSmallOverpay_currentBehavior() public {
+    // R-I-03 after-fix: a native overpayment (favorable ETH/USD drift between
+    // quote and execution) is now accepted; the FULL msg.value is collected as
+    // commission (not refunded, not stranded) and the deposit completes.
+    function test_fundsIn_nativeOverpayAcceptedAndCollected_afterFix() public {
         _setFundsInNativeRule(100);
 
         (, uint256 nativeCommission,) =
             cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
         assertGt(nativeCommission, 0, 'native fee quoted');
 
-        vm.deal(user, nativeCommission + 1);
+        uint256 sent = nativeCommission + 0.01 ether; // overpay (price moved down)
+        vm.deal(user, sent);
 
-        uint256 userTokenBefore   = usdt0.balanceOf(user);
-        uint256 bridgeTokenBefore = usdt0.balanceOf(address(bridge));
-        uint256 cmNativeBefore    = address(cm).balance;
-        uint256 nativePoolBefore  = cm.nativeCommissionPool();
-        // The deposit reverts, so no record is created under the id it would derive.
-        bytes32 expectedOpId = _deriveOpId(
-            SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
-        );
-        uint256 recordBefore      = rgbModule.fundsInRecords(expectedOpId);
+        uint256 cmNativeBefore   = address(cm).balance;
+        uint256 nativePoolBefore = cm.nativeCommissionPool();
 
-        // Current behavior: native fundsIn requires exact msg.value. Even a
-        // 1-wei overpay reverts before token pull, commission credit, or RGB
-        // settlement bookkeeping.
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn{ value: sent }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        // Full msg.value collected as commission — surplus neither refunded nor
+        // left in the Bridge.
+        assertEq(address(cm).balance,       cmNativeBefore + sent,   'cm received full msg.value');
+        assertEq(cm.nativeCommissionPool(), nativePoolBefore + sent, 'native pool credited full msg.value');
+        assertEq(address(bridge).balance,   0,                       'no native stranded in bridge');
+        // Deposit completed: RGB record created (NATIVE rule → token commission 0, net == gross).
+        assertEq(rgbModule.fundsInRecords(opId), AMOUNT, 'deposit recorded from actual amount');
+    }
+
+    // R-I-03: underpaying the freshly-quoted native commission (price moved up)
+    // still reverts — the lower bound is enforced.
+    function test_fundsIn_nativeUnderpayReverts_afterFix() public {
+        _setFundsInNativeRule(100);
+
+        (, uint256 nativeCommission,) =
+            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
+        assertGt(nativeCommission, 1, 'native fee quoted');
+
+        vm.deal(user, nativeCommission);
         vm.expectRevert(IBridge.NativeValueMismatch.selector);
         vm.prank(user);
-        bridge.fundsIn{ value: nativeCommission + 1 }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
-
-        assertEq(usdt0.balanceOf(user),           userTokenBefore,   'user token unchanged');
-        assertEq(usdt0.balanceOf(address(bridge)), bridgeTokenBefore, 'bridge token unchanged');
-        assertEq(address(cm).balance,             cmNativeBefore,    'cm native unchanged');
-        assertEq(cm.nativeCommissionPool(),       nativePoolBefore,  'native pool unchanged');
-        assertEq(rgbModule.fundsInRecords(expectedOpId), recordBefore, 'record unchanged');
+        bridge.fundsIn{ value: nativeCommission - 1 }(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
     // ========================================================================
@@ -2496,7 +2532,10 @@ contract BridgeTest is Test {
     // Current behavior: Bridge calls the settlement hook after pulling gross
     // funds but before forwarding token commission, so a hook can observe funds
     // that will not remain as Bridge liquidity after the call.
-    function test_onFundsInHookSeesBalanceIncludingFutureCommission_currentBehavior() public {
+    // R-W-17 after-fix: the token commission is forwarded before the onFundsIn
+    // hook, so a settlement module reading getContractBalance during the hook
+    // observes only the net the Bridge retains — never the in-flight commission.
+    function test_onFundsInHookSeesNetBalanceNotFutureCommission_afterFix() public {
         uint256 percent = 400; // 4%
         _setFundsInTokenRule(percent);
 
@@ -2555,8 +2594,8 @@ contract BridgeTest is Test {
         assertEq(observingModule.lastNetAmount(), netAmount, 'module got net amount');
         assertEq(
             observingModule.lastObservedBalanceOnFundsIn(),
-            bridgeBefore + AMOUNT,
-            'hook saw gross bridge balance'
+            bridgeBefore + netAmount,
+            'hook sees only the retained net, not the in-flight commission'
         );
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore + netAmount, 'final bridge net');
         assertEq(usdt0.balanceOf(address(cm)), cmBefore + tokenCommission, 'cm token delta');
@@ -2917,5 +2956,257 @@ contract BridgeTest is Test {
         );
 
         assertEq(usdt0.balanceOf(recipient), AMOUNT, 'release via derived id succeeds');
+    }
+
+    // ========================================================================
+    // fee-on-transfer safe ingress accounting
+    //
+    // `_fundsIn` credits the ledger from the ACTUAL amount received
+    // (balanceAfter - balanceBefore), not the nominal `amount`. For a
+    // fee-on-transfer token the bridge receives less than `amount`, so the
+    // record / lockedLiquidity / events must reflect `received - tokenCommission`
+    // and never the nominal figure (which would overstate the ledger and later
+    // brick the release with AmountExceedBridgePool).
+    //
+    // These tests build a full parallel stack whose Bridge TOKEN is a
+    // FeeOnTransferERC20, mirroring setUp() exactly (same predicted-bridge nonce
+    // math, CM, RouteRegistry, verifier reuse of `btcRelay`, module, both routes,
+    // feed, outflow limits, ownership transfer+accept, user funding).
+    // ========================================================================
+
+    struct FeeStack {
+        Bridge              bridge;
+        FeeOnTransferERC20  token;
+        RgbSettlementModule module;
+        CommissionManager   cm;
+    }
+
+    /// @dev Deploy a full parallel bridge stack backed by a fee-on-transfer
+    ///      token. Mirrors setUp() one-for-one. The RGB verifier / `btcRelay` /
+    ///      `_proof()` are shared (the source-block relay data is identical).
+    function _deployFeeStack(uint256 feeBps) internal returns (FeeStack memory s) {
+        s.token = new FeeOnTransferERC20('Fee USDT0', 'fUSDT0', feeBps);
+
+        vm.startPrank(deployer);
+        uint64  currentNonce    = vm.getNonce(deployer);
+        address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
+
+        s.cm = new CommissionManager(predictedBridge);
+        RouteRegistry feeRouteRegistry = new RouteRegistry(predictedBridge, deployer);
+        s.bridge = new Bridge(
+            address(s.token),
+            address(feeRouteRegistry),
+            payable(address(s.cm)),
+            address(0),
+            1
+        );
+
+        // Reuse the suite's RGB verifier (shares `btcRelay` + `_proof()`); a
+        // fresh module is bound to this stack's route registry.
+        s.module = new RgbSettlementModule(address(feeRouteRegistry));
+
+        feeRouteRegistry.setRoute(
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID,
+            true, address(rgbVerifier), address(s.module)
+        );
+        feeRouteRegistry.setRoute(
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID,
+            true, address(rgbVerifier), address(s.module)
+        );
+
+        s.cm.setEthUsdFeed(address(ethUsdFeed), 1 hours);
+
+        s.bridge.setOutflowLimit(RGB_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
+        s.bridge.setGlobalOutflowLimit(1_000_000 ether, uint256(1_000_000 ether) / 1 days);
+
+        s.bridge.transferOwnership(multisig);
+        vm.stopPrank();
+
+        vm.prank(multisig);
+        s.bridge.acceptOwnership();
+
+        // Fund `user` generously and approve the fee bridge. `mint` is untaxed,
+        // so `user` holds exactly the minted amount.
+        s.token.mint(user, AMOUNT * 10);
+        vm.prank(user);
+        s.token.approve(address(s.bridge), type(uint256).max);
+    }
+
+    /// @dev Set a FUNDS_IN TOKEN commission rule on a fee stack's CM for the
+    ///      (SOURCE_CHAIN_ID → RGB_CHAIN_ID) route.
+    function _setFeeStackFundsInTokenRule(
+        FeeStack memory s,
+        uint256 stablePercent,
+        uint8   multiplier
+    ) internal {
+        vm.prank(deployer);
+        s.cm.setCommissionRule(
+            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(s.token),
+            CommissionConfig({
+                stablePercent: stablePercent,
+                multiplier: multiplier,
+                side: CommissionSide.FUNDS_IN,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+    }
+
+    /// @dev Burn-id derivation bound to a fee stack's Bridge + token (the shared
+    ///      `_deriveBurnId` binds the setUp `bridge`/`usdt0`).
+    function _deriveBurnIdFor(
+        FeeStack memory s,
+        address recipient_,
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory sourceAddress,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal view returns (uint256) {
+        return uint256(keccak256(abi.encode(
+            FUNDS_OUT_BURN_ID_TYPEHASH,
+            address(s.bridge),
+            block.chainid,
+            address(s.token),
+            recipient_,
+            amount,
+            sourceChainId,
+            destinationChainId,
+            keccak256(bytes(sourceAddress)),
+            keccak256(proof),
+            keccak256(settlementData)
+        )));
+    }
+
+    // --- Record/ledger/event use ACTUAL received, not nominal ---
+
+    function test_fundsIn_feeToken_creditsActualReceivedNotNominal() public {
+        FeeStack memory s = _deployFeeStack(100); // 1% fee, no commission rule
+
+        uint256 received = AMOUNT - s.token.feeOn(AMOUNT);
+        assertLt(received, AMOUNT, 'sanity: fee token delivers less than nominal');
+
+        bytes32 sourceSender = bytes32(uint256(uint160(user)));
+
+        // BridgeFundsIn must carry gross `amount == AMOUNT` and `netAmount == received`.
+        vm.expectEmit(true, true, false, true);
+        emit FundsIn(user, RGB_OP_ID, received);
+        vm.expectEmit(false, true, true, true);
+        emit BridgeFundsIn(
+            bytes32(0), sourceSender, user, 0, AMOUNT, received, 0, 0, SOURCE_CHAIN_ID, RGB_CHAIN_ID, DST_ADDR
+        );
+
+        vm.prank(user);
+        bytes32 opId = s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(s.module.fundsInRecords(opId), received, 'record credits actual received');
+        assertEq(s.bridge.lockedLiquidity(RGB_CHAIN_ID), received, 'lockedLiquidity credits actual received');
+        assertEq(s.token.balanceOf(address(s.bridge)), received, 'bridge token balance == received');
+    }
+
+    // --- With a TOKEN commission the ledger is not overstated ---
+
+    function test_fundsIn_feeToken_ledgerNotOverstatedWithCommission() public {
+        FeeStack memory s = _deployFeeStack(100); // 1% transfer fee
+        // 4% FUNDS_IN TOKEN commission rule (stablePercent 400, multiplier 100).
+        _setFeeStackFundsInTokenRule(s, 400, 100);
+
+        uint256 received        = AMOUNT - s.token.feeOn(AMOUNT);
+        // Commission is quoted from the NOMINAL amount.
+        uint256 tokenCommission = s.cm.calculateStableFee(AMOUNT, 400, 100);
+        assertGt(tokenCommission, 0, 'sanity: non-zero commission');
+
+        vm.prank(user);
+        s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        // Ledger credited from actual received minus the (nominal-quoted) commission.
+        assertEq(
+            s.bridge.lockedLiquidity(RGB_CHAIN_ID),
+            received - tokenCommission,
+            'lockedLiquidity == received - tokenCommission'
+        );
+
+        // The Bridge→CM commission hop is itself taxed by the fee token, so the
+        // CM credits by its own balance delta: tokenCommission - feeOn(tokenCommission).
+        assertEq(
+            s.cm.tokenCommissionPool(address(s.token)),
+            tokenCommission - s.token.feeOn(tokenCommission),
+            'CM pool credited by its own balance delta'
+        );
+
+        // No overstate: the bridge's retained token balance equals the credited
+        // lockedLiquidity exactly (bridge sent `tokenCommission` out to the CM).
+        uint256 bridgeRetained = s.token.balanceOf(address(s.bridge));
+        assertEq(bridgeRetained, received - tokenCommission, 'bridge retained == lockedLiquidity');
+        assertEq(
+            s.bridge.lockedLiquidity(RGB_CHAIN_ID),
+            bridgeRetained,
+            'lockedLiquidity + bridge-retained invariant: credited == held'
+        );
+    }
+
+    // --- The recorded (actual) amount is releasable via fundsOut ---
+
+    function test_fundsOut_feeToken_recordedAmountIsReleasable() public {
+        FeeStack memory s = _deployFeeStack(100); // 1% fee, no commission
+
+        uint256 received = AMOUNT - s.token.feeOn(AMOUNT);
+
+        vm.prank(user);
+        bytes32 opId = s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        assertEq(s.module.fundsInRecords(opId), received, 'record == actual received');
+
+        // Release EXACTLY the recorded amount. Before the fix the record would
+        // have been the nominal AMOUNT (> bridge balance `received`) and the
+        // release would revert AmountExceedBridgePool.
+        bytes memory proof          = _proof();
+        bytes memory settlementData = _settlementWithAmounts(_ids(opId), _one(received));
+        uint256 burnId = _deriveBurnIdFor(
+            s, recipient, received, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+
+        uint256 recipientBefore = s.token.balanceOf(recipient);
+
+        vm.prank(multisig);
+        s.bridge.fundsOut(IBridge.FundsOutParams(
+            recipient, received, burnId,
+            RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR,
+            proof, settlementData
+        ));
+
+        // The outbound transfer is also taxed, so the recipient nets
+        // `received - feeOn(received)`. The payoff is that the release did NOT
+        // revert and value moved.
+        uint256 delta = s.token.balanceOf(recipient) - recipientBefore;
+        assertGt(delta, 0, 'recipient balance increased');
+        assertEq(delta, received - s.token.feeOn(received), 'recipient nets received minus outbound fee');
+        assertEq(s.bridge.lockedLiquidity(RGB_CHAIN_ID), 0, 'lockedLiquidity fully released');
+    }
+
+    // --- Received < tokenCommission reverts InsufficientReceived ---
+    //
+    // Fee = 9000 bps (90%) → received = 10% of AMOUNT = 10e18. The fee-shape
+    // guard caps the commission fraction at `stablePercent / multiplier^2`
+    // (stablePercent ≤ 9000, stablePercent ≤ multiplier^2). Choosing
+    // multiplier = 95, stablePercent = 9000 yields a fraction 9000/9025 ≈ 99.7%,
+    // so the commission quote on the NOMINAL AMOUNT (~99.7e18) far exceeds the
+    // actual received (10e18) — configurable within the guard, so no boundary
+    // compromise is needed.
+    function test_fundsIn_feeToken_revertsWhenFeeExceedsCommission() public {
+        FeeStack memory s = _deployFeeStack(9000); // 90% transfer fee
+        _setFeeStackFundsInTokenRule(s, 9000, 95); // ~99.7% commission on nominal
+
+        uint256 received        = AMOUNT - s.token.feeOn(AMOUNT);
+        uint256 tokenCommission = s.cm.calculateStableFee(AMOUNT, 9000, 95);
+
+        assertEq(received, AMOUNT / 10, 'sanity: received == 10% of nominal');
+        assertGt(tokenCommission, received, 'sanity: commission exceeds actual received');
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IBridge.InsufficientReceived.selector, received, tokenCommission
+        ));
+        vm.prank(user);
+        s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 }

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -45,6 +45,8 @@ contract CommissionManagerTest is Test {
     );
     event EthUsdFeedUpdated(address indexed feed, uint256 heartbeat);
     event TokenCommissionReceived(address indexed token, uint256 amount);
+    event SequencerUptimeFeedUpdated(address indexed feed);
+    event EthUsdPriceBoundsUpdated(uint256 minPrice, uint256 maxPrice);
 
     function setUp() public {
         // Anvil starts at timestamp 1; warp past the heartbeat so staleness
@@ -144,16 +146,17 @@ contract CommissionManagerTest is Test {
         cm.convertTokenFeeToNative(1, 19);
     }
 
-    // Current behavior: native quote validation only requires a fresh positive
-    // Chainlink answer. There is no sequencer uptime feed or min/max bound, so
-    // a fresh outlier price is still used for conversion.
-    function test_nativeQuoteDoesNotCheckSequencerUptime_currentBehavior() public {
-        ethUsdFeed.setAnswer(1);
+    // With the min/max band UNSET (the default), a fresh positive answer is
+    // accepted no matter how extreme — which is exactly why an Arbitrum
+    // deployment configures `setEthUsdPriceBounds`. Band-enabled rejection is
+    // covered by test_convertTokenFeeToNative_revertsWhenPriceBelowMin/AboveMax.
+    function test_convertTokenFeeToNative_allowsOutlierWhenBandUnset() public {
+        ethUsdFeed.setAnswer(1); // $1e-8 — an extreme outlier
         ethUsdFeed.setUpdatedAt(block.timestamp);
 
         uint256 nativeFee = cm.convertTokenFeeToNative(1e18, 18);
 
-        assertEq(nativeFee, 1e26, 'fresh positive outlier accepted');
+        assertEq(nativeFee, 1e26, 'fresh outlier accepted while band is unset');
     }
 
     function test_buildRouteKey_matchesEncodeHash() public view {
@@ -693,62 +696,63 @@ contract CommissionManagerTest is Test {
 
         vm.prank(user);
         vm.expectRevert(ICommissionManager.OnlyBridge.selector);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
         assertEq(cm.tokenCommissionPool(address(token)), amt);
     }
 
     function test_receiveTokenCommission_revertsNothingReceived() public {
         vm.prank(BRIDGE);
         vm.expectRevert(ICommissionManager.NothingReceived.selector);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), 0);
     }
 
-    function test_receiveTokenCommission_revertsNothingReceived_whenNoNewTokens() public {
-        uint256 amt = 10 ether;
-        token.mint(address(cm), amt);
-        vm.startPrank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
-        vm.expectRevert(ICommissionManager.NothingReceived.selector);
-        cm.receiveTokenCommission(address(token));
-        vm.stopPrank();
+    // After the R-I-04 fix the pool is credited by the passed `credited`, not by
+    // balanceOf - pool. Crediting more than the on-chain balance can back reverts
+    // BalanceBelowRecordedPool (guards against over-crediting).
+    function test_receiveTokenCommission_revertsWhenCreditExceedsBalance() public {
+        token.mint(address(cm), 5 ether);
+        vm.prank(BRIDGE);
+        vm.expectRevert(ICommissionManager.BalanceBelowRecordedPool.selector);
+        cm.receiveTokenCommission(address(token), 6 ether);
     }
 
-    // Current behavior: token commission accounting records the whole balance
-    // delta since the last pool update, so unsolicited tokens already sitting
-    // in the CommissionManager are credited with the next bridge commission.
-    function test_unsolicitedTokenBalanceIncludedInNextCommissionCredit_currentBehavior() public {
+    // R-I-04 after-fix: an unsolicited direct transfer already sitting in the CM
+    // is NOT folded into the pool. The Bridge measures only its own transfer and
+    // passes that as `credited`; the donation stays as a stray balance.
+    function test_receiveTokenCommission_doesNotAbsorbUnsolicitedBalance_afterFix() public {
         uint256 unsolicitedAmount = 3 ether;
         uint256 legitimateAmount  = 7 ether;
-        uint256 expectedCredit    = unsolicitedAmount + legitimateAmount;
 
         token.mint(user, unsolicitedAmount);
         vm.prank(user);
-        token.transfer(address(cm), unsolicitedAmount);
+        token.transfer(address(cm), unsolicitedAmount); // donation
 
         token.mint(BRIDGE, legitimateAmount);
         vm.prank(BRIDGE);
-        token.transfer(address(cm), legitimateAmount);
+        token.transfer(address(cm), legitimateAmount); // the Bridge's transfer
 
-        assertEq(token.balanceOf(address(cm)), expectedCredit, 'pre cm token balance');
+        assertEq(token.balanceOf(address(cm)), unsolicitedAmount + legitimateAmount, 'pre cm token balance');
         assertEq(cm.tokenCommissionPool(address(token)), 0, 'pre cm pool');
 
+        // Bridge credits ONLY the amount its transfer actually delivered.
         vm.expectEmit(true, false, false, true, address(cm));
-        emit TokenCommissionReceived(address(token), expectedCredit);
+        emit TokenCommissionReceived(address(token), legitimateAmount);
 
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), legitimateAmount);
 
-        assertEq(cm.tokenCommissionPool(address(token)), expectedCredit, 'pool includes unsolicited balance');
+        assertEq(cm.tokenCommissionPool(address(token)), legitimateAmount, 'pool credited only the legit commission');
+        assertEq(token.balanceOf(address(cm)), unsolicitedAmount + legitimateAmount, 'donation stays as stray balance');
     }
 
     function test_withdrawTokenCommission_transfersAndUpdatesPool() public {
         uint256 amt = 50 ether;
         token.mint(address(cm), amt);
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(owner);
         cm.withdrawTokenCommission(address(token), recipient, amt);
@@ -761,7 +765,7 @@ contract CommissionManagerTest is Test {
         uint256 amt = 30 ether;
         token.mint(address(cm), amt);
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(owner);
         cm.withdrawAllTokenCommission(address(token), recipient);
@@ -873,5 +877,156 @@ contract CommissionManagerTest is Test {
                 'native fee formula'
             );
         }
+    }
+
+    // =========================================================================
+    // L2 sequencer-uptime gate + min/max price band
+    // =========================================================================
+
+    /// @dev The sequencer uptime feed is a standard AggregatorV3Interface;
+    ///      MockAggregatorV3 reports `startedAt == updatedAt`, so we drive
+    ///      `startedAt` via the constructor's `updatedAt` argument. `status`
+    ///      is the sequencer answer (0 = up, 1 = down).
+    function _sequencerFeed(int256 status, uint256 startedAt_) internal returns (MockAggregatorV3) {
+        return new MockAggregatorV3(0, status, startedAt_);
+    }
+
+    function _setSequencer(int256 status, uint256 startedAt_) internal returns (MockAggregatorV3 seq) {
+        seq = _sequencerFeed(status, startedAt_);
+        vm.prank(owner);
+        cm.setSequencerUptimeFeed(address(seq));
+    }
+
+    // --- sequencer uptime ---
+
+    function test_convertTokenFeeToNative_noSequencerCheckWhenUnset() public view {
+        // No sequencer feed wired (setUp does not set one) → quote works.
+        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    }
+
+    function test_convertTokenFeeToNative_revertsWhenSequencerDown() public {
+        _setSequencer(1, block.timestamp - 2 hours); // answer == 1 => down
+        vm.expectRevert(ICommissionManager.SequencerDown.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_revertsDuringGracePeriod() public {
+        // Up, but restarted this block → within the grace window.
+        _setSequencer(0, block.timestamp);
+        vm.expectRevert(ICommissionManager.GracePeriodNotOver.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_revertsAtGraceBoundary() public {
+        // Exactly at the grace period: `block.timestamp - startedAt == GRACE`,
+        // and the check is `<= GRACE`, so it still reverts.
+        _setSequencer(0, block.timestamp - cm.SEQUENCER_GRACE_PERIOD());
+        vm.expectRevert(ICommissionManager.GracePeriodNotOver.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_passesWhenSequencerUpPastGrace() public {
+        _setSequencer(0, block.timestamp - cm.SEQUENCER_GRACE_PERIOD() - 1);
+        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14); // same as happy path
+    }
+
+    // --- min/max price band ---
+
+    function test_convertTokenFeeToNative_noBandWhenUnset() public view {
+        // No band configured in setUp → any positive fresh answer is accepted.
+        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    }
+
+    function test_convertTokenFeeToNative_revertsWhenPriceBelowMin() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        ethUsdFeed.setAnswer(999e8);              // below min
+        ethUsdFeed.setUpdatedAt(block.timestamp); // keep fresh so StalePrice doesn't mask it
+        vm.expectRevert(ICommissionManager.PriceOutOfBounds.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_revertsWhenPriceAboveMax() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        ethUsdFeed.setAnswer(100_001e8);          // above max
+        ethUsdFeed.setUpdatedAt(block.timestamp);
+        vm.expectRevert(ICommissionManager.PriceOutOfBounds.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_passesWithinBand() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        // DEFAULT_ETH_USD = 2000e8 sits inside the band.
+        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    }
+
+    function test_convertTokenFeeToNative_healthySequencerAndBandTogether() public {
+        _setSequencer(0, block.timestamp - cm.SEQUENCER_GRACE_PERIOD() - 1);
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    }
+
+    // --- setters ---
+
+    function test_setSequencerUptimeFeed_setsAndEmits() public {
+        address seq = makeAddr('seqFeed');
+        vm.expectEmit(true, false, false, false, address(cm));
+        emit SequencerUptimeFeedUpdated(seq);
+        vm.prank(owner);
+        cm.setSequencerUptimeFeed(seq);
+        assertEq(cm.sequencerUptimeFeed(), seq);
+    }
+
+    function test_setSequencerUptimeFeed_canDisableWithZero() public {
+        vm.prank(owner);
+        cm.setSequencerUptimeFeed(makeAddr('seqFeed'));
+        vm.prank(owner);
+        cm.setSequencerUptimeFeed(address(0));
+        assertEq(cm.sequencerUptimeFeed(), address(0));
+    }
+
+    function test_setSequencerUptimeFeed_onlyOwner() public {
+        vm.prank(user);
+        vm.expectRevert();
+        cm.setSequencerUptimeFeed(makeAddr('seqFeed'));
+    }
+
+    function test_setEthUsdPriceBounds_setsAndEmits() public {
+        vm.expectEmit(false, false, false, true, address(cm));
+        emit EthUsdPriceBoundsUpdated(1_000e8, 100_000e8);
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        assertEq(cm.ethUsdMinPrice(), 1_000e8);
+        assertEq(cm.ethUsdMaxPrice(), 100_000e8);
+    }
+
+    function test_setEthUsdPriceBounds_disableWithZeros() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(0, 0);
+        assertEq(cm.ethUsdMinPrice(), 0);
+        assertEq(cm.ethUsdMaxPrice(), 0);
+    }
+
+    function test_setEthUsdPriceBounds_revertsOnZeroMinWithNonZeroMax() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.InvalidPriceBounds.selector);
+        cm.setEthUsdPriceBounds(0, 100e8);
+    }
+
+    function test_setEthUsdPriceBounds_revertsWhenMinNotBelowMax() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.InvalidPriceBounds.selector);
+        cm.setEthUsdPriceBounds(100e8, 100e8);
+    }
+
+    function test_setEthUsdPriceBounds_onlyOwner() public {
+        vm.prank(user);
+        vm.expectRevert();
+        cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
     }
 }

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -208,6 +208,7 @@ contract IntegrationTest is Test {
             address(bridge),
             address(cm),
             enc, 2,
+            RGB_CHAIN_ID,
             fed, 2,
             commissionReceiver,
             TIMELOCK,
@@ -350,7 +351,7 @@ contract IntegrationTest is Test {
             settlementData
         );
 
-        uint256 outNonce    = proxy.teeNonce();
+        uint256 outNonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 outDeadline = block.timestamp + 1 hours;
         bytes32 outDigest   = MultisigHelper.digestTeeFundsOut(
             domainSep, params, outNonce, outDeadline

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -85,9 +85,11 @@ contract IntegrationTest is Test {
     uint256 constant FUNDS_OUT_PERCENT = 100;
     uint8   constant FUNDS_OUT_MULT    = 100;
 
-    uint256 constant BURN_ID   = 9_001;
     // Non-zero RGB OpId threaded through the RGB-route settlementData on fundsIn.
     uint256 constant RGB_OP_ID = 0xABCDEF;
+    bytes32 constant FUNDS_OUT_BURN_ID_TYPEHASH = keccak256(
+        'UtexoFundsOutBurnId(address bridge,uint256 chainId,address token,address recipient,uint256 amount,uint256 sourceChainId,uint256 destinationChainId,bytes32 sourceAddressHash,bytes32 proofHash,bytes32 settlementDataHash)'
+    );
 
     // RGB proof = two (height, commit) pairs: a deep source block (RGB
     // burn/lock) and a fresh latest block (relay head). gap = 6 - 1 = 5.
@@ -121,6 +123,30 @@ contract IntegrationTest is Test {
     // =========================================================================
     // Setup
     // =========================================================================
+
+    function _deriveBurnId(
+        address recipient_,
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory sourceAddress,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal view returns (uint256) {
+        return uint256(keccak256(abi.encode(
+            FUNDS_OUT_BURN_ID_TYPEHASH,
+            address(bridge),
+            block.chainid,
+            address(token),
+            recipient_,
+            amount,
+            sourceChainId,
+            destinationChainId,
+            keccak256(bytes(sourceAddress)),
+            keccak256(proof),
+            keccak256(settlementData)
+        )));
+    }
 
     function setUp() public {
         encA1 = vm.addr(encPk1); encA2 = vm.addr(encPk2); encA3 = vm.addr(encPk3);
@@ -308,14 +334,18 @@ contract IntegrationTest is Test {
 
         bytes memory proof          = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT);
         bytes memory settlementData = abi.encode(fundsInIds, fundsInAmounts);
+        string memory sourceAddress = 'rgb:sender/utxo1src';
+        uint256 burnId = _deriveBurnId(
+            recipient, netBridgedIn, RGB_CHAIN_ID, SOURCE_CHAIN_ID, sourceAddress, proof, settlementData
+        );
 
         IBridge.FundsOutParams memory params = IBridge.FundsOutParams(
             recipient,
             netBridgedIn,          // amount = full bridged pool from this deposit
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
-            'rgb:sender/utxo1src',
+            sourceAddress,
             proof,
             settlementData
         );
@@ -336,10 +366,10 @@ contract IntegrationTest is Test {
             netBridgedIn,
             netOut,
             tokenCommissionOut,
-            BURN_ID,
+            burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
-            'rgb:sender/utxo1src'
+            sourceAddress
         );
 
         proxy.fundsOutCall(params, outNonce, outDeadline, 3, teeSigs);
@@ -349,7 +379,7 @@ contract IntegrationTest is Test {
         assertEq(token.balanceOf(address(cm)),           tokenCommissionIn + tokenCommissionOut, 'cm accrued both fees');
         assertEq(cm.tokenCommissionPool(address(token)), tokenCommissionIn + tokenCommissionOut, 'cm pool mirrors');
         assertEq(rgbModule.fundsInRecords(opId),         netBridgedIn,                           'fundsIn record unchanged (permanent)');
-        assertTrue(bridge.consumedBurnIds(BURN_ID),                                              'burnId recorded');
+        assertTrue(bridge.consumedBurnIds(burnId),                                               'burnId recorded');
 
         // -------------------------------------------------------------------------
         // 4. Federation withdraws ERC-20 commission from CM to commissionReceiver.

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -68,8 +68,9 @@ contract MultisigProxyTest is Test {
     using MultisigHelper for bytes32;
 
     // ---- Re-declared events ------------------------------------------------
-    event FundsOutExecuted(uint256 indexed nonce, uint256 enclaveBitmap);
+    event FundsOutExecuted(uint256 indexed sourceChainId, uint256 indexed nonce, uint256 enclaveBitmap);
     event LzFundsOutExecuted(
+        uint256 indexed sourceChainId,
         uint256 indexed nonce,
         uint256 enclaveBitmap,
         uint32  dstEid,
@@ -88,7 +89,7 @@ contract MultisigProxyTest is Test {
     );
     event ProposalCancelled(bytes32 indexed proposalId);
     event ProposalExecuted(bytes32 indexed proposalId, IMultisigProxy.OperationType indexed opType);
-    event EnclaveSignersUpdated(address[] newSigners, uint256 newThreshold);
+    event EnclaveSignersUpdated(uint256 indexed sourceChainId, address[] newSigners, uint256 newThreshold);
     event FederationSignersUpdated(address[] newSigners, uint256 newThreshold);
     event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
@@ -244,6 +245,7 @@ contract MultisigProxyTest is Test {
             address(bridge),
             address(cm),
             enc, 2,
+            RGB_CHAIN_ID,
             fed, 2,
             commissionReceiver,
             TIMELOCK,
@@ -421,7 +423,7 @@ contract MultisigProxyTest is Test {
         view
         returns (uint256 nonce, uint256 bitmap, bytes[] memory sigs)
     {
-        nonce = proxy.teeNonce();
+        nonce = proxy.teeNonce(RGB_CHAIN_ID);
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
         uint256[] memory pks;
         (pks, bitmap) = _encSigSet2of3();
@@ -447,14 +449,14 @@ contract MultisigProxyTest is Test {
     function test_constructor_setsState() public view {
         assertEq(proxy.bridge(), address(bridge));
         assertEq(proxy.commissionManager(), address(cm));
-        assertEq(proxy.enclaveThreshold(), 2);
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), 2);
         assertEq(proxy.federationThreshold(), 2);
         assertEq(proxy.commissionRecipient(), commissionReceiver);
         assertEq(proxy.timelockDuration(), TIMELOCK);
         assertEq(proxy.proposalNonce(), 0);
-        assertEq(proxy.teeNonce(),      0);
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),      0);
 
-        address[] memory enc = proxy.getEnclaveSigners();
+        address[] memory enc = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(enc.length, 3);
         assertEq(enc[0], encA1);
 
@@ -466,38 +468,38 @@ contract MultisigProxyTest is Test {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroBridge.selector);
-        new MultisigProxy(address(0), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(0), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommissionManager() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionManager.selector);
-        new MultisigProxy(address(bridge), address(0), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(0), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnNoEnclaveSigners() public {
         address[] memory enc = new address[](0);
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.NoSigners.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnBadEnclaveThreshold() public {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 3, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 3, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommission() public {
         vm.expectRevert(IMultisigProxy.ZeroCommissionRecipient.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, address(0), TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, address(0), TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnTimelockTooLong() public {
         vm.expectRevert(IMultisigProxy.TimelockTooLong.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, 30 days, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, 30 days, MIN_TIMELOCK);
     }
 
     // ---- R-W-11: MIN_TIMELOCK floor (post-fix) ----
@@ -506,19 +508,19 @@ contract MultisigProxyTest is Test {
     function test_constructor_revertsOnTimelockBelowMinTimelock() public {
         // timelock (1h) is below the requested floor (2h) -> TimelockTooShort
         vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, 1 hours, 2 hours);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, 1 hours, 2 hours);
     }
 
     /// @dev A zero floor is rejected — it would defeat the purpose of the fix.
     function test_constructor_revertsOnZeroMinTimelock() public {
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, TIMELOCK, 0);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, 0);
     }
 
     /// @dev A floor at/above the upper bound leaves no valid range — rejected.
     function test_constructor_revertsOnMinTimelockTooLong() public {
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, TIMELOCK, 30 days);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, 30 days);
     }
 
     function test_minTimelock_returnsConfiguredFloor() public view {
@@ -530,7 +532,7 @@ contract MultisigProxyTest is Test {
         // the call clears the threshold guard and reverts in _validateSigners.
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA1;
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroAddressSigner() public {
@@ -539,7 +541,7 @@ contract MultisigProxyTest is Test {
         // _validateSigners.
         address[] memory enc = new address[](2); enc[0] = address(0); enc[1] = encA2;
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     // ========================================================================
@@ -574,41 +576,41 @@ contract MultisigProxyTest is Test {
 
     function test_constructor_rejectsOneOfThree_enclave() public {
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _signers(3), 1, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _signers(3), 1, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_rejectsOneOfOne_enclave() public {
         // n < 2 — single-key set, rejected even though 2*1 > 1.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _signers(1), 1, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _signers(1), 1, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_rejectsSubMajority_enclave() public {
         // 2-of-4: 2*2 == 4, not a strict majority.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _signers(4), 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _signers(4), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_rejectsOneOfThree_federation() public {
         // Enclave valid, federation 1-of-3 — the floor applies to both sets.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _signers(3), 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _signers(3), 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_acceptsTwoOfTwo() public {
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(2), 2, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(2), 2, RGB_CHAIN_ID, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.enclaveThreshold(),    2);
+        assertEq(p.enclaveThreshold(RGB_CHAIN_ID),    2);
         assertEq(p.federationThreshold(), 2);
     }
 
     function test_constructor_acceptsThreeOfFour() public {
         // Strict majority with a non-trivial set (2*3 > 4).
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(4), 3, _signersB(4), 3, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(4), 3, RGB_CHAIN_ID, _signersB(4), 3, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.enclaveThreshold(),    3);
+        assertEq(p.enclaveThreshold(RGB_CHAIN_ID),    3);
         assertEq(p.federationThreshold(), 3);
     }
 
@@ -621,14 +623,14 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, badThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, badThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         // Threshold validity is now enforced up front, at propose time.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, badThreshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, badThreshold, nonce, deadline, bitmap, sigs);
     }
 
     // ---- Intrinsic set validation runs at propose time ----
@@ -643,13 +645,13 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, threshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, threshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.NoSigners.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, threshold, nonce, deadline, bitmap, sigs);
     }
 
     function test_proposeUpdateEnclaveSigners_rejectsZeroAddressSignerAtPropose() public {
@@ -660,13 +662,13 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, threshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, threshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, threshold, nonce, deadline, bitmap, sigs);
     }
 
     function test_proposeUpdateEnclaveSigners_rejectsDuplicateSignerAtPropose() public {
@@ -677,13 +679,13 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, threshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, threshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, threshold, nonce, deadline, bitmap, sigs);
     }
 
     function test_proposeUpdateFederationSigners_rejectsEmptySetAtPropose() public {
@@ -752,14 +754,14 @@ contract MultisigProxyTest is Test {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
         address[] memory fed = new address[](2); fed[0] = encA1; fed[1] = fedA2;
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, encA1));
-        new MultisigProxy(address(bridge), address(cm), enc, 2, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_acceptsDisjointSignerSets() public {
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(2), 2, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(2), 2, RGB_CHAIN_ID, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.getEnclaveSigners().length,    2);
+        assertEq(p.getEnclaveSigners(RGB_CHAIN_ID).length,    2);
         assertEq(p.getFederationSigners().length, 2);
     }
 
@@ -771,16 +773,16 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, fedA1));
-        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        proxy.executeProposal(id, abi.encode(RGB_CHAIN_ID, newSigners, newThreshold));
     }
 
     function test_proposeUpdateFederationSigners_rejectsOverlapWithEnclaveAtExecute() public {
@@ -818,7 +820,7 @@ contract MultisigProxyTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
         new MultisigProxy(
-            address(bridge), address(cm), enc, encThreshold, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), enc, encThreshold, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
     }
 
@@ -827,9 +829,9 @@ contract MultisigProxyTest is Test {
         uint256 threshold = max / 2 + 1; // 11-of-20 strict majority
 
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(max), threshold, _signersB(max), threshold, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(max), threshold, RGB_CHAIN_ID, _signersB(max), threshold, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.getEnclaveSigners().length,    max);
+        assertEq(p.getEnclaveSigners(RGB_CHAIN_ID).length,    max);
         assertEq(p.getFederationSigners().length, max);
     }
 
@@ -841,14 +843,14 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         // Signer-set size is now enforced up front, at propose time.
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
-        proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
     }
 
     // ========================================================================
@@ -857,25 +859,25 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_releasesViaBridge() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        vm.expectEmit(true, false, false, true);
-        emit FundsOutExecuted(nonce, bitmap);
+        vm.expectEmit(true, true, false, true);
+        emit FundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap);
 
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
         assertEq(token.balanceOf(recipient), AMOUNT);
-        assertEq(proxy.teeNonce(), nonce + 1);
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1);
     }
 
     function test_fundsOutCall_revertsOnExpired() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp - 1;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -897,7 +899,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnDeadlineTooFar() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE() + 1;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -910,7 +912,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_acceptsDeadlineAtMaxBoundary() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE(); // exact boundary, strict `>` lets it through
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -928,7 +930,7 @@ contract MultisigProxyTest is Test {
         _setLzAdapter(address(adapter));
 
         IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE() + 1;
 
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
@@ -947,7 +949,7 @@ contract MultisigProxyTest is Test {
         _setLzAdapter(address(adapter));
 
         IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE(); // exact boundary
 
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
@@ -957,7 +959,7 @@ contract MultisigProxyTest is Test {
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
         assertEq(token.balanceOf(mockOft), AMOUNT, 'lz release executes at the exact deadline ceiling');
-        assertEq(proxy.teeNonce(),         nonce + 1, 'teeNonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),         nonce + 1, 'teeNonce incremented');
     }
 
     function test_fundsOutCall_revertsOnWrongNonce() public {
@@ -979,7 +981,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnBelowThreshold() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -992,7 +994,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnBadSignature() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -1007,7 +1009,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnSigCountMismatch() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -1021,7 +1023,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnBitmapOutOfRange() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -1034,7 +1036,7 @@ contract MultisigProxyTest is Test {
 
     function test_lzFundsOutCall_revertsIfAdapterUnset() public {
         IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
@@ -1050,7 +1052,7 @@ contract MultisigProxyTest is Test {
     // ========================================================================
 
     function test_emergencyPause_works() public {
-        uint256 nonce = proxy.proposalNonce();
+        uint256 nonce = proxy.emergencyNonce();
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
@@ -1063,11 +1065,12 @@ contract MultisigProxyTest is Test {
         proxy.emergencyPause(nonce, deadline, bitmap, sigs);
 
         assertTrue(bridge.paused());
-        assertEq(proxy.proposalNonce(), nonce + 1);
+        assertEq(proxy.emergencyNonce(), nonce + 1, 'emergency lane advanced');
+        assertEq(proxy.proposalNonce(), 0, 'proposal lane untouched by emergency');
     }
 
     function test_emergencyPause_revertsOnExpired() public {
-        uint256 nonce = proxy.proposalNonce();
+        uint256 nonce = proxy.emergencyNonce();
         uint256 deadline = block.timestamp - 1;
 
         bytes32 digest = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
@@ -1093,7 +1096,7 @@ contract MultisigProxyTest is Test {
     function test_emergencyUnpause_works() public {
         test_emergencyPause_works();
 
-        uint256 nonce = proxy.proposalNonce();
+        uint256 nonce = proxy.emergencyNonce();
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestEmergencyUnpause(domainSep, nonce, deadline);
@@ -1118,7 +1121,7 @@ contract MultisigProxyTest is Test {
     ///      must be frozen as well.
     function test_emergencyPause_freezesEnclaveFundsOut() public {
         // Federation triggers the emergency freeze (both paths).
-        uint256 nonce    = proxy.proposalNonce();
+        uint256 nonce    = proxy.emergencyNonce();
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 digest   = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
         (uint256[] memory fpks, uint256 fbitmap) = _fedSigSet2of3();
@@ -1135,7 +1138,7 @@ contract MultisigProxyTest is Test {
         // Enclave-signed release is frozen too — the revert propagates from
         // Bridge.fundsOut through proxy.fundsOutCall.
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 encNonce      = proxy.teeNonce();
+        uint256 encNonce      = proxy.teeNonce(RGB_CHAIN_ID);
         bytes32 encDigest     = MultisigHelper.digestTeeFundsOut(domainSep, params, encNonce, deadline);
         (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
         bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
@@ -1171,7 +1174,7 @@ contract MultisigProxyTest is Test {
 
         // ...but the enclave release still executes.
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 encNonce      = proxy.teeNonce();
+        uint256 encNonce      = proxy.teeNonce(RGB_CHAIN_ID);
         bytes32 encDigest     = MultisigHelper.digestTeeFundsOut(domainSep, params, encNonce, t + 1 days);
         (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
         bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
@@ -1294,20 +1297,20 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
-        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        proxy.executeProposal(id, abi.encode(RGB_CHAIN_ID, newSigners, newThreshold));
 
-        address[] memory after_ = proxy.getEnclaveSigners();
+        address[] memory after_ = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(after_.length, 2);
         assertEq(after_[1], newSigner);
-        assertEq(proxy.enclaveThreshold(), newThreshold);
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), newThreshold);
     }
 
     // ========================================================================
@@ -1557,8 +1560,8 @@ contract MultisigProxyTest is Test {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(encPk1, digest);
         bytes memory sig = abi.encodePacked(r, s, v);
 
-        assertTrue(proxy.verifyEnclaveSignature(digest, sig, 0));
-        assertFalse(proxy.verifyEnclaveSignature(digest, sig, 1));
+        assertTrue(proxy.verifyEnclaveSignature(RGB_CHAIN_ID, digest, sig, 0));
+        assertFalse(proxy.verifyEnclaveSignature(RGB_CHAIN_ID, digest, sig, 1));
     }
 
     function test_verifyEnclaveSignature_revertsOutOfRange() public {
@@ -1567,7 +1570,7 @@ contract MultisigProxyTest is Test {
         bytes memory sig = abi.encodePacked(r, s, v);
 
         vm.expectRevert(IMultisigProxy.IndexOutOfRange.selector);
-        proxy.verifyEnclaveSignature(digest, sig, 99);
+        proxy.verifyEnclaveSignature(RGB_CHAIN_ID, digest, sig, 99);
     }
 
     // ========================================================================
@@ -1952,7 +1955,7 @@ contract MultisigProxyTest is Test {
         // Sign a valid TEE fundsOut on the original chain (domainSep was cached
         // at setUp for block.chainid).
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -1995,7 +1998,7 @@ contract MultisigProxyTest is Test {
 
         // Prepare signed TEE execution and snapshot proxy + Bridge accounting.
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
@@ -2027,12 +2030,12 @@ contract MultisigProxyTest is Test {
             SOURCE_CHAIN_ID,
             SRC_ADDR
         );
-        vm.expectEmit(true, false, false, true);
-        emit FundsOutExecuted(nonce, bitmap);
+        vm.expectEmit(true, true, false, true);
+        emit FundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap);
 
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(), nonce + 1, 'nonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'nonce incremented');
         assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT,        'bridge gross debit');
         assertEq(token.balanceOf(recipient),       recipientBefore + netAmount, 'recipient net delta');
@@ -2124,13 +2127,13 @@ contract MultisigProxyTest is Test {
         );
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(), nonce + 1, 'tee nonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'tee nonce incremented');
         assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)),  bridgeBefore - AMOUNT,          'bridge gross debit');
         assertEq(token.balanceOf(address(cm)),      cmBefore + tokenCommission,     'cm fee delta');
@@ -2210,7 +2213,7 @@ contract MultisigProxyTest is Test {
         vm.expectRevert(bytes('native fee'));
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE - 1 }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce,            'tee nonce unchanged');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce,            'tee nonce unchanged');
         assertFalse(bridge.consumedBurnIds(params.burnId),          'burn id unchanged');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter token unchanged');
@@ -2295,7 +2298,7 @@ contract MultisigProxyTest is Test {
         vm.expectRevert(bytes('verify: block commitment'));
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce,            'tee nonce unchanged');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce,            'tee nonce unchanged');
         assertFalse(bridge.consumedBurnIds(params.burnId),          'burn id unchanged');
         assertEq(adapter.sendOutCalls(),           0,               'adapter not called');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
@@ -2387,13 +2390,13 @@ contract MultisigProxyTest is Test {
         );
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce + 1,        'tee nonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce + 1,        'tee nonce incremented');
         assertTrue(bridge.consumedBurnIds(params.burnId),            'burn id consumed');
         assertEq(adapter.sendOutCalls(),           1,               'adapter called once');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge token debit');
@@ -2486,13 +2489,13 @@ contract MultisigProxyTest is Test {
         );
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce + 1,        'tee nonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce + 1,        'tee nonce incremented');
         assertTrue(bridge.consumedBurnIds(params.burnId),            'burn id consumed');
         assertEq(adapter.sendOutCalls(),           1,               'adapter called once');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge token debit');
@@ -2627,7 +2630,7 @@ contract MultisigProxyTest is Test {
         // later, this test should be inverted to expect a revert.
         IBridge.FundsOutParams memory params = _fundsOutParams(drainRecipient, bridgeBefore, BURN_ID);
         assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
@@ -2644,12 +2647,12 @@ contract MultisigProxyTest is Test {
             SOURCE_CHAIN_ID,
             SRC_ADDR
         );
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit FundsOutExecuted(nonce, bitmap);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit FundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap);
 
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(), nonce + 1, 'nonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'nonce incremented');
         assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)), 0, 'bridge pool drained');
         assertEq(token.balanceOf(drainRecipient), recipientBefore + bridgeBefore, 'recipient got full pool');
@@ -2663,22 +2666,22 @@ contract MultisigProxyTest is Test {
         newSigners[2] = makeAddr('unattestedEnc3');
         uint256 newThreshold = 2;
 
-        address[] memory before_ = proxy.getEnclaveSigners();
+        address[] memory before_ = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(before_.length, 3, 'pre enclave count');
         assertEq(before_[0], encA1, 'pre signer 0');
         assertEq(before_[1], encA2, 'pre signer 1');
         assertEq(before_[2], encA3, 'pre signer 2');
-        assertEq(proxy.enclaveThreshold(), 2, 'pre enclave threshold');
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), 2, 'pre enclave threshold');
 
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
 
@@ -2686,19 +2689,19 @@ contract MultisigProxyTest is Test {
         // this case documents that only address shape and threshold are checked,
         // with no on-chain enclave attestation evidence. If attestation is
         // enforced later, this test should be inverted to expect a revert.
-        vm.expectEmit(false, false, false, true, address(proxy));
-        emit EnclaveSignersUpdated(newSigners, newThreshold);
+        vm.expectEmit(true, false, false, true, address(proxy));
+        emit EnclaveSignersUpdated(RGB_CHAIN_ID, newSigners, newThreshold);
         vm.expectEmit(true, true, false, true, address(proxy));
         emit ProposalExecuted(id, IMultisigProxy.OperationType.UpdateEnclaveSigners);
 
-        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        proxy.executeProposal(id, abi.encode(RGB_CHAIN_ID, newSigners, newThreshold));
 
-        address[] memory after_ = proxy.getEnclaveSigners();
+        address[] memory after_ = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(after_.length, 3, 'post enclave count');
         assertEq(after_[0], newSigners[0], 'post signer 0');
         assertEq(after_[1], newSigners[1], 'post signer 1');
         assertEq(after_[2], newSigners[2], 'post signer 2');
-        assertEq(proxy.enclaveThreshold(), newThreshold, 'post enclave threshold');
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), newThreshold, 'post enclave threshold');
     }
 
     function test_proposalUsesSnapshottedTimelock_afterFix() public {
@@ -2749,42 +2752,38 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.bridge(), newBridge, 'snapshotted proposal executes despite the live timelock raise');
     }
 
-    // Current behavior: emergency actions and regular proposals share
-    // proposalNonce, so an emergency pause can stale an already signed regular
-    // proposal before it is submitted on-chain.
-    function test_emergencyAndRegularProposalNonceCollide_currentBehavior() public {
+    // R-I-09 after-fix: emergency actions run on a separate `emergencyNonce`, so
+    // an emergency pause does NOT stale an already-signed regular proposal — the
+    // pre-signed proposal still submits.
+    function test_emergencyDoesNotStaleRegularProposal_afterFix() public {
         address newBridge = makeAddr('nonceCollisionBridge');
         uint256 regularNonce = proxy.proposalNonce();
         uint256 regularDeadline = block.timestamp + 1 days;
 
+        // Pre-sign a regular proposal at the current proposal-lane nonce.
         bytes32 regularDigest = MultisigHelper.digestProposeUpdateBridge(
             domainSep, newBridge, regularNonce, regularDeadline
         );
         (uint256[] memory regularPks, uint256 regularBitmap) = _fedSigSet2of3();
         bytes[] memory regularSigs = MultisigHelper.signAll(vm, regularDigest, regularPks);
 
-        uint256 emergencyDeadline = block.timestamp + 1 hours;
-        bytes32 emergencyDigest = MultisigHelper.digestEmergencyPause(domainSep, regularNonce, emergencyDeadline);
+        // An emergency pause runs on its own lane nonce.
+        uint256 emergencyLaneNonce = proxy.emergencyNonce();
+        uint256 emergencyDeadline  = block.timestamp + 1 hours;
+        bytes32 emergencyDigest = MultisigHelper.digestEmergencyPause(domainSep, emergencyLaneNonce, emergencyDeadline);
         (uint256[] memory emergencyPks, uint256 emergencyBitmap) = _fedSigSet2of3();
         bytes[] memory emergencySigs = MultisigHelper.signAll(vm, emergencyDigest, emergencyPks);
 
-        assertFalse(bridge.paused(), 'pre bridge active');
-        assertEq(proxy.proposalNonce(), regularNonce, 'pre proposal nonce');
-        assertEq(proxy.bridge(), address(bridge), 'pre bridge target');
-
-        vm.expectEmit(false, false, false, true, address(proxy));
-        emit EmergencyPaused(regularNonce, emergencyBitmap);
-
-        proxy.emergencyPause(regularNonce, emergencyDeadline, emergencyBitmap, emergencySigs);
+        proxy.emergencyPause(emergencyLaneNonce, emergencyDeadline, emergencyBitmap, emergencySigs);
 
         assertTrue(bridge.paused(), 'bridge paused by emergency action');
-        assertEq(proxy.proposalNonce(), regularNonce + 1, 'emergency consumed proposal nonce');
+        assertEq(proxy.emergencyNonce(), emergencyLaneNonce + 1, 'emergency advanced only its own lane');
+        assertEq(proxy.proposalNonce(), regularNonce, 'proposal lane untouched by emergency');
 
-        vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
-        proxy.proposeUpdateBridge(newBridge, regularNonce, regularDeadline, regularBitmap, regularSigs);
-
-        assertEq(proxy.proposalNonce(), regularNonce + 1, 'stale proposal leaves nonce unchanged');
-        assertEq(proxy.bridge(), address(bridge), 'stale proposal leaves bridge unchanged');
+        // The pre-signed regular proposal is still valid and submits successfully.
+        bytes32 id = proxy.proposeUpdateBridge(newBridge, regularNonce, regularDeadline, regularBitmap, regularSigs);
+        assertTrue(id != bytes32(0), 'regular proposal created despite the emergency action');
+        assertEq(proxy.proposalNonce(), regularNonce + 1, 'regular proposal consumed its lane nonce');
     }
 
     // Generic Bridge admin execution can still call
@@ -2884,72 +2883,483 @@ contract MultisigProxyTest is Test {
     // The typed commission-withdraw path pins the recipient to
     // commissionRecipient, while generic CM admin execution forwards arbitrary
     // calldata and lets the encoded withdrawal recipient win.
-    function test_adminExecuteCommissionManagerBypassesRecipientPin_currentBehavior() public {
-        address arbitraryRecipient = makeAddr('arbitraryCommissionRecipient');
+    // R-W-15 after-fix: the generic AdminExecuteCommissionManager path can no
+    // longer reach a commission-withdrawal selector, so it cannot re-point
+    // commission away from the pinned `commissionRecipient`. The guard fires at
+    // propose time (before signature verification), so no valid federation
+    // signatures are needed to observe it.
+    function test_adminExecuteCommissionManager_rejectsWithdrawSelectors_afterFix() public {
+        bytes[] memory callDatas = new bytes[](4);
+        callDatas[0] = abi.encodeWithSignature(
+            'withdrawTokenCommission(address,address,uint256)', address(token), user, uint256(1));
+        callDatas[1] = abi.encodeWithSignature(
+            'withdrawNativeCommission(address,uint256)', user, uint256(1));
+        callDatas[2] = abi.encodeWithSignature(
+            'withdrawAllTokenCommission(address,address)', address(token), user);
+        callDatas[3] = abi.encodeWithSignature(
+            'withdrawAllNativeCommission(address)', user);
 
-        vm.prank(address(proxy));
-        cm.setCommissionRule(
-            SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(token),
-            CommissionConfig({
-                stablePercent: 400, // 4%
-                multiplier: 100,
-                side: CommissionSide.FUNDS_IN,
-                currency: CommissionCurrency.TOKEN,
-                isSet: true
-            })
-        );
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes[] memory noSigs = new bytes[](0); // guard reverts before sig checks
 
-        uint256 depositAmount = 100e18;
-        vm.prank(user);
-        bridge.fundsIn(depositAmount, RGB_CHAIN_ID, DST_ADDR, abi.encode(RGB_OP_ID));
+        for (uint256 i = 0; i < callDatas.length; i++) {
+            vm.expectRevert(abi.encodeWithSelector(
+                IMultisigProxy.ForbiddenCommissionManagerSelector.selector, bytes4(callDatas[i])
+            ));
+            proxy.proposeAdminExecuteCommissionManager(callDatas[i], nonce, deadline, 0, noSigs);
+        }
+    }
 
-        uint256 expectedCommission = (depositAmount * 400) / 100 / 100;
-        uint256 poolBefore = cm.tokenCommissionPool(address(token));
-        uint256 pinnedRecipientBefore = token.balanceOf(commissionReceiver);
-        uint256 arbitraryRecipientBefore = token.balanceOf(arbitraryRecipient);
-
-        assertEq(poolBefore, expectedCommission, 'pre cm pool');
-        assertEq(pinnedRecipientBefore, 0, 'pre pinned recipient');
-        assertEq(arbitraryRecipientBefore, 0, 'pre arbitrary recipient');
-
+    // The generic path stays open for non-withdrawal CommissionManager setters.
+    function test_adminExecuteCommissionManager_allowsNonWithdrawSelector() public {
         bytes memory callData = abi.encodeWithSignature(
-            'withdrawTokenCommission(address,address,uint256)',
-            address(token),
-            arbitraryRecipient,
-            expectedCommission
+            'setGlobalDefaults(uint256,uint8,uint8,uint8)', uint256(0), uint8(100), uint8(0), uint8(0)
         );
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
         bytes32 digest = MultisigHelper.digestProposeAdminExecuteCM(
-            domainSep,
-            bytes4(callData),
-            callData,
-            nonce,
-            deadline
+            domainSep, bytes4(callData), callData, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         bytes32 id = proxy.proposeAdminExecuteCommissionManager(callData, nonce, deadline, bitmap, sigs);
+        assertTrue(id != bytes32(0), 'non-withdrawal CM selector accepted on the generic path');
+    }
 
-        vm.warp(block.timestamp + TIMELOCK + 1);
+    // ========================================================================
+    // Per-source-chain enclave signer sets
+    // ========================================================================
+    //
+    // NOTE: these tests run multiple propose -> warp -> execute cycles. Time is
+    // read via `vm.getBlockTimestamp()` rather than the `block.timestamp` opcode:
+    // under via_ir the optimizer caches `block.timestamp` across the `vm.warp`
+    // staticcall, so a later cycle would otherwise reuse a stale timestamp.
 
-        // Current behavior: generic CM admin execution emits only the
-        // CommissionManager withdrawal event and sends funds to the calldata
-        // recipient, not to the proxy's pinned commissionRecipient.
-        vm.expectEmit(true, true, false, true, address(cm));
-        emit TokenCommissionWithdrawn(address(token), arbitraryRecipient, expectedCommission);
-        vm.expectEmit(true, true, false, true, address(proxy));
-        emit ProposalExecuted(id, IMultisigProxy.OperationType.AdminExecuteCommissionManager);
+    /// @dev `n` deterministic, globally-unique signer addresses for `chainId`,
+    ///      in a keccak namespace disjoint from the setUp enclave/federation
+    ///      addresses and from every other chain's generated set.
+    function _encSetFor(uint256 chainId, uint256 n) internal pure returns (address[] memory a) {
+        a = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            a[i] = address(uint160(uint256(keccak256(abi.encode('enc-set', chainId, i)))));
+        }
+    }
 
-        proxy.executeProposal(id, callData);
-
-        assertEq(cm.tokenCommissionPool(address(token)), 0, 'cm pool drained');
-        assertEq(token.balanceOf(commissionReceiver), pinnedRecipientBefore, 'pinned recipient unchanged');
-        assertEq(
-            token.balanceOf(arbitraryRecipient),
-            arbitraryRecipientBefore + expectedCommission,
-            'arbitrary recipient credited'
+    /// @dev Register (or rotate) an enclave set for `chainId` via the federation
+    ///      propose -> timelock -> execute path (signed by the original 2-of-3
+    ///      federation, which is left untouched by these helpers).
+    function _govUpdateEnclave(uint256 chainId, address[] memory signers, uint256 threshold) internal {
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, chainId, signers, threshold, nonce, deadline
         );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(chainId, signers, threshold, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(chainId, signers, threshold));
+    }
+
+    function _slice(uint256[] memory a, uint256 k) internal pure returns (uint256[] memory r) {
+        r = new uint256[](k);
+        for (uint256 i = 0; i < k; i++) r[i] = a[i];
+    }
+
+    function _bitmapFor(uint256 k) internal pure returns (uint256 b) {
+        for (uint256 i = 0; i < k; i++) b |= (uint256(1) << i);
+    }
+
+    /// @dev A federation candidate set derived from sequential private keys so
+    ///      the caller retains the pks to sign the *next* rotation.
+    function _fedFromPks(uint256 base, uint256 n)
+        internal
+        returns (address[] memory addrs, uint256[] memory pks)
+    {
+        addrs = new address[](n);
+        pks   = new uint256[](n);
+        for (uint256 i = 0; i < n; i++) {
+            pks[i]   = base + i;
+            addrs[i] = vm.addr(pks[i]);
+        }
+    }
+
+    /// @dev An enclave candidate set derived from sequential private keys, so a
+    ///      test can register the set AND later sign a real release with it.
+    function _encFromPks(uint256 base, uint256 n)
+        internal
+        returns (address[] memory addrs, uint256[] memory pks)
+    {
+        addrs = new address[](n);
+        pks   = new uint256[](n);
+        for (uint256 i = 0; i < n; i++) {
+            pks[i]   = base + i;
+            addrs[i] = vm.addr(pks[i]);
+        }
+    }
+
+    /// @dev Rotate the federation set, signing with the *current* federation pks,
+    ///      returning the gas consumed by executeProposal (the disjoint-loop leg).
+    function _rotateFedMeasured(
+        address[] memory newAddrs,
+        uint256 newThr,
+        uint256[] memory curPks,
+        uint256 curBitmap
+    ) internal returns (uint256 gasUsed) {
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(
+            domainSep, newAddrs, newThr, nonce, deadline
+        );
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, curPks);
+        bytes32 id = proxy.proposeUpdateFederationSigners(newAddrs, newThr, nonce, deadline, curBitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+        uint256 g0 = gasleft();
+        proxy.executeProposal(id, abi.encode(newAddrs, newThr));
+        gasUsed = g0 - gasleft();
+    }
+
+    // ---- release-path behaviour -------------------------------------------
+
+    /// @dev `fundsOutCall` for a source chain with no registered enclave set
+    ///      reverts UnknownSourceChain before touching the nonce/signatures.
+    function test_perSourceChain_fundsOutRevertsForUnregisteredSourceChain() public {
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        p.sourceChainId = 424_242; // not registered
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(424_242)));
+        proxy.fundsOutCall(p, 0, vm.getBlockTimestamp() + 1 hours, 0, new bytes[](0));
+    }
+
+    /// @dev A release for chain B signed by chain A's (RGB) enclave keys is
+    ///      rejected: selection by sourceChainId verifies A's signatures against
+    ///      B's set, which does not contain them.
+    function test_perSourceChain_signatureFromAnotherChainRejected() public {
+        uint256 chainB = 7_000_001;
+        _govUpdateEnclave(chainB, _encSetFor(chainB, 3), 2);
+
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        p.sourceChainId = chainB;
+        uint256 nonce    = proxy.teeNonce(chainB); // 0
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, p, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3(); // RGB signers
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        // Must fail at the signer check (recovered RGB signer != chainB's set),
+        // NOT downstream in the Bridge — that is what proves signer-set isolation.
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.fundsOutCall(p, nonce, deadline, bitmap, sigs);
+    }
+
+    /// @dev Each source chain has an independent teeNonce lane: an RGB release
+    ///      advances only RGB's nonce, not another registered chain's.
+    function test_perSourceChain_teeNonceLanesIndependent() public {
+        uint256 chainB = 7_000_002;
+        _govUpdateEnclave(chainB, _encSetFor(chainB, 3), 2);
+
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), 0, 'RGB nonce starts at 0');
+        assertEq(proxy.teeNonce(chainB), 0, 'chainB nonce starts at 0');
+
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, p, proxy.teeNonce(RGB_CHAIN_ID), deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        proxy.fundsOutCall(p, 0, deadline, bitmap, sigs);
+
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), 1, 'RGB lane advanced');
+        assertEq(proxy.teeNonce(chainB), 0, 'chainB lane untouched');
+    }
+
+    // ---- registration / rotation ------------------------------------------
+
+    function test_perSourceChain_registerNewChain() public {
+        uint256 chainB = 8_000_001;
+        address[] memory sB = _encSetFor(chainB, 4);
+        _govUpdateEnclave(chainB, sB, 3); // 2*3 > 4
+
+        assertEq(proxy.enclaveThreshold(chainB), 3);
+        address[] memory got = proxy.getEnclaveSigners(chainB);
+        assertEq(got.length, 4);
+        assertEq(got[0], sB[0]);
+
+        uint256[] memory chains = proxy.getEnclaveSourceChains();
+        assertEq(chains.length, 2, 'RGB + chainB');
+        assertEq(chains[0], RGB_CHAIN_ID);
+        assertEq(chains[1], chainB);
+    }
+
+    /// @dev Federation rotation must be disjoint from *every* enclave chain.
+    function test_perSourceChain_federationRotationRejectsEnclaveOverlap() public {
+        uint256 chainB = 8_000_002;
+        address[] memory sB = _encSetFor(chainB, 3);
+        _govUpdateEnclave(chainB, sB, 2);
+
+        address[] memory newFed = new address[](3);
+        newFed[0] = sB[0]; // overlaps chainB
+        newFed[1] = fedA2;
+        newFed[2] = fedA3;
+
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(domainSep, newFed, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateFederationSigners(newFed, 2, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, sB[0]));
+        proxy.executeProposal(id, abi.encode(newFed, 2));
+    }
+
+    /// @dev An enclave rotation for chain C must be disjoint from other enclave
+    ///      chains (here chain B).
+    function test_perSourceChain_enclaveRotationRejectsOtherChainOverlap() public {
+        uint256 chainB = 8_000_003;
+        address[] memory sB = _encSetFor(chainB, 3);
+        _govUpdateEnclave(chainB, sB, 2);
+
+        uint256 chainC = 8_000_004;
+        address[] memory sC = _encSetFor(chainC, 3);
+        sC[1] = sB[2]; // inject overlap with chainB
+
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, chainC, sC, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(chainC, sC, 2, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, sB[2]));
+        proxy.executeProposal(id, abi.encode(chainC, sC, 2));
+    }
+
+    /// @dev A partial rotation may keep some of the chain's own keys — the
+    ///      disjoint check self-excludes the chain being rotated.
+    function test_perSourceChain_partialRotationSelfExclusionAllowed() public {
+        address[] memory newRgb = new address[](2);
+        newRgb[0] = encA1; // keep an existing RGB signer
+        newRgb[1] = makeAddr('rgbFresh');
+        uint256 chainsBefore = proxy.getEnclaveSourceChains().length;
+        _govUpdateEnclave(RGB_CHAIN_ID, newRgb, 2);
+
+        address[] memory got = proxy.getEnclaveSigners(RGB_CHAIN_ID);
+        assertEq(got.length, 2);
+        assertEq(got[0], encA1, 'kept its own key via self-exclusion');
+        // Rotating an existing chain must not add a duplicate registry entry.
+        assertEq(proxy.getEnclaveSourceChains().length, chainsBefore, 'no duplicate source-chain entry on rotation');
+    }
+
+    /// @dev Registering more than MAX_ENCLAVE_SOURCE_CHAINS source chains is
+    ///      rejected at execute (bounds the cross-set disjoint loop).
+    function test_perSourceChain_maxEnclaveSourceChainsCap() public {
+        uint256 maxChains = proxy.MAX_ENCLAVE_SOURCE_CHAINS();
+        // RGB already occupies slot 1 — fill the rest.
+        for (uint256 k = 0; k < maxChains - 1; k++) {
+            uint256 chainId = 6_000_000 + k;
+            _govUpdateEnclave(chainId, _encSetFor(chainId, 2), 2);
+        }
+        assertEq(proxy.getEnclaveSourceChains().length, maxChains);
+
+        uint256 overflowChain = 6_999_999;
+        address[] memory s = _encSetFor(overflowChain, 2);
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, overflowChain, s, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(overflowChain, s, 2, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IMultisigProxy.TooManyEnclaveSourceChains.selector, maxChains + 1, maxChains
+        ));
+        proxy.executeProposal(id, abi.encode(overflowChain, s, 2));
+    }
+
+    // ---- positive per-source authorization --------------------------------
+
+    /// @dev A per-source set's OWN keys authorize a release for that chain, and
+    ///      the correct nonce lane advances. RGB is rotated to keys we control
+    ///      so the full release (reusing RGB's configured route/liquidity) runs.
+    function test_perSourceChain_ownKeysAuthorizeRelease() public {
+        (address[] memory encAddrs, uint256[] memory encPks) = _encFromPks(0xEEE0000, 3);
+        _govUpdateEnclave(RGB_CHAIN_ID, encAddrs, 2);
+
+        uint256 balBefore = token.balanceOf(recipient);
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, p, nonce, deadline);
+        uint256[] memory signPks = new uint256[](2);
+        signPks[0] = encPks[0]; signPks[1] = encPks[1];
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, signPks);
+
+        proxy.fundsOutCall(p, nonce, deadline, 0x3, sigs);
+
+        assertGt(token.balanceOf(recipient), balBefore, 'chain-owned keys authorized the release');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'RGB nonce advanced');
+    }
+
+    /// @dev The LZ branch selects the enclave set + nonce lane by source chain:
+    ///      an RGB LZ release advances only RGB's lane and emits sourceChainId.
+    function test_perSourceChain_lz_selectsPerSourceLane() public {
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));                          // fresh ts (first gov action)
+        _govUpdateEnclave(7_100_001, _encSetFor(7_100_001, 3), 2); // second registered chain
+
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        vm.expectEmit(true, true, false, false);
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, params.dstEid, params.recipient, AMOUNT);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
+
+        assertEq(token.balanceOf(mockOft), AMOUNT, 'LZ release forwarded to OFT');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'RGB LZ lane advanced');
+        assertEq(proxy.teeNonce(7_100_001), 0, 'other chain LZ lane untouched');
+    }
+
+    /// @dev lzFundsOutCall for an unregistered source chain reverts UnknownSourceChain.
+    function test_perSourceChain_lz_unregisteredSourceReverts() public {
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        params.sourceChainId = 424_242; // unregistered (checked before adapter/signatures)
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(424_242)));
+        proxy.lzFundsOutCall(params, 0, vm.getBlockTimestamp() + 1 hours, 0, new bytes[](0));
+    }
+
+    /// @dev An LZ release for chain B signed by RGB keys is rejected at the
+    ///      signer check (per-source selection), not downstream.
+    function test_perSourceChain_lz_signatureFromAnotherChainRejected() public {
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));
+        uint256 chainB = 7_200_001;
+        _govUpdateEnclave(chainB, _encSetFor(chainB, 3), 2);
+
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        params.sourceChainId = chainB;
+        uint256 nonce    = proxy.teeNonce(chainB); // 0
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3(); // RGB signers
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
+    }
+
+    // ---- governance binding / validation -----------------------------------
+
+    /// @dev The enclave-rotation proposal digest is bound to sourceChainId:
+    ///      a digest signed for RGB cannot authorize a rotation of chain B.
+    ///      Guards against regressing the sourceChainId out of the typehash.
+    function test_perSourceChain_proposeUpdateEnclaveDigestBoundToSourceChain() public {
+        uint256 chainB = 7_300_001;
+        address[] memory sB = _encSetFor(chainB, 2);
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        // Federation signs the digest for RGB_CHAIN_ID...
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, RGB_CHAIN_ID, sB, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        // ...but the proposal is submitted for chainB -> digest mismatch.
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.proposeUpdateEnclaveSigners(chainB, sB, 2, nonce, deadline, bitmap, sigs);
+    }
+
+    /// @dev sourceChainId == 0 is reserved (threshold 0 is the "unregistered"
+    ///      sentinel), so it is rejected at construction.
+    function test_perSourceChain_constructorRejectsZeroSourceChain() public {
+        address[] memory enc = _validEnc();
+        address[] memory fed = _validFed();
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(0)));
+        new MultisigProxy(address(bridge), address(cm), enc, 2, 0, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    /// @dev ...and rejected up front by proposeUpdateEnclaveSigners (before sigs).
+    function test_perSourceChain_proposeRejectsZeroSourceChain() public {
+        address[] memory sB = _encSetFor(1, 2);
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes[] memory noSigs = new bytes[](0);
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(0)));
+        proxy.proposeUpdateEnclaveSigners(0, sB, 2, nonce, deadline, 0, noSigs);
+    }
+
+    // ---- gas boundary ------------------------------------------------------
+
+    /// @dev Boundary/gas: fill the registry to MAX_ENCLAVE_SOURCE_CHAINS (32),
+    ///      each with the maximum MAX_SIGNERS (20) enclave signers, then confirm
+    ///      an enclave rotation and federation rotations (3/5/10 signers) still
+    ///      execute well under a conservative block gas limit — the cross-set
+    ///      disjoint loop is the worst case. Thresholds must be a strict majority
+    ///      (2*t > n), so 20-signer sets use t=11 (t=3 would be rejected as
+    ///      sub-majority); the disjoint-loop gas is independent of the threshold.
+    function test_perSourceChain_gas_updateSignersAtMaxChainsAndMaxSigners() public {
+        uint256 BLOCK_GAS_LIMIT = 30_000_000; // conservative; Arbitrum allows far more
+        uint256 nChains  = proxy.MAX_ENCLAVE_SOURCE_CHAINS(); // 32
+        uint256 nSigners = proxy.MAX_SIGNERS();               // 20
+        uint256 t20      = 11;                                 // strict majority of 20
+
+        // Rotate RGB to 20 signers, then register (nChains - 1) more 20-signer
+        // chains so all 32 chains carry the maximum set.
+        _govUpdateEnclave(RGB_CHAIN_ID, _encSetFor(RGB_CHAIN_ID, nSigners), t20);
+        for (uint256 k = 0; k < nChains - 1; k++) {
+            uint256 chainId = 5_000_000 + k;
+            _govUpdateEnclave(chainId, _encSetFor(chainId, nSigners), t20);
+        }
+        assertEq(proxy.getEnclaveSourceChains().length, nChains, 'registry filled to the cap');
+
+        // --- enclave rotation of an existing 20-signer chain: disjoint runs
+        //     over the other 31 sets (~20 * 31 * 20 comparisons) + federation.
+        {
+            uint256 rotChain = 5_000_000;
+            address[] memory fresh = _encSetFor(9_999_999, nSigners); // disjoint namespace
+            uint256 nonce    = proxy.proposalNonce();
+            uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+            bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, rotChain, fresh, t20, nonce, deadline);
+            (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+            bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+            bytes32 id = proxy.proposeUpdateEnclaveSigners(rotChain, fresh, t20, nonce, deadline, bitmap, sigs);
+            vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+            uint256 g0 = gasleft();
+            proxy.executeProposal(id, abi.encode(rotChain, fresh, t20));
+            uint256 gEnc = g0 - gasleft();
+            emit log_named_uint('gas: updateEnclaveSigners @32chains x20 (rotate)', gEnc);
+            assertLt(gEnc, BLOCK_GAS_LIMIT, 'enclave rotation exceeds block gas limit');
+        }
+
+        // --- federation rotations for sizes 3, 5, 10: disjoint runs over all
+        //     32 enclave sets. Each rotation is signed by the current federation,
+        //     so we thread the pks forward.
+        (uint256[] memory origPks, uint256 origBitmap) = _fedSigSet2of3();
+
+        (address[] memory f3, uint256[] memory p3) = _fedFromPks(0xFED30000, 3);
+        uint256 g3 = _rotateFedMeasured(f3, 2, origPks, origBitmap);
+        emit log_named_uint('gas: updateFederationSigners size=3 @32x20', g3);
+        assertLt(g3, BLOCK_GAS_LIMIT, 'fed(3) rotation exceeds block gas limit');
+
+        (address[] memory f5, uint256[] memory p5) = _fedFromPks(0xFED50000, 5);
+        uint256 g5 = _rotateFedMeasured(f5, 3, _slice(p3, 2), _bitmapFor(2)); // signed by f3 (t=2)
+        emit log_named_uint('gas: updateFederationSigners size=5 @32x20', g5);
+        assertLt(g5, BLOCK_GAS_LIMIT, 'fed(5) rotation exceeds block gas limit');
+
+        (address[] memory f10, ) = _fedFromPks(0xFED100000, 10);
+        uint256 g10 = _rotateFedMeasured(f10, 6, _slice(p5, 3), _bitmapFor(3)); // signed by f5 (t=3)
+        emit log_named_uint('gas: updateFederationSigners size=10 @32x20', g10);
+        assertLt(g10, BLOCK_GAS_LIMIT, 'fed(10) rotation exceeds block gas limit');
     }
 }

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -166,6 +166,9 @@ contract MultisigProxyTest is Test {
     uint256 constant TX_ID   = 42;
     uint256 constant RGB_OP_ID = 0xABCDEF;
     uint256 constant BURN_ID = 9_001;
+    bytes32 constant FUNDS_OUT_BURN_ID_TYPEHASH = keccak256(
+        'UtexoFundsOutBurnId(address bridge,uint256 chainId,address token,address recipient,uint256 amount,uint256 sourceChainId,uint256 destinationChainId,bytes32 sourceAddressHash,bytes32 proofHash,bytes32 settlementDataHash)'
+    );
     uint256 constant LZ_NATIVE_FEE = 0.01 ether;
     uint32  constant DST_EID = 30110;
     bytes32 constant LZ_RECIPIENT = bytes32(uint256(uint160(0xBEEF)));
@@ -315,6 +318,30 @@ contract MultisigProxyTest is Test {
         return abi.encode(ids, amounts);
     }
 
+    function _deriveBurnId(
+        address bridgeRecipient,
+        uint256 amount,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        string memory sourceAddress,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal view returns (uint256) {
+        return uint256(keccak256(abi.encode(
+            FUNDS_OUT_BURN_ID_TYPEHASH,
+            address(bridge),
+            block.chainid,
+            address(token),
+            bridgeRecipient,
+            amount,
+            sourceChainId,
+            destinationChainId,
+            keccak256(bytes(sourceAddress)),
+            keccak256(proof),
+            keccak256(settlementData)
+        )));
+    }
+
     /// @dev Valid strict-majority signer sets (2-of-2) used as filler in
     ///      constructor-revert tests that target a non-threshold revert.
     function _validEnc() internal view returns (address[] memory a) {
@@ -329,44 +356,56 @@ contract MultisigProxyTest is Test {
         a[1] = fedA2;
     }
 
-    /// @dev Standard single-release params (recipient = `recipient`, AMOUNT, BURN_ID).
+    /// @dev Standard single-release params (recipient = `recipient`, AMOUNT, canonical burnId).
     function _fundsOutParams() internal view returns (IBridge.FundsOutParams memory) {
         return _fundsOutParams(recipient, AMOUNT, BURN_ID);
     }
 
-    function _fundsOutParams(address payoutRecipient, uint256 amount, uint256 burnId)
+    function _fundsOutParams(address payoutRecipient, uint256 amount, uint256 /* burnId */)
         internal
         view
         returns (IBridge.FundsOutParams memory)
     {
+        bytes memory proof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT);
+        bytes memory settlementData = _settlement(_fundsInIds());
+        uint256 derivedBurnId = _deriveBurnId(
+            payoutRecipient, amount, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+
         return IBridge.FundsOutParams({
             recipient:          payoutRecipient,
             amount:             amount,
-            burnId:             burnId,
+            burnId:             derivedBurnId,
             sourceChainId:      RGB_CHAIN_ID,
             destinationChainId: SOURCE_CHAIN_ID,
             sourceAddress:      SRC_ADDR,
-            proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT),
-            settlementData:     _settlement(_fundsInIds())
+            proof:              proof,
+            settlementData:     settlementData
         });
     }
 
     /// @dev Flow-4 LZ release params. The Bridge recipient is forced to the
     ///      adapter on-chain, so it is not part of these params; `recipient`
     ///      here is the bytes32 destination on the far chain.
-    function _lzFundsOutParams(uint256 amount, uint256 burnId, bytes32[] memory ids)
+    function _lzFundsOutParams(uint256 amount, uint256 /* burnId */, bytes32[] memory ids)
         internal
         view
         returns (IMultisigProxy.LzFundsOutParams memory)
     {
+        bytes memory proof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT);
+        bytes memory settlementData = _settlement(ids);
+        uint256 derivedBurnId = _deriveBurnId(
+            proxy.lzAdapter(), amount, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+
         return IMultisigProxy.LzFundsOutParams({
             amount:             amount,
-            burnId:             burnId,
+            burnId:             derivedBurnId,
             sourceChainId:      RGB_CHAIN_ID,
             destinationChainId: SOURCE_CHAIN_ID,
             sourceAddress:      SRC_ADDR,
-            proof:              abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT, LATEST_COMMIT),
-            settlementData:     _settlement(ids),
+            proof:              proof,
+            settlementData:     settlementData,
             dstEid:             DST_EID,
             recipient:          LZ_RECIPIENT,
             minAmountLD:        0,
@@ -1975,7 +2014,7 @@ contract MultisigProxyTest is Test {
         assertEq(cmPoolBefore,     0,          'pre cm pool');
         assertEq(nativePoolBefore, 0,          'pre native pool');
         assertEq(recordBefore,     AMOUNT * 5, 'pre record');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         vm.expectEmit(true, true, false, true);
         emit BridgeFundsOut(
@@ -1983,7 +2022,7 @@ contract MultisigProxyTest is Test {
             AMOUNT,
             netAmount,
             tokenCommission,
-            BURN_ID,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
@@ -1994,7 +2033,7 @@ contract MultisigProxyTest is Test {
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
         assertEq(proxy.teeNonce(), nonce + 1, 'nonce incremented');
-        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
+        assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT,        'bridge gross debit');
         assertEq(token.balanceOf(recipient),       recipientBefore + netAmount, 'recipient net delta');
         assertEq(token.balanceOf(address(cm)),     cmBefore + tokenCommission,  'cm fee delta');
@@ -2068,7 +2107,7 @@ contract MultisigProxyTest is Test {
         assertEq(recordBefore,   AMOUNT * 5, 'pre record');
         assertEq(adapterEthBefore, 0,        'pre adapter native');
         assertEq(oftEthBefore,     0,        'pre oft native');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, netAmount));
 
@@ -2078,7 +2117,7 @@ contract MultisigProxyTest is Test {
             AMOUNT,
             netAmount,
             tokenCommission,
-            BURN_ID,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
@@ -2092,7 +2131,7 @@ contract MultisigProxyTest is Test {
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
         assertEq(proxy.teeNonce(), nonce + 1, 'tee nonce incremented');
-        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
+        assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)),  bridgeBefore - AMOUNT,          'bridge gross debit');
         assertEq(token.balanceOf(address(cm)),      cmBefore + tokenCommission,     'cm fee delta');
         assertEq(cm.tokenCommissionPool(address(token)), cmPoolBefore + tokenCommission, 'cm pool delta');
@@ -2163,7 +2202,7 @@ contract MultisigProxyTest is Test {
         assertEq(cmPoolBefore,     0,          'pre cm pool');
         assertEq(nativePoolBefore, 0,          'pre native pool');
         assertEq(recordBefore,     AMOUNT * 5, 'pre record');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         // An underfunded native fee reverts in sendOut, after Bridge.fundsOut
         // already ran inside the same lzFundsOutCall transaction.
@@ -2172,7 +2211,7 @@ contract MultisigProxyTest is Test {
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE - 1 }(params, nonce, deadline, bitmap, sigs);
 
         assertEq(proxy.teeNonce(),                nonce,            'tee nonce unchanged');
-        assertFalse(bridge.consumedBurnIds(BURN_ID),                'burn id unchanged');
+        assertFalse(bridge.consumedBurnIds(params.burnId),          'burn id unchanged');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter token unchanged');
         assertEq(token.balanceOf(mockOft),          oftBefore,      'oft token unchanged');
@@ -2203,7 +2242,7 @@ contract MultisigProxyTest is Test {
             })
         );
 
-        (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount) =
+        (uint256 tokenCommission, uint256 nativeCommission,) =
             cm.calculateFundsOutCommission(RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token), AMOUNT);
         assertGt(tokenCommission, 0, 'token fee quoted');
         assertEq(nativeCommission, 0, 'native fee is zero');
@@ -2217,6 +2256,15 @@ contract MultisigProxyTest is Test {
         // Well-formed two-pair proof whose source block is unknown to the relay,
         // so Bridge.fundsOut reverts before the adapter send can run.
         params.proof = abi.encode(uint256(999_999), keccak256('unknown-block'), LATEST_HEIGHT, LATEST_COMMIT);
+        params.burnId = _deriveBurnId(
+            address(adapter),
+            params.amount,
+            params.sourceChainId,
+            params.destinationChainId,
+            params.sourceAddress,
+            params.proof,
+            params.settlementData
+        );
 
         uint256 deadline = block.timestamp + 1 hours;
         (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
@@ -2241,14 +2289,14 @@ contract MultisigProxyTest is Test {
         assertEq(nativePoolBefore, 0,          'pre native pool');
         assertEq(recordBefore,     AMOUNT * 5, 'pre record');
         assertEq(adapter.sendOutCalls(), 0,    'pre adapter calls');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         vm.expectRevert(bytes('verify: block commitment'));
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
         assertEq(proxy.teeNonce(),                nonce,            'tee nonce unchanged');
-        assertFalse(bridge.consumedBurnIds(BURN_ID),                'burn id unchanged');
+        assertFalse(bridge.consumedBurnIds(params.burnId),          'burn id unchanged');
         assertEq(adapter.sendOutCalls(),           0,               'adapter not called');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter token unchanged');
@@ -2322,7 +2370,7 @@ contract MultisigProxyTest is Test {
         assertEq(nativePoolBefore, 0,          'pre native pool');
         assertEq(recordBefore,     AMOUNT * 5, 'pre record');
         assertEq(adapter.sendOutCalls(), 0,    'pre adapter calls');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, netAmount));
 
@@ -2332,7 +2380,7 @@ contract MultisigProxyTest is Test {
             AMOUNT,
             netAmount,
             tokenCommission,
-            BURN_ID,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
@@ -2346,7 +2394,7 @@ contract MultisigProxyTest is Test {
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
         assertEq(proxy.teeNonce(),                nonce + 1,        'tee nonce incremented');
-        assertTrue(bridge.consumedBurnIds(BURN_ID),                  'burn id consumed');
+        assertTrue(bridge.consumedBurnIds(params.burnId),            'burn id consumed');
         assertEq(adapter.sendOutCalls(),           1,               'adapter called once');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge token debit');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter no residue');
@@ -2363,8 +2411,6 @@ contract MultisigProxyTest is Test {
     // Flow-4 success coverage for duplicate RGB settlement ids: the reworked
     // module verifies each (id, amount) pair by pure read, so duplicates pass.
     function test_lzFundsOutCall_duplicateSettlementIdsFullConsume_succeedsAndIgnoresDuplicate() public {
-        uint256 burnId = BURN_ID + 1;
-
         vm.prank(user);
         bytes32 secondOpId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, abi.encode(RGB_OP_ID));
 
@@ -2397,7 +2443,7 @@ contract MultisigProxyTest is Test {
         duplicateIds[0] = secondOpId;
         duplicateIds[1] = secondOpId;
 
-        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, burnId, duplicateIds);
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID + 1, duplicateIds);
 
         uint256 deadline = block.timestamp + 1 hours;
         (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
@@ -2423,7 +2469,7 @@ contract MultisigProxyTest is Test {
         assertEq(originalRecordBefore,    AMOUNT * 5, 'pre original record');
         assertEq(duplicateRecordBefore,   AMOUNT,     'pre duplicate record');
         assertEq(adapter.sendOutCalls(),  0,          'pre adapter calls');
-        assertFalse(bridge.consumedBurnIds(burnId), 'pre burn id');
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
 
         bytes32 sendOutGuid = keccak256(abi.encode('mock-send-out', DST_EID, LZ_RECIPIENT, netAmount));
 
@@ -2433,7 +2479,7 @@ contract MultisigProxyTest is Test {
             AMOUNT,
             netAmount,
             tokenCommission,
-            burnId,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
@@ -2447,7 +2493,7 @@ contract MultisigProxyTest is Test {
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
         assertEq(proxy.teeNonce(),                nonce + 1,        'tee nonce incremented');
-        assertTrue(bridge.consumedBurnIds(burnId),                  'burn id consumed');
+        assertTrue(bridge.consumedBurnIds(params.burnId),            'burn id consumed');
         assertEq(adapter.sendOutCalls(),           1,               'adapter called once');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge token debit');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter no residue');
@@ -2541,7 +2587,7 @@ contract MultisigProxyTest is Test {
             AMOUNT,
             netAmount,
             tokenCommission,
-            BURN_ID,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
@@ -2577,11 +2623,10 @@ contract MultisigProxyTest is Test {
         assertEq(bridgeBefore,    AMOUNT * 5, 'pre bridge pool');
         assertEq(recipientBefore, 0,          'pre recipient token');
         assertEq(recordBefore,    bridgeBefore, 'pre record backs full pool');
-        assertFalse(bridge.consumedBurnIds(BURN_ID), 'pre burn id');
-
         // Current behavior: if an on-chain amount cap or rate limit is added
         // later, this test should be inverted to expect a revert.
         IBridge.FundsOutParams memory params = _fundsOutParams(drainRecipient, bridgeBefore, BURN_ID);
+        assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
         uint256 nonce = proxy.teeNonce();
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -2594,7 +2639,7 @@ contract MultisigProxyTest is Test {
             bridgeBefore,
             bridgeBefore,
             0,
-            BURN_ID,
+            params.burnId,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
             SRC_ADDR
@@ -2605,7 +2650,7 @@ contract MultisigProxyTest is Test {
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
         assertEq(proxy.teeNonce(), nonce + 1, 'nonce incremented');
-        assertTrue(bridge.consumedBurnIds(BURN_ID), 'burn id consumed');
+        assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)), 0, 'bridge pool drained');
         assertEq(token.balanceOf(drainRecipient), recipientBefore + bridgeBefore, 'recipient got full pool');
         assertEq(rgbModule.fundsInRecords(seedOpId), recordBefore, 'record unchanged (proof-of-mint permanent)');

--- a/ethereum/test/mocks/FeeOnTransferERC20.sol
+++ b/ethereum/test/mocks/FeeOnTransferERC20.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import { ERC20 } from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+
+/// @title FeeOnTransferERC20
+/// @notice Mintable ERC-20 that charges a fee (in basis points) on every
+///         movement between two non-zero addresses — i.e. both `transfer` and
+///         `transferFrom`. The recipient receives `amount - fee`; the `fee`
+///         is burned (total supply drops), so the recipient's balance delta is
+///         `amount - fee`.
+/// @dev    Mint (`from == address(0)`) and burn (`to == address(0)`) are NOT
+///         taxed, so `mint(addr, x)` credits exactly `x`. OZ v5 routes every
+///         balance change through `_update`, so overriding it taxes transfer and
+///         transferFrom uniformly.
+contract FeeOnTransferERC20 is ERC20 {
+    /// @notice Fee charged on transfers, in basis points (1% == 100 bps).
+    uint256 public feeBps;
+
+    uint256 private constant _BPS_DENOMINATOR = 10_000;
+
+    constructor(string memory name_, string memory symbol_, uint256 feeBps_)
+        ERC20(name_, symbol_)
+    {
+        feeBps = feeBps_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    /// @notice Fee that would be charged on a movement of `amount`.
+    function feeOn(uint256 amount) public view returns (uint256) {
+        return (amount * feeBps) / _BPS_DENOMINATOR;
+    }
+
+    /// @dev Tax only movements between two non-zero addresses (transfer /
+    ///      transferFrom). The fee is burned: credit the recipient
+    ///      `amount - fee` and remove `fee` from total supply.
+    function _update(address from, address to, uint256 value) internal override {
+        if (from != address(0) && to != address(0) && feeBps != 0) {
+            uint256 fee = feeOn(value);
+            if (fee != 0) {
+                // Debit `from` fully, credit `to` net, burn the fee.
+                super._update(from, to, value - fee);
+                super._update(from, address(0), fee);
+                return;
+            }
+        }
+        super._update(from, to, value);
+    }
+}

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -42,7 +42,7 @@ library MultisigHelper {
     );
 
     bytes32 internal constant PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH = keccak256(
-        'ProposeUpdateEnclaveSigners(address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
+        'ProposeUpdateEnclaveSigners(uint256 sourceChainId,address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
     );
 
     bytes32 internal constant PROPOSE_UPDATE_FEDERATION_SIGNERS_TYPEHASH = keccak256(
@@ -220,6 +220,7 @@ library MultisigHelper {
 
     function digestProposeUpdateEnclaveSigners(
         bytes32 domainSep,
+        uint256 sourceChainId,
         address[] memory newSigners,
         uint256 newThreshold,
         uint256 nonce,
@@ -227,7 +228,7 @@ library MultisigHelper {
     ) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(
             PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH,
-            hashAddressArray(newSigners), newThreshold, nonce, deadline
+            sourceChainId, hashAddressArray(newSigners), newThreshold, nonce, deadline
         )));
     }
 


### PR DESCRIPTION
Summary:
- mirror Bridge burnId derivation in Bridge, MultisigProxy, and integration tests
- add InvalidBurnId regressions for mismatched burnId, proof, and settlementData
- update replay, outflow, and LZ expectations to assert the canonical signed burnId
