### PR TITLE
test(R-I-04): commission credit no longer absorbs unsolicited transfers

### DIFF
--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -43,7 +43,7 @@ import { RgbSettlementModule } from '../../src/settlement/RgbSettlementModule.so
 ///
 /// Env (required):
 ///   PRIVATE_KEY, USDT0_ADDRESS, BTC_RELAY_ADDRESS,
-///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD,
+///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD, INITIAL_ENCLAVE_SOURCE_CHAIN_ID,
 ///   FEDERATION_SIGNERS, FEDERATION_THRESHOLD,
 ///   COMMISSION_RECIPIENT, TIMELOCK_DURATION, MIN_TIMELOCK,
 ///   MIN_FUNDS_IN_AMOUNT
@@ -93,6 +93,7 @@ contract DeployAll is Script {
         address btcRelay       = vm.envAddress('BTC_RELAY_ADDRESS');
         address[] memory enc   = vm.envAddress('ENCLAVE_SIGNERS', ',');
         uint256 encThr         = vm.envUint('ENCLAVE_THRESHOLD');
+        uint256 initialSrcChain = vm.envUint('INITIAL_ENCLAVE_SOURCE_CHAIN_ID');
         address[] memory fed   = vm.envAddress('FEDERATION_SIGNERS', ',');
         uint256 fedThr         = vm.envUint('FEDERATION_THRESHOLD');
         address commission     = vm.envAddress('COMMISSION_RECIPIENT');
@@ -156,7 +157,7 @@ contract DeployAll is Script {
         proxy = new MultisigProxy(
             address(bridge),
             address(cm),
-            enc, encThr,
+            enc, encThr, initialSrcChain,
             fed, fedThr,
             commission,
             timelock,

--- a/ethereum/script/deploy/DeployMultisigProxy.s.sol
+++ b/ethereum/script/deploy/DeployMultisigProxy.s.sol
@@ -14,6 +14,7 @@ import { MultisigProxy } from '../../src/MultisigProxy.sol';
 ///   COMMISSION_MANAGER    — existing CommissionManager deployment
 ///   ENCLAVE_SIGNERS       — comma-separated TEE signer addresses
 ///   ENCLAVE_THRESHOLD     — M for enclave M-of-N
+///   INITIAL_ENCLAVE_SOURCE_CHAIN_ID — source chain id the initial enclave set authorises (non-zero)
 ///   FEDERATION_SIGNERS    — comma-separated governance signer addresses
 ///   FEDERATION_THRESHOLD  — M for federation M-of-N
 ///   COMMISSION_RECIPIENT  — destination for commission withdrawals
@@ -30,6 +31,7 @@ contract DeployMultisigProxy is Script {
         address commissionManager  = vm.envAddress('COMMISSION_MANAGER');
         address[] memory enc       = vm.envAddress('ENCLAVE_SIGNERS', ',');
         uint256 encThr             = vm.envUint('ENCLAVE_THRESHOLD');
+        uint256 initialSrcChain    = vm.envUint('INITIAL_ENCLAVE_SOURCE_CHAIN_ID');
         address[] memory fed       = vm.envAddress('FEDERATION_SIGNERS', ',');
         uint256 fedThr             = vm.envUint('FEDERATION_THRESHOLD');
         address commission         = vm.envAddress('COMMISSION_RECIPIENT');
@@ -40,7 +42,7 @@ contract DeployMultisigProxy is Script {
         proxy = new MultisigProxy(
             bridgeAddr,
             commissionManager,
-            enc, encThr,
+            enc, encThr, initialSrcChain,
             fed, fedThr,
             commission,
             timelock,
@@ -51,7 +53,8 @@ contract DeployMultisigProxy is Script {
         console2.log('MultisigProxy deployed at:', address(proxy));
         console2.log('Bridge:                   ', proxy.bridge());
         console2.log('CommissionManager:        ', proxy.commissionManager());
-        console2.log('Enclave threshold:        ', proxy.enclaveThreshold());
+        console2.log('Initial enclave srcChain: ', initialSrcChain);
+        console2.log('Enclave threshold:        ', proxy.enclaveThreshold(initialSrcChain));
         console2.log('Federation threshold:     ', proxy.federationThreshold());
         console2.log('Commission recipient:     ', proxy.commissionRecipient());
         console2.log('Timelock duration (sec):  ', proxy.timelockDuration());

--- a/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
+++ b/ethereum/script/interact/MultisigExecuteFundsOut.s.sol
@@ -56,7 +56,7 @@ contract MultisigExecuteFundsOut is Script {
 
         IBridge.FundsOutParams memory params = _loadParams();
 
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(params.sourceChainId);
         uint256 deadline = block.timestamp + vm.envUint('DEADLINE_OFFSET');
         uint256 bitmap   = vm.envUint('ENCLAVE_BITMAP');
 
@@ -73,6 +73,6 @@ contract MultisigExecuteFundsOut is Script {
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
         vm.stopBroadcast();
 
-        console2.log('fundsOutCall() succeeded. New nonce:', proxy.teeNonce());
+        console2.log('fundsOutCall() succeeded. New nonce:', proxy.teeNonce(params.sourceChainId));
     }
 }

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -19,7 +19,7 @@ import { OutflowRateLimiter } from './libraries/OutflowRateLimiter.sol';
 ///         protocol fees are held separately from bridge liquidity.
 ///
 /// @dev - Owner is `MultisigProxy`. `fundsOut` is called via
-///        `MultisigProxy.execute()` (TEE M-of-N).
+///        `MultisigProxy.fundsOutCall()` (TEE M-of-N).
 ///      - Route-specific finality verification and per-route settlement
 ///        accounting (RGB `fundsInRecords` etc.) live behind the
 ///        `RouteRegistry` dispatcher in dedicated plugin contracts. Bridge
@@ -517,6 +517,14 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (received < tokenCommission) revert InsufficientReceived(received, tokenCommission);
         ctx.netAmount = received - tokenCommission;
 
+        // Forward token commission BEFORE the settlement hook so that any
+        // external call the hook makes (or a contract reading `getContractBalance`
+        // during it) observes only the net amount the Bridge actually retains,
+        // never the in-flight commission about to leave. `netAmount` is
+        // already fixed above, so the hook does not depend on the tokens still
+        // being held here.
+        if (tokenCommission != 0) _forwardTokenCommission(tokenCommission);
+
         // Delegate per-route inbound bookkeeping. The module returns an optional
         // correlation id (the RGB OpId for the RGB route; 0 otherwise) to surface
         // in the RGB-only `FundsIn` event below.
@@ -527,9 +535,6 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // the accumulated locked liquidity. Credited from the ACTUAL received
         // amount so the ledger can never exceed real custody.
         lockedLiquidity[destinationChainId] += ctx.netAmount;
-
-        // Forward token commission, if any, to the CommissionManager pool.
-        if (tokenCommission != 0) _forwardTokenCommission(tokenCommission);
 
         // Forward the FULL native value to the CommissionManager pool. Any
         // surplus over the quoted `nativeCommission` (favorable oracle drift) is

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -43,25 +43,48 @@ contract MultisigProxy is IMultisigProxy {
     ///         until then (closes adapter-execute by default).
     address public lzAdapter;
 
-    address[] private _enclaveSigners;
-    uint256 public enclaveThreshold;
+    /// @notice Per-source-chain enclave signer sets. Each source network (RGB,
+    ///         Concordium/Arch, …) is validated by its own TEE code and therefore
+    ///         has its own key set; a release for `sourceChainId` is authorised
+    ///         only by the set registered for that chain. Selected on the release
+    ///         path via `params.sourceChainId`, which is already committed to in
+    ///         the enclave EIP-712 digest — so a signature for one source chain
+    ///         cannot be replayed against another.
+    mapping(uint256 sourceChainId => address[]) private _enclaveSigners;
+
+    /// @notice Per-source-chain enclave quorum. `0` means the source chain is
+    ///         not registered — used as the existence guard on the release path.
+    mapping(uint256 sourceChainId => uint256) public enclaveThreshold;
+
+    /// @notice Registered enclave source chains, for enumeration and the
+    ///         cross-set disjointness checks. Bounded by `MAX_ENCLAVE_SOURCE_CHAINS`.
+    uint256[] private _enclaveSourceChains;
 
     address[] private _federationSigners;
     uint256 public federationThreshold;
 
     address public commissionRecipient;
 
-    /// @notice Sequential nonce shared by the typed TEE methods (`fundsOut` /
-    ///         `lzFundsOut`). Each successful call must match the current value
-    ///         and then increments it, giving all enclave releases a single
-    ///         total order and one-shot replay protection.
-    uint256 public teeNonce;
+    /// @notice Per-source-chain nonce for the typed TEE methods (`fundsOutCall`
+    ///         / `lzFundsOutCall`). Each source chain has its own lane, so the
+    ///         TEE operating one network cannot invalidate another network's
+    ///         pre-signed release. Each successful call must match the current
+    ///         value for its `sourceChainId` and then increments it.
+    mapping(uint256 sourceChainId => uint256) public teeNonce;
 
     /// @notice Federation proposals.
     mapping(bytes32 => Proposal) private _proposals;
 
-    /// @notice Sequential nonce for all federation operations (propose, cancel, emergency).
+    /// @notice Sequential nonce for the regular federation lane: `_propose`
+    ///         (all typed proposals) and `cancelProposal`.
     uint256 public proposalNonce;
+
+    /// @notice Sequential nonce for the emergency lane: `emergencyPause` /
+    ///         `emergencyUnpause`. Kept separate from `proposalNonce` so an
+    ///         emergency action cannot invalidate an already-signed regular
+    ///         proposal. Cross-lane replay is independently prevented by
+    ///         each operation's distinct EIP-712 typehash.
+    uint256 public emergencyNonce;
 
     /// @notice Minimum delay (seconds) between proposal creation and execution.
     uint256 public timelockDuration;
@@ -92,6 +115,11 @@ contract MultisigProxy is IMultisigProxy {
     ///         `uint256` signature-bitmap width (so no signer index is ever
     ///         unreachable). 20 is ample for an enclave/federation committee.
     uint256 public constant MAX_SIGNERS = 20;
+
+    /// @notice Hard upper bound on the number of registered enclave source
+    ///         chains. Bounds the cross-set disjointness loop (run on every
+    ///         signer rotation), keeping governance updates gas-predictable.
+    uint256 public constant MAX_ENCLAVE_SOURCE_CHAINS = 32;
 
     /// @notice Length of a Solidity function selector (`bytes4`) in bytes. Used
     ///         to guard `callData` against payloads too short to even carry a
@@ -129,7 +157,7 @@ contract MultisigProxy is IMultisigProxy {
         'ProposeAdminExecute(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)'
     );
     bytes32 private constant _PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH = keccak256(
-        'ProposeUpdateEnclaveSigners(address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
+        'ProposeUpdateEnclaveSigners(uint256 sourceChainId,address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
     );
     bytes32 private constant _PROPOSE_UPDATE_FEDERATION_SIGNERS_TYPEHASH = keccak256(
         'ProposeUpdateFederationSigners(address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
@@ -210,6 +238,7 @@ contract MultisigProxy is IMultisigProxy {
         address commissionManager_,
         address[] memory enclaveSigners_,
         uint256 enclaveThreshold_,
+        uint256 initialEnclaveSourceChain_,
         address[] memory federationSigners_,
         uint256 federationThreshold_,
         address commissionRecipient_,
@@ -219,6 +248,7 @@ contract MultisigProxy is IMultisigProxy {
         if (bridge_ == address(0)) revert ZeroBridge();
         if (commissionManager_ == address(0)) revert ZeroCommissionManager();
         if (enclaveSigners_.length == 0) revert NoSigners();
+        if (initialEnclaveSourceChain_ == 0) revert UnknownSourceChain(0);
         _requireValidThreshold(enclaveThreshold_, enclaveSigners_.length);
         if (federationSigners_.length == 0) revert NoSigners();
         _requireValidThreshold(federationThreshold_, federationSigners_.length);
@@ -235,8 +265,9 @@ contract MultisigProxy is IMultisigProxy {
 
         bridge = bridge_;
         commissionManager = commissionManager_;
-        _enclaveSigners = enclaveSigners_;
-        enclaveThreshold = enclaveThreshold_;
+        _enclaveSigners[initialEnclaveSourceChain_] = enclaveSigners_;
+        enclaveThreshold[initialEnclaveSourceChain_] = enclaveThreshold_;
+        _enclaveSourceChains.push(initialEnclaveSourceChain_);
         _federationSigners = federationSigners_;
         federationThreshold = federationThreshold_;
         commissionRecipient = commissionRecipient_;
@@ -261,18 +292,22 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata enclaveSigs
     ) external {
         _checkTeeTiming(deadline);
-        if (nonce != teeNonce) revert InvalidNonce();
+        // Select the enclave set by the release's source chain. `sourceChainId`
+        // is committed to in the digest below, so a signature is bound to the
+        // set of exactly one source chain. A zero threshold = unregistered.
+        if (enclaveThreshold[params.sourceChainId] == 0) revert UnknownSourceChain(params.sourceChainId);
+        if (nonce != teeNonce[params.sourceChainId]) revert InvalidNonce();
 
         _verifySignatures(
             _hashTypedData(_fundsOutStructHash(params, nonce, deadline)),
-            enclaveBitmap, enclaveSigs, _enclaveSigners, enclaveThreshold
+            enclaveBitmap, enclaveSigs, _enclaveSigners[params.sourceChainId], enclaveThreshold[params.sourceChainId]
         );
 
-        teeNonce++;
+        teeNonce[params.sourceChainId]++;
 
         IBridge(bridge).fundsOut(params);
 
-        emit FundsOutExecuted(nonce, enclaveBitmap);
+        emit FundsOutExecuted(params.sourceChainId, nonce, enclaveBitmap);
     }
 
     /// @dev EIP-712 struct hash for `TeeFundsOut`. Isolated in its own frame to
@@ -311,17 +346,18 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata enclaveSigs
     ) external payable {
         _checkTeeTiming(deadline);
-        if (nonce != teeNonce) revert InvalidNonce();
+        if (enclaveThreshold[params.sourceChainId] == 0) revert UnknownSourceChain(params.sourceChainId);
+        if (nonce != teeNonce[params.sourceChainId]) revert InvalidNonce();
 
         address adapter = lzAdapter;
         if (adapter == address(0)) revert LZAdapterNotSet();
 
         _verifySignatures(
             _hashTypedData(_lzFundsOutStructHash(params, nonce, deadline)),
-            enclaveBitmap, enclaveSigs, _enclaveSigners, enclaveThreshold
+            enclaveBitmap, enclaveSigs, _enclaveSigners[params.sourceChainId], enclaveThreshold[params.sourceChainId]
         );
 
-        teeNonce++;
+        teeNonce[params.sourceChainId]++;
 
         // Release to the adapter, then bridge exactly what the adapter received,
         // so the release and the cross-chain send are bound on-chain. The Bridge
@@ -347,7 +383,7 @@ contract MultisigProxy is IMultisigProxy {
             params.dstEid, params.recipient, delivered, params.minAmountLD, params.extraOptions
         );
 
-        emit LzFundsOutExecuted(nonce, enclaveBitmap, params.dstEid, params.recipient, delivered);
+        emit LzFundsOutExecuted(params.sourceChainId, nonce, enclaveBitmap, params.dstEid, params.recipient, delivered);
     }
 
     /// @dev EIP-712 struct hash for `TeeLzFundsOut`. Isolated in its own frame
@@ -402,14 +438,14 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata fedSigs
     ) external {
         if (block.timestamp > deadline) revert Expired();
-        if (nonce != proposalNonce) revert InvalidNonce();
+        if (nonce != emergencyNonce) revert InvalidNonce();
 
         bytes32 digest = _hashTypedData(
             keccak256(abi.encode(_EMERGENCY_PAUSE_TYPEHASH, nonce, deadline))
         );
         _verifySignatures(digest, fedBitmap, fedSigs, _federationSigners, federationThreshold);
 
-        proposalNonce++;
+        emergencyNonce++;
 
         // Emergency freeze of BOTH inflow and outflow — no timelock, federation
         // signatures only. Also halts the enclave/TEE release path (it routes
@@ -428,14 +464,14 @@ contract MultisigProxy is IMultisigProxy {
         bytes[] calldata fedSigs
     ) external {
         if (block.timestamp > deadline) revert Expired();
-        if (nonce != proposalNonce) revert InvalidNonce();
+        if (nonce != emergencyNonce) revert InvalidNonce();
 
         bytes32 digest = _hashTypedData(
             keccak256(abi.encode(_EMERGENCY_UNPAUSE_TYPEHASH, nonce, deadline))
         );
         _verifySignatures(digest, fedBitmap, fedSigs, _federationSigners, federationThreshold);
 
-        proposalNonce++;
+        emergencyNonce++;
 
         // Lift the emergency freeze on BOTH inflow and outflow.
         (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature('emergencyUnpauseAll()'));
@@ -470,6 +506,7 @@ contract MultisigProxy is IMultisigProxy {
 
     /// @inheritdoc IMultisigProxy
     function proposeUpdateEnclaveSigners(
+        uint256 sourceChainId,
         address[] calldata newSigners,
         uint256 newThreshold,
         uint256 nonce,
@@ -480,19 +517,21 @@ contract MultisigProxy is IMultisigProxy {
         // Validate the proposed set up front so a malformed rotation reverts
         // here instead of consuming a nonce + timelock slot and failing only at
         // execution. Disjointness is intentionally left to execute time: it
-        // depends on the live counterpart set, which may change before then.
+        // depends on the live federation and other enclave sets, which may
+        // change before then.
+        if (sourceChainId == 0) revert UnknownSourceChain(0);
         if (newSigners.length == 0) revert NoSigners();
         _requireValidThreshold(newThreshold, newSigners.length);
         _validateSigners(newSigners);
 
         bytes32 structHash = keccak256(abi.encode(
             _PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH,
-            _hashAddressArray(newSigners), newThreshold, nonce, deadline
+            sourceChainId, _hashAddressArray(newSigners), newThreshold, nonce, deadline
         ));
 
         return _propose(
             OperationType.UpdateEnclaveSigners,
-            abi.encode(newSigners, newThreshold),
+            abi.encode(sourceChainId, newSigners, newThreshold),
             nonce, deadline, structHash, fedBitmap, fedSigs
         );
     }
@@ -906,19 +945,26 @@ contract MultisigProxy is IMultisigProxy {
 
     /// @inheritdoc IMultisigProxy
     function verifyEnclaveSignature(
+        uint256 sourceChainId,
         bytes32 digest,
         bytes calldata signature,
         uint256 signerIndex
     ) external view returns (bool) {
-        if (signerIndex >= _enclaveSigners.length) revert IndexOutOfRange();
+        address[] storage set = _enclaveSigners[sourceChainId];
+        if (signerIndex >= set.length) revert IndexOutOfRange();
         address recovered = ECDSA.recover(digest, signature);
-        return recovered == _enclaveSigners[signerIndex];
+        return recovered == set[signerIndex];
     }
 
 
     /// @inheritdoc IMultisigProxy
-    function getEnclaveSigners() external view returns (address[] memory) {
-        return _enclaveSigners;
+    function getEnclaveSigners(uint256 sourceChainId) external view returns (address[] memory) {
+        return _enclaveSigners[sourceChainId];
+    }
+
+    /// @inheritdoc IMultisigProxy
+    function getEnclaveSourceChains() external view returns (uint256[] memory) {
+        return _enclaveSourceChains;
     }
 
     /// @inheritdoc IMultisigProxy
@@ -984,21 +1030,37 @@ contract MultisigProxy is IMultisigProxy {
             _propagateRevert(ok, ret);
 
         } else if (opType == OperationType.UpdateEnclaveSigners) {
-            (address[] memory newSigners, uint256 newThreshold) = abi.decode(opData, (address[], uint256));
+            (uint256 sourceChainId, address[] memory newSigners, uint256 newThreshold) =
+                abi.decode(opData, (uint256, address[], uint256));
+            if (sourceChainId == 0) revert UnknownSourceChain(0);
             if (newSigners.length == 0) revert NoSigners();
             _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
+            // Keep every trust domain independent: disjoint from the federation
+            // and from every *other* enclave source chain (skip this chain, so a
+            // partial rotation that keeps some of its own keys is allowed).
             _requireDisjoint(newSigners, _federationSigners);
-            _enclaveSigners = newSigners;
-            enclaveThreshold = newThreshold;
-            emit EnclaveSignersUpdated(newSigners, newThreshold);
+            _requireDisjointFromAllEnclaveSets(newSigners, sourceChainId);
+
+            // Register a brand-new source chain (bounded); existing ones just
+            // overwrite their set/threshold.
+            if (enclaveThreshold[sourceChainId] == 0) {
+                if (_enclaveSourceChains.length >= MAX_ENCLAVE_SOURCE_CHAINS) {
+                    revert TooManyEnclaveSourceChains(_enclaveSourceChains.length + 1, MAX_ENCLAVE_SOURCE_CHAINS);
+                }
+                _enclaveSourceChains.push(sourceChainId);
+            }
+            _enclaveSigners[sourceChainId] = newSigners;
+            enclaveThreshold[sourceChainId] = newThreshold;
+            emit EnclaveSignersUpdated(sourceChainId, newSigners, newThreshold);
 
         } else if (opType == OperationType.UpdateFederationSigners) {
             (address[] memory newSigners, uint256 newThreshold) = abi.decode(opData, (address[], uint256));
             if (newSigners.length == 0) revert NoSigners();
             _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
-            _requireDisjoint(newSigners, _enclaveSigners);
+            // Federation must stay disjoint from every enclave source-chain set.
+            _requireDisjointFromAllEnclaveSets(newSigners, 0);
             _federationSigners = newSigners;
             federationThreshold = newThreshold;
             emit FederationSignersUpdated(newSigners, newThreshold);
@@ -1221,6 +1283,19 @@ contract MultisigProxy is IMultisigProxy {
             for (uint256 j = 0; j < counterpart.length; j++) {
                 if (candidate[i] == counterpart[j]) revert SignerSetsOverlap(candidate[i]);
             }
+        }
+    }
+
+    /// @dev Reverts if `candidate` overlaps any registered enclave source-chain
+    ///      set, skipping `exceptSourceChain` (pass `0` to skip none). Used to
+    ///      keep every enclave set disjoint from the others and from the
+    ///      federation. Cost is bounded by `MAX_ENCLAVE_SOURCE_CHAINS` *
+    ///      `MAX_SIGNERS` * candidate length.
+    function _requireDisjointFromAllEnclaveSets(address[] memory candidate, uint256 exceptSourceChain) private view {
+        uint256[] memory chains = _enclaveSourceChains;
+        for (uint256 i = 0; i < chains.length; i++) {
+            if (chains[i] == exceptSourceChain) continue;
+            _requireDisjoint(candidate, _enclaveSigners[chains[i]]);
         }
     }
 

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -13,7 +13,8 @@ import { IBridge } from './IBridge.sol';
 ///        - `fundsOutCall`   — a single `Bridge.fundsOut` (RGB → Arbitrum);
 ///        - `lzFundsOutCall`  — `Bridge.fundsOut` to the LZ adapter then
 ///          `adapter.sendOut`, with the two legs bound on-chain (RGB → non-Arbitrum).
-///      Both share a single sequential `teeNonce` for replay protection.
+///      Each source chain has its own `teeNonce` lane, selected by the
+///      release's `sourceChainId`, for per-network replay protection.
 ///
 ///      FEDERATION SIGNERS (governance / admin nodes)
 ///      All administrative operations go through a two-phase timelock:
@@ -67,6 +68,8 @@ interface IMultisigProxy {
     error DuplicateSigner();
     error SignerSetsOverlap(address signer);
     error TooManySigners(uint256 count, uint256 max);
+    error UnknownSourceChain(uint256 sourceChainId);
+    error TooManyEnclaveSourceChains(uint256 count, uint256 max);
     error CallFailed();
     error UnknownOperationType();
     error ZeroRecipient();
@@ -133,8 +136,9 @@ interface IMultisigProxy {
     // =========================================================================
 
     // TEE — typed enclave releases
-    event FundsOutExecuted(uint256 indexed nonce, uint256 enclaveBitmap);
+    event FundsOutExecuted(uint256 indexed sourceChainId, uint256 indexed nonce, uint256 enclaveBitmap);
     event LzFundsOutExecuted(
+        uint256 indexed sourceChainId,
         uint256 indexed nonce,
         uint256 enclaveBitmap,
         uint32  dstEid,
@@ -159,7 +163,7 @@ interface IMultisigProxy {
     event EmergencyUnpaused(uint256 nonce, uint256 fedBitmap);
 
     // Emitted when proposals are executed
-    event EnclaveSignersUpdated(address[] newSigners, uint256 newThreshold);
+    event EnclaveSignersUpdated(uint256 indexed sourceChainId, address[] newSigners, uint256 newThreshold);
     event FederationSignersUpdated(address[] newSigners, uint256 newThreshold);
     event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
@@ -233,9 +237,12 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose replacing the enclave signer set.
-    /// @dev opData = abi.encode(address[] newSigners, uint256 newThreshold)
+    /// @notice Propose replacing (or registering) the enclave signer set for a
+    ///         given source chain. A `sourceChainId` with no set yet is
+    ///         registered on execution (bounded by `MAX_ENCLAVE_SOURCE_CHAINS`).
+    /// @dev opData = abi.encode(uint256 sourceChainId, address[] newSigners, uint256 newThreshold)
     function proposeUpdateEnclaveSigners(
+        uint256 sourceChainId,
         address[] calldata newSigners,
         uint256 newThreshold,
         uint256 nonce,
@@ -464,24 +471,29 @@ interface IMultisigProxy {
     // View
     // =========================================================================
 
-    /// @notice Verify that `signature` over `digest` was produced by the enclave signer at `signerIndex`.
+    /// @notice Verify that `signature` over `digest` was produced by the enclave
+    ///         signer at `signerIndex` for the given `sourceChainId` set.
     function verifyEnclaveSignature(
+        uint256 sourceChainId,
         bytes32 digest,
         bytes calldata signature,
         uint256 signerIndex
     ) external view returns (bool);
 
-    function teeNonce() external view returns (uint256);
+    function teeNonce(uint256 sourceChainId) external view returns (uint256);
     function bridge() external view returns (address);
     function commissionManager() external view returns (address);
     function lzAdapter() external view returns (address);
-    function getEnclaveSigners() external view returns (address[] memory);
-    function enclaveThreshold() external view returns (uint256);
+    function getEnclaveSigners(uint256 sourceChainId) external view returns (address[] memory);
+    function getEnclaveSourceChains() external view returns (uint256[] memory);
+    function enclaveThreshold(uint256 sourceChainId) external view returns (uint256);
     function getFederationSigners() external view returns (address[] memory);
     function federationThreshold() external view returns (uint256);
     function commissionRecipient() external view returns (address);
     function DOMAIN_SEPARATOR() external view returns (bytes32);
     function proposalNonce() external view returns (uint256);
+
+    function emergencyNonce() external view returns (uint256);
     function timelockDuration() external view returns (uint256);
     function MIN_TIMELOCK() external view returns (uint256);
     function getProposal(bytes32 proposalId) external view returns (Proposal memory);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -2532,7 +2532,10 @@ contract BridgeTest is Test {
     // Current behavior: Bridge calls the settlement hook after pulling gross
     // funds but before forwarding token commission, so a hook can observe funds
     // that will not remain as Bridge liquidity after the call.
-    function test_onFundsInHookSeesBalanceIncludingFutureCommission_currentBehavior() public {
+    // R-W-17 after-fix: the token commission is forwarded before the onFundsIn
+    // hook, so a settlement module reading getContractBalance during the hook
+    // observes only the net the Bridge retains — never the in-flight commission.
+    function test_onFundsInHookSeesNetBalanceNotFutureCommission_afterFix() public {
         uint256 percent = 400; // 4%
         _setFundsInTokenRule(percent);
 
@@ -2591,8 +2594,8 @@ contract BridgeTest is Test {
         assertEq(observingModule.lastNetAmount(), netAmount, 'module got net amount');
         assertEq(
             observingModule.lastObservedBalanceOnFundsIn(),
-            bridgeBefore + AMOUNT,
-            'hook saw gross bridge balance'
+            bridgeBefore + netAmount,
+            'hook sees only the retained net, not the in-flight commission'
         );
         assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore + netAmount, 'final bridge net');
         assertEq(usdt0.balanceOf(address(cm)), cmBefore + tokenCommission, 'cm token delta');

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -1663,6 +1663,31 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId),           expectedNet,         'record = net');
     }
 
+    // R-I-04 end-to-end: a token already donated directly to the CommissionManager
+    // is NOT absorbed as commission. Bridge measures the delta of its own transfer,
+    // so the pool grows by exactly the real fee; the donation stays a stray balance.
+    function test_fundsIn_tokenCommission_doesNotAbsorbCmDonation_afterFix() public {
+        _setFundsInTokenRule(400); // 4%
+        uint256 expectedCommission = (AMOUNT * 400) / 100 / 100;
+
+        // Unsolicited direct transfer into the CommissionManager.
+        address donor = makeAddr('cmDonor');
+        uint256 donation = 5e18;
+        usdt0.mint(donor, donation);
+        vm.prank(donor);
+        usdt0.transfer(address(cm), donation);
+
+        assertEq(cm.tokenCommissionPool(address(usdt0)), 0,        'pre pool (donation not counted)');
+        assertEq(usdt0.balanceOf(address(cm)),           donation, 'pre cm balance holds donation');
+
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        // Pool grew by exactly the real commission — the donation was not folded in.
+        assertEq(cm.tokenCommissionPool(address(usdt0)), expectedCommission,            'pool grew only by real commission');
+        assertEq(usdt0.balanceOf(address(cm)),           donation + expectedCommission, 'donation still present as stray balance');
+    }
+
     // ========================================================================
     // Commission — fundsIn NATIVE
     // ========================================================================

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -696,62 +696,63 @@ contract CommissionManagerTest is Test {
 
         vm.prank(user);
         vm.expectRevert(ICommissionManager.OnlyBridge.selector);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
         assertEq(cm.tokenCommissionPool(address(token)), amt);
     }
 
     function test_receiveTokenCommission_revertsNothingReceived() public {
         vm.prank(BRIDGE);
         vm.expectRevert(ICommissionManager.NothingReceived.selector);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), 0);
     }
 
-    function test_receiveTokenCommission_revertsNothingReceived_whenNoNewTokens() public {
-        uint256 amt = 10 ether;
-        token.mint(address(cm), amt);
-        vm.startPrank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
-        vm.expectRevert(ICommissionManager.NothingReceived.selector);
-        cm.receiveTokenCommission(address(token));
-        vm.stopPrank();
+    // After the R-I-04 fix the pool is credited by the passed `credited`, not by
+    // balanceOf - pool. Crediting more than the on-chain balance can back reverts
+    // BalanceBelowRecordedPool (guards against over-crediting).
+    function test_receiveTokenCommission_revertsWhenCreditExceedsBalance() public {
+        token.mint(address(cm), 5 ether);
+        vm.prank(BRIDGE);
+        vm.expectRevert(ICommissionManager.BalanceBelowRecordedPool.selector);
+        cm.receiveTokenCommission(address(token), 6 ether);
     }
 
-    // Current behavior: token commission accounting records the whole balance
-    // delta since the last pool update, so unsolicited tokens already sitting
-    // in the CommissionManager are credited with the next bridge commission.
-    function test_unsolicitedTokenBalanceIncludedInNextCommissionCredit_currentBehavior() public {
+    // R-I-04 after-fix: an unsolicited direct transfer already sitting in the CM
+    // is NOT folded into the pool. The Bridge measures only its own transfer and
+    // passes that as `credited`; the donation stays as a stray balance.
+    function test_receiveTokenCommission_doesNotAbsorbUnsolicitedBalance_afterFix() public {
         uint256 unsolicitedAmount = 3 ether;
         uint256 legitimateAmount  = 7 ether;
-        uint256 expectedCredit    = unsolicitedAmount + legitimateAmount;
 
         token.mint(user, unsolicitedAmount);
         vm.prank(user);
-        token.transfer(address(cm), unsolicitedAmount);
+        token.transfer(address(cm), unsolicitedAmount); // donation
 
         token.mint(BRIDGE, legitimateAmount);
         vm.prank(BRIDGE);
-        token.transfer(address(cm), legitimateAmount);
+        token.transfer(address(cm), legitimateAmount); // the Bridge's transfer
 
-        assertEq(token.balanceOf(address(cm)), expectedCredit, 'pre cm token balance');
+        assertEq(token.balanceOf(address(cm)), unsolicitedAmount + legitimateAmount, 'pre cm token balance');
         assertEq(cm.tokenCommissionPool(address(token)), 0, 'pre cm pool');
 
+        // Bridge credits ONLY the amount its transfer actually delivered.
         vm.expectEmit(true, false, false, true, address(cm));
-        emit TokenCommissionReceived(address(token), expectedCredit);
+        emit TokenCommissionReceived(address(token), legitimateAmount);
 
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), legitimateAmount);
 
-        assertEq(cm.tokenCommissionPool(address(token)), expectedCredit, 'pool includes unsolicited balance');
+        assertEq(cm.tokenCommissionPool(address(token)), legitimateAmount, 'pool credited only the legit commission');
+        assertEq(token.balanceOf(address(cm)), unsolicitedAmount + legitimateAmount, 'donation stays as stray balance');
     }
 
     function test_withdrawTokenCommission_transfersAndUpdatesPool() public {
         uint256 amt = 50 ether;
         token.mint(address(cm), amt);
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(owner);
         cm.withdrawTokenCommission(address(token), recipient, amt);
@@ -764,7 +765,7 @@ contract CommissionManagerTest is Test {
         uint256 amt = 30 ether;
         token.mint(address(cm), amt);
         vm.prank(BRIDGE);
-        cm.receiveTokenCommission(address(token));
+        cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(owner);
         cm.withdrawAllTokenCommission(address(token), recipient);

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -208,6 +208,7 @@ contract IntegrationTest is Test {
             address(bridge),
             address(cm),
             enc, 2,
+            RGB_CHAIN_ID,
             fed, 2,
             commissionReceiver,
             TIMELOCK,
@@ -350,7 +351,7 @@ contract IntegrationTest is Test {
             settlementData
         );
 
-        uint256 outNonce    = proxy.teeNonce();
+        uint256 outNonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 outDeadline = block.timestamp + 1 hours;
         bytes32 outDigest   = MultisigHelper.digestTeeFundsOut(
             domainSep, params, outNonce, outDeadline

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -68,8 +68,9 @@ contract MultisigProxyTest is Test {
     using MultisigHelper for bytes32;
 
     // ---- Re-declared events ------------------------------------------------
-    event FundsOutExecuted(uint256 indexed nonce, uint256 enclaveBitmap);
+    event FundsOutExecuted(uint256 indexed sourceChainId, uint256 indexed nonce, uint256 enclaveBitmap);
     event LzFundsOutExecuted(
+        uint256 indexed sourceChainId,
         uint256 indexed nonce,
         uint256 enclaveBitmap,
         uint32  dstEid,
@@ -88,7 +89,7 @@ contract MultisigProxyTest is Test {
     );
     event ProposalCancelled(bytes32 indexed proposalId);
     event ProposalExecuted(bytes32 indexed proposalId, IMultisigProxy.OperationType indexed opType);
-    event EnclaveSignersUpdated(address[] newSigners, uint256 newThreshold);
+    event EnclaveSignersUpdated(uint256 indexed sourceChainId, address[] newSigners, uint256 newThreshold);
     event FederationSignersUpdated(address[] newSigners, uint256 newThreshold);
     event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
@@ -244,6 +245,7 @@ contract MultisigProxyTest is Test {
             address(bridge),
             address(cm),
             enc, 2,
+            RGB_CHAIN_ID,
             fed, 2,
             commissionReceiver,
             TIMELOCK,
@@ -421,7 +423,7 @@ contract MultisigProxyTest is Test {
         view
         returns (uint256 nonce, uint256 bitmap, bytes[] memory sigs)
     {
-        nonce = proxy.teeNonce();
+        nonce = proxy.teeNonce(RGB_CHAIN_ID);
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
         uint256[] memory pks;
         (pks, bitmap) = _encSigSet2of3();
@@ -447,14 +449,14 @@ contract MultisigProxyTest is Test {
     function test_constructor_setsState() public view {
         assertEq(proxy.bridge(), address(bridge));
         assertEq(proxy.commissionManager(), address(cm));
-        assertEq(proxy.enclaveThreshold(), 2);
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), 2);
         assertEq(proxy.federationThreshold(), 2);
         assertEq(proxy.commissionRecipient(), commissionReceiver);
         assertEq(proxy.timelockDuration(), TIMELOCK);
         assertEq(proxy.proposalNonce(), 0);
-        assertEq(proxy.teeNonce(),      0);
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),      0);
 
-        address[] memory enc = proxy.getEnclaveSigners();
+        address[] memory enc = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(enc.length, 3);
         assertEq(enc[0], encA1);
 
@@ -466,38 +468,38 @@ contract MultisigProxyTest is Test {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroBridge.selector);
-        new MultisigProxy(address(0), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(0), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommissionManager() public {
         address[] memory enc = new address[](1); enc[0] = encA1;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionManager.selector);
-        new MultisigProxy(address(bridge), address(0), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(0), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnNoEnclaveSigners() public {
         address[] memory enc = new address[](0);
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.NoSigners.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 1, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnBadEnclaveThreshold() public {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
         address[] memory fed = new address[](1); fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 3, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 3, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommission() public {
         vm.expectRevert(IMultisigProxy.ZeroCommissionRecipient.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, address(0), TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, address(0), TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnTimelockTooLong() public {
         vm.expectRevert(IMultisigProxy.TimelockTooLong.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, 30 days, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, 30 days, MIN_TIMELOCK);
     }
 
     // ---- R-W-11: MIN_TIMELOCK floor (post-fix) ----
@@ -506,19 +508,19 @@ contract MultisigProxyTest is Test {
     function test_constructor_revertsOnTimelockBelowMinTimelock() public {
         // timelock (1h) is below the requested floor (2h) -> TimelockTooShort
         vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, 1 hours, 2 hours);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, 1 hours, 2 hours);
     }
 
     /// @dev A zero floor is rejected — it would defeat the purpose of the fix.
     function test_constructor_revertsOnZeroMinTimelock() public {
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, TIMELOCK, 0);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, 0);
     }
 
     /// @dev A floor at/above the upper bound leaves no valid range — rejected.
     function test_constructor_revertsOnMinTimelockTooLong() public {
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _validFed(), 2, commissionReceiver, TIMELOCK, 30 days);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, 30 days);
     }
 
     function test_minTimelock_returnsConfiguredFloor() public view {
@@ -530,7 +532,7 @@ contract MultisigProxyTest is Test {
         // the call clears the threshold guard and reverts in _validateSigners.
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA1;
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroAddressSigner() public {
@@ -539,7 +541,7 @@ contract MultisigProxyTest is Test {
         // _validateSigners.
         address[] memory enc = new address[](2); enc[0] = address(0); enc[1] = encA2;
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        new MultisigProxy(address(bridge), address(cm), enc, 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     // ========================================================================
@@ -574,41 +576,41 @@ contract MultisigProxyTest is Test {
 
     function test_constructor_rejectsOneOfThree_enclave() public {
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _signers(3), 1, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _signers(3), 1, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_rejectsOneOfOne_enclave() public {
         // n < 2 — single-key set, rejected even though 2*1 > 1.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _signers(1), 1, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _signers(1), 1, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_rejectsSubMajority_enclave() public {
         // 2-of-4: 2*2 == 4, not a strict majority.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _signers(4), 2, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _signers(4), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_rejectsOneOfThree_federation() public {
         // Enclave valid, federation 1-of-3 — the floor applies to both sets.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, _signers(3), 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _signers(3), 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_acceptsTwoOfTwo() public {
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(2), 2, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(2), 2, RGB_CHAIN_ID, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.enclaveThreshold(),    2);
+        assertEq(p.enclaveThreshold(RGB_CHAIN_ID),    2);
         assertEq(p.federationThreshold(), 2);
     }
 
     function test_constructor_acceptsThreeOfFour() public {
         // Strict majority with a non-trivial set (2*3 > 4).
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(4), 3, _signersB(4), 3, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(4), 3, RGB_CHAIN_ID, _signersB(4), 3, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.enclaveThreshold(),    3);
+        assertEq(p.enclaveThreshold(RGB_CHAIN_ID),    3);
         assertEq(p.federationThreshold(), 3);
     }
 
@@ -621,14 +623,14 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, badThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, badThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         // Threshold validity is now enforced up front, at propose time.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, badThreshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, badThreshold, nonce, deadline, bitmap, sigs);
     }
 
     // ---- Intrinsic set validation runs at propose time ----
@@ -643,13 +645,13 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, threshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, threshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.NoSigners.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, threshold, nonce, deadline, bitmap, sigs);
     }
 
     function test_proposeUpdateEnclaveSigners_rejectsZeroAddressSignerAtPropose() public {
@@ -660,13 +662,13 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, threshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, threshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, threshold, nonce, deadline, bitmap, sigs);
     }
 
     function test_proposeUpdateEnclaveSigners_rejectsDuplicateSignerAtPropose() public {
@@ -677,13 +679,13 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, threshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, threshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        proxy.proposeUpdateEnclaveSigners(newSigners, threshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, threshold, nonce, deadline, bitmap, sigs);
     }
 
     function test_proposeUpdateFederationSigners_rejectsEmptySetAtPropose() public {
@@ -752,14 +754,14 @@ contract MultisigProxyTest is Test {
         address[] memory enc = new address[](2); enc[0] = encA1; enc[1] = encA2;
         address[] memory fed = new address[](2); fed[0] = encA1; fed[1] = fedA2;
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, encA1));
-        new MultisigProxy(address(bridge), address(cm), enc, 2, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_acceptsDisjointSignerSets() public {
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(2), 2, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(2), 2, RGB_CHAIN_ID, _signersB(2), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.getEnclaveSigners().length,    2);
+        assertEq(p.getEnclaveSigners(RGB_CHAIN_ID).length,    2);
         assertEq(p.getFederationSigners().length, 2);
     }
 
@@ -771,16 +773,16 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, fedA1));
-        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        proxy.executeProposal(id, abi.encode(RGB_CHAIN_ID, newSigners, newThreshold));
     }
 
     function test_proposeUpdateFederationSigners_rejectsOverlapWithEnclaveAtExecute() public {
@@ -818,7 +820,7 @@ contract MultisigProxyTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
         new MultisigProxy(
-            address(bridge), address(cm), enc, encThreshold, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), enc, encThreshold, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
     }
 
@@ -827,9 +829,9 @@ contract MultisigProxyTest is Test {
         uint256 threshold = max / 2 + 1; // 11-of-20 strict majority
 
         MultisigProxy p = new MultisigProxy(
-            address(bridge), address(cm), _signers(max), threshold, _signersB(max), threshold, commissionReceiver, TIMELOCK, MIN_TIMELOCK
+            address(bridge), address(cm), _signers(max), threshold, RGB_CHAIN_ID, _signersB(max), threshold, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
-        assertEq(p.getEnclaveSigners().length,    max);
+        assertEq(p.getEnclaveSigners(RGB_CHAIN_ID).length,    max);
         assertEq(p.getFederationSigners().length, max);
     }
 
@@ -841,14 +843,14 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         // Signer-set size is now enforced up front, at propose time.
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
-        proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
     }
 
     // ========================================================================
@@ -857,25 +859,25 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_releasesViaBridge() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        vm.expectEmit(true, false, false, true);
-        emit FundsOutExecuted(nonce, bitmap);
+        vm.expectEmit(true, true, false, true);
+        emit FundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap);
 
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
         assertEq(token.balanceOf(recipient), AMOUNT);
-        assertEq(proxy.teeNonce(), nonce + 1);
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1);
     }
 
     function test_fundsOutCall_revertsOnExpired() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp - 1;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -897,7 +899,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnDeadlineTooFar() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE() + 1;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -910,7 +912,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_acceptsDeadlineAtMaxBoundary() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE(); // exact boundary, strict `>` lets it through
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -928,7 +930,7 @@ contract MultisigProxyTest is Test {
         _setLzAdapter(address(adapter));
 
         IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE() + 1;
 
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
@@ -947,7 +949,7 @@ contract MultisigProxyTest is Test {
         _setLzAdapter(address(adapter));
 
         IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + proxy.MAX_TEE_DEADLINE(); // exact boundary
 
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
@@ -957,7 +959,7 @@ contract MultisigProxyTest is Test {
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
         assertEq(token.balanceOf(mockOft), AMOUNT, 'lz release executes at the exact deadline ceiling');
-        assertEq(proxy.teeNonce(),         nonce + 1, 'teeNonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),         nonce + 1, 'teeNonce incremented');
     }
 
     function test_fundsOutCall_revertsOnWrongNonce() public {
@@ -979,7 +981,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnBelowThreshold() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -992,7 +994,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnBadSignature() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -1007,7 +1009,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnSigCountMismatch() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -1021,7 +1023,7 @@ contract MultisigProxyTest is Test {
 
     function test_fundsOutCall_revertsOnBitmapOutOfRange() public {
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -1034,7 +1036,7 @@ contract MultisigProxyTest is Test {
 
     function test_lzFundsOutCall_revertsIfAdapterUnset() public {
         IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
-        uint256 nonce    = proxy.teeNonce();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
@@ -1050,7 +1052,7 @@ contract MultisigProxyTest is Test {
     // ========================================================================
 
     function test_emergencyPause_works() public {
-        uint256 nonce = proxy.proposalNonce();
+        uint256 nonce = proxy.emergencyNonce();
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
@@ -1063,11 +1065,12 @@ contract MultisigProxyTest is Test {
         proxy.emergencyPause(nonce, deadline, bitmap, sigs);
 
         assertTrue(bridge.paused());
-        assertEq(proxy.proposalNonce(), nonce + 1);
+        assertEq(proxy.emergencyNonce(), nonce + 1, 'emergency lane advanced');
+        assertEq(proxy.proposalNonce(), 0, 'proposal lane untouched by emergency');
     }
 
     function test_emergencyPause_revertsOnExpired() public {
-        uint256 nonce = proxy.proposalNonce();
+        uint256 nonce = proxy.emergencyNonce();
         uint256 deadline = block.timestamp - 1;
 
         bytes32 digest = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
@@ -1093,7 +1096,7 @@ contract MultisigProxyTest is Test {
     function test_emergencyUnpause_works() public {
         test_emergencyPause_works();
 
-        uint256 nonce = proxy.proposalNonce();
+        uint256 nonce = proxy.emergencyNonce();
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestEmergencyUnpause(domainSep, nonce, deadline);
@@ -1118,7 +1121,7 @@ contract MultisigProxyTest is Test {
     ///      must be frozen as well.
     function test_emergencyPause_freezesEnclaveFundsOut() public {
         // Federation triggers the emergency freeze (both paths).
-        uint256 nonce    = proxy.proposalNonce();
+        uint256 nonce    = proxy.emergencyNonce();
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 digest   = MultisigHelper.digestEmergencyPause(domainSep, nonce, deadline);
         (uint256[] memory fpks, uint256 fbitmap) = _fedSigSet2of3();
@@ -1135,7 +1138,7 @@ contract MultisigProxyTest is Test {
         // Enclave-signed release is frozen too — the revert propagates from
         // Bridge.fundsOut through proxy.fundsOutCall.
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 encNonce      = proxy.teeNonce();
+        uint256 encNonce      = proxy.teeNonce(RGB_CHAIN_ID);
         bytes32 encDigest     = MultisigHelper.digestTeeFundsOut(domainSep, params, encNonce, deadline);
         (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
         bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
@@ -1171,7 +1174,7 @@ contract MultisigProxyTest is Test {
 
         // ...but the enclave release still executes.
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 encNonce      = proxy.teeNonce();
+        uint256 encNonce      = proxy.teeNonce(RGB_CHAIN_ID);
         bytes32 encDigest     = MultisigHelper.digestTeeFundsOut(domainSep, params, encNonce, t + 1 days);
         (uint256[] memory epks, uint256 ebitmap) = _encSigSet2of3();
         bytes[] memory esigs   = MultisigHelper.signAll(vm, encDigest, epks);
@@ -1294,20 +1297,20 @@ contract MultisigProxyTest is Test {
         uint256 deadline = block.timestamp + 1 days;
 
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
-        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        proxy.executeProposal(id, abi.encode(RGB_CHAIN_ID, newSigners, newThreshold));
 
-        address[] memory after_ = proxy.getEnclaveSigners();
+        address[] memory after_ = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(after_.length, 2);
         assertEq(after_[1], newSigner);
-        assertEq(proxy.enclaveThreshold(), newThreshold);
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), newThreshold);
     }
 
     // ========================================================================
@@ -1557,8 +1560,8 @@ contract MultisigProxyTest is Test {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(encPk1, digest);
         bytes memory sig = abi.encodePacked(r, s, v);
 
-        assertTrue(proxy.verifyEnclaveSignature(digest, sig, 0));
-        assertFalse(proxy.verifyEnclaveSignature(digest, sig, 1));
+        assertTrue(proxy.verifyEnclaveSignature(RGB_CHAIN_ID, digest, sig, 0));
+        assertFalse(proxy.verifyEnclaveSignature(RGB_CHAIN_ID, digest, sig, 1));
     }
 
     function test_verifyEnclaveSignature_revertsOutOfRange() public {
@@ -1567,7 +1570,7 @@ contract MultisigProxyTest is Test {
         bytes memory sig = abi.encodePacked(r, s, v);
 
         vm.expectRevert(IMultisigProxy.IndexOutOfRange.selector);
-        proxy.verifyEnclaveSignature(digest, sig, 99);
+        proxy.verifyEnclaveSignature(RGB_CHAIN_ID, digest, sig, 99);
     }
 
     // ========================================================================
@@ -1952,7 +1955,7 @@ contract MultisigProxyTest is Test {
         // Sign a valid TEE fundsOut on the original chain (domainSep was cached
         // at setUp for block.chainid).
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
 
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
@@ -1995,7 +1998,7 @@ contract MultisigProxyTest is Test {
 
         // Prepare signed TEE execution and snapshot proxy + Bridge accounting.
         IBridge.FundsOutParams memory params = _fundsOutParams();
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
@@ -2027,12 +2030,12 @@ contract MultisigProxyTest is Test {
             SOURCE_CHAIN_ID,
             SRC_ADDR
         );
-        vm.expectEmit(true, false, false, true);
-        emit FundsOutExecuted(nonce, bitmap);
+        vm.expectEmit(true, true, false, true);
+        emit FundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap);
 
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(), nonce + 1, 'nonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'nonce incremented');
         assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT,        'bridge gross debit');
         assertEq(token.balanceOf(recipient),       recipientBefore + netAmount, 'recipient net delta');
@@ -2124,13 +2127,13 @@ contract MultisigProxyTest is Test {
         );
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(), nonce + 1, 'tee nonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'tee nonce incremented');
         assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)),  bridgeBefore - AMOUNT,          'bridge gross debit');
         assertEq(token.balanceOf(address(cm)),      cmBefore + tokenCommission,     'cm fee delta');
@@ -2210,7 +2213,7 @@ contract MultisigProxyTest is Test {
         vm.expectRevert(bytes('native fee'));
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE - 1 }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce,            'tee nonce unchanged');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce,            'tee nonce unchanged');
         assertFalse(bridge.consumedBurnIds(params.burnId),          'burn id unchanged');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
         assertEq(token.balanceOf(address(adapter)), adapterBefore,  'adapter token unchanged');
@@ -2295,7 +2298,7 @@ contract MultisigProxyTest is Test {
         vm.expectRevert(bytes('verify: block commitment'));
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce,            'tee nonce unchanged');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce,            'tee nonce unchanged');
         assertFalse(bridge.consumedBurnIds(params.burnId),          'burn id unchanged');
         assertEq(adapter.sendOutCalls(),           0,               'adapter not called');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore,    'bridge token unchanged');
@@ -2387,13 +2390,13 @@ contract MultisigProxyTest is Test {
         );
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce + 1,        'tee nonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce + 1,        'tee nonce incremented');
         assertTrue(bridge.consumedBurnIds(params.burnId),            'burn id consumed');
         assertEq(adapter.sendOutCalls(),           1,               'adapter called once');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge token debit');
@@ -2486,13 +2489,13 @@ contract MultisigProxyTest is Test {
         );
         vm.expectEmit(true, false, false, true, address(adapter));
         emit SendOut(sendOutGuid, DST_EID, LZ_RECIPIENT, netAmount);
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit LzFundsOutExecuted(nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, DST_EID, LZ_RECIPIENT, netAmount);
 
         vm.deal(address(this), LZ_NATIVE_FEE);
         proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(),                nonce + 1,        'tee nonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID),                nonce + 1,        'tee nonce incremented');
         assertTrue(bridge.consumedBurnIds(params.burnId),            'burn id consumed');
         assertEq(adapter.sendOutCalls(),           1,               'adapter called once');
         assertEq(token.balanceOf(address(bridge)), bridgeBefore - AMOUNT, 'bridge token debit');
@@ -2627,7 +2630,7 @@ contract MultisigProxyTest is Test {
         // later, this test should be inverted to expect a revert.
         IBridge.FundsOutParams memory params = _fundsOutParams(drainRecipient, bridgeBefore, BURN_ID);
         assertFalse(bridge.consumedBurnIds(params.burnId), 'pre burn id');
-        uint256 nonce = proxy.teeNonce();
+        uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
@@ -2644,12 +2647,12 @@ contract MultisigProxyTest is Test {
             SOURCE_CHAIN_ID,
             SRC_ADDR
         );
-        vm.expectEmit(true, false, false, true, address(proxy));
-        emit FundsOutExecuted(nonce, bitmap);
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit FundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap);
 
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(), nonce + 1, 'nonce incremented');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'nonce incremented');
         assertTrue(bridge.consumedBurnIds(params.burnId), 'burn id consumed');
         assertEq(token.balanceOf(address(bridge)), 0, 'bridge pool drained');
         assertEq(token.balanceOf(drainRecipient), recipientBefore + bridgeBefore, 'recipient got full pool');
@@ -2663,22 +2666,22 @@ contract MultisigProxyTest is Test {
         newSigners[2] = makeAddr('unattestedEnc3');
         uint256 newThreshold = 2;
 
-        address[] memory before_ = proxy.getEnclaveSigners();
+        address[] memory before_ = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(before_.length, 3, 'pre enclave count');
         assertEq(before_[0], encA1, 'pre signer 0');
         assertEq(before_[1], encA2, 'pre signer 1');
         assertEq(before_[2], encA3, 'pre signer 2');
-        assertEq(proxy.enclaveThreshold(), 2, 'pre enclave threshold');
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), 2, 'pre enclave threshold');
 
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
         bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
-            domainSep, newSigners, newThreshold, nonce, deadline
+            domainSep, RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline
         );
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(newSigners, newThreshold, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(RGB_CHAIN_ID, newSigners, newThreshold, nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
 
@@ -2686,19 +2689,19 @@ contract MultisigProxyTest is Test {
         // this case documents that only address shape and threshold are checked,
         // with no on-chain enclave attestation evidence. If attestation is
         // enforced later, this test should be inverted to expect a revert.
-        vm.expectEmit(false, false, false, true, address(proxy));
-        emit EnclaveSignersUpdated(newSigners, newThreshold);
+        vm.expectEmit(true, false, false, true, address(proxy));
+        emit EnclaveSignersUpdated(RGB_CHAIN_ID, newSigners, newThreshold);
         vm.expectEmit(true, true, false, true, address(proxy));
         emit ProposalExecuted(id, IMultisigProxy.OperationType.UpdateEnclaveSigners);
 
-        proxy.executeProposal(id, abi.encode(newSigners, newThreshold));
+        proxy.executeProposal(id, abi.encode(RGB_CHAIN_ID, newSigners, newThreshold));
 
-        address[] memory after_ = proxy.getEnclaveSigners();
+        address[] memory after_ = proxy.getEnclaveSigners(RGB_CHAIN_ID);
         assertEq(after_.length, 3, 'post enclave count');
         assertEq(after_[0], newSigners[0], 'post signer 0');
         assertEq(after_[1], newSigners[1], 'post signer 1');
         assertEq(after_[2], newSigners[2], 'post signer 2');
-        assertEq(proxy.enclaveThreshold(), newThreshold, 'post enclave threshold');
+        assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), newThreshold, 'post enclave threshold');
     }
 
     function test_proposalUsesSnapshottedTimelock_afterFix() public {
@@ -2749,42 +2752,38 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.bridge(), newBridge, 'snapshotted proposal executes despite the live timelock raise');
     }
 
-    // Current behavior: emergency actions and regular proposals share
-    // proposalNonce, so an emergency pause can stale an already signed regular
-    // proposal before it is submitted on-chain.
-    function test_emergencyAndRegularProposalNonceCollide_currentBehavior() public {
+    // R-I-09 after-fix: emergency actions run on a separate `emergencyNonce`, so
+    // an emergency pause does NOT stale an already-signed regular proposal — the
+    // pre-signed proposal still submits.
+    function test_emergencyDoesNotStaleRegularProposal_afterFix() public {
         address newBridge = makeAddr('nonceCollisionBridge');
         uint256 regularNonce = proxy.proposalNonce();
         uint256 regularDeadline = block.timestamp + 1 days;
 
+        // Pre-sign a regular proposal at the current proposal-lane nonce.
         bytes32 regularDigest = MultisigHelper.digestProposeUpdateBridge(
             domainSep, newBridge, regularNonce, regularDeadline
         );
         (uint256[] memory regularPks, uint256 regularBitmap) = _fedSigSet2of3();
         bytes[] memory regularSigs = MultisigHelper.signAll(vm, regularDigest, regularPks);
 
-        uint256 emergencyDeadline = block.timestamp + 1 hours;
-        bytes32 emergencyDigest = MultisigHelper.digestEmergencyPause(domainSep, regularNonce, emergencyDeadline);
+        // An emergency pause runs on its own lane nonce.
+        uint256 emergencyLaneNonce = proxy.emergencyNonce();
+        uint256 emergencyDeadline  = block.timestamp + 1 hours;
+        bytes32 emergencyDigest = MultisigHelper.digestEmergencyPause(domainSep, emergencyLaneNonce, emergencyDeadline);
         (uint256[] memory emergencyPks, uint256 emergencyBitmap) = _fedSigSet2of3();
         bytes[] memory emergencySigs = MultisigHelper.signAll(vm, emergencyDigest, emergencyPks);
 
-        assertFalse(bridge.paused(), 'pre bridge active');
-        assertEq(proxy.proposalNonce(), regularNonce, 'pre proposal nonce');
-        assertEq(proxy.bridge(), address(bridge), 'pre bridge target');
-
-        vm.expectEmit(false, false, false, true, address(proxy));
-        emit EmergencyPaused(regularNonce, emergencyBitmap);
-
-        proxy.emergencyPause(regularNonce, emergencyDeadline, emergencyBitmap, emergencySigs);
+        proxy.emergencyPause(emergencyLaneNonce, emergencyDeadline, emergencyBitmap, emergencySigs);
 
         assertTrue(bridge.paused(), 'bridge paused by emergency action');
-        assertEq(proxy.proposalNonce(), regularNonce + 1, 'emergency consumed proposal nonce');
+        assertEq(proxy.emergencyNonce(), emergencyLaneNonce + 1, 'emergency advanced only its own lane');
+        assertEq(proxy.proposalNonce(), regularNonce, 'proposal lane untouched by emergency');
 
-        vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
-        proxy.proposeUpdateBridge(newBridge, regularNonce, regularDeadline, regularBitmap, regularSigs);
-
-        assertEq(proxy.proposalNonce(), regularNonce + 1, 'stale proposal leaves nonce unchanged');
-        assertEq(proxy.bridge(), address(bridge), 'stale proposal leaves bridge unchanged');
+        // The pre-signed regular proposal is still valid and submits successfully.
+        bytes32 id = proxy.proposeUpdateBridge(newBridge, regularNonce, regularDeadline, regularBitmap, regularSigs);
+        assertTrue(id != bytes32(0), 'regular proposal created despite the emergency action');
+        assertEq(proxy.proposalNonce(), regularNonce + 1, 'regular proposal consumed its lane nonce');
     }
 
     // Generic Bridge admin execution can still call
@@ -2927,5 +2926,440 @@ contract MultisigProxyTest is Test {
 
         bytes32 id = proxy.proposeAdminExecuteCommissionManager(callData, nonce, deadline, bitmap, sigs);
         assertTrue(id != bytes32(0), 'non-withdrawal CM selector accepted on the generic path');
+    }
+
+    // ========================================================================
+    // Per-source-chain enclave signer sets
+    // ========================================================================
+    //
+    // NOTE: these tests run multiple propose -> warp -> execute cycles. Time is
+    // read via `vm.getBlockTimestamp()` rather than the `block.timestamp` opcode:
+    // under via_ir the optimizer caches `block.timestamp` across the `vm.warp`
+    // staticcall, so a later cycle would otherwise reuse a stale timestamp.
+
+    /// @dev `n` deterministic, globally-unique signer addresses for `chainId`,
+    ///      in a keccak namespace disjoint from the setUp enclave/federation
+    ///      addresses and from every other chain's generated set.
+    function _encSetFor(uint256 chainId, uint256 n) internal pure returns (address[] memory a) {
+        a = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            a[i] = address(uint160(uint256(keccak256(abi.encode('enc-set', chainId, i)))));
+        }
+    }
+
+    /// @dev Register (or rotate) an enclave set for `chainId` via the federation
+    ///      propose -> timelock -> execute path (signed by the original 2-of-3
+    ///      federation, which is left untouched by these helpers).
+    function _govUpdateEnclave(uint256 chainId, address[] memory signers, uint256 threshold) internal {
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(
+            domainSep, chainId, signers, threshold, nonce, deadline
+        );
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(chainId, signers, threshold, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+        proxy.executeProposal(id, abi.encode(chainId, signers, threshold));
+    }
+
+    function _slice(uint256[] memory a, uint256 k) internal pure returns (uint256[] memory r) {
+        r = new uint256[](k);
+        for (uint256 i = 0; i < k; i++) r[i] = a[i];
+    }
+
+    function _bitmapFor(uint256 k) internal pure returns (uint256 b) {
+        for (uint256 i = 0; i < k; i++) b |= (uint256(1) << i);
+    }
+
+    /// @dev A federation candidate set derived from sequential private keys so
+    ///      the caller retains the pks to sign the *next* rotation.
+    function _fedFromPks(uint256 base, uint256 n)
+        internal
+        returns (address[] memory addrs, uint256[] memory pks)
+    {
+        addrs = new address[](n);
+        pks   = new uint256[](n);
+        for (uint256 i = 0; i < n; i++) {
+            pks[i]   = base + i;
+            addrs[i] = vm.addr(pks[i]);
+        }
+    }
+
+    /// @dev An enclave candidate set derived from sequential private keys, so a
+    ///      test can register the set AND later sign a real release with it.
+    function _encFromPks(uint256 base, uint256 n)
+        internal
+        returns (address[] memory addrs, uint256[] memory pks)
+    {
+        addrs = new address[](n);
+        pks   = new uint256[](n);
+        for (uint256 i = 0; i < n; i++) {
+            pks[i]   = base + i;
+            addrs[i] = vm.addr(pks[i]);
+        }
+    }
+
+    /// @dev Rotate the federation set, signing with the *current* federation pks,
+    ///      returning the gas consumed by executeProposal (the disjoint-loop leg).
+    function _rotateFedMeasured(
+        address[] memory newAddrs,
+        uint256 newThr,
+        uint256[] memory curPks,
+        uint256 curBitmap
+    ) internal returns (uint256 gasUsed) {
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(
+            domainSep, newAddrs, newThr, nonce, deadline
+        );
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, curPks);
+        bytes32 id = proxy.proposeUpdateFederationSigners(newAddrs, newThr, nonce, deadline, curBitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+        uint256 g0 = gasleft();
+        proxy.executeProposal(id, abi.encode(newAddrs, newThr));
+        gasUsed = g0 - gasleft();
+    }
+
+    // ---- release-path behaviour -------------------------------------------
+
+    /// @dev `fundsOutCall` for a source chain with no registered enclave set
+    ///      reverts UnknownSourceChain before touching the nonce/signatures.
+    function test_perSourceChain_fundsOutRevertsForUnregisteredSourceChain() public {
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        p.sourceChainId = 424_242; // not registered
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(424_242)));
+        proxy.fundsOutCall(p, 0, vm.getBlockTimestamp() + 1 hours, 0, new bytes[](0));
+    }
+
+    /// @dev A release for chain B signed by chain A's (RGB) enclave keys is
+    ///      rejected: selection by sourceChainId verifies A's signatures against
+    ///      B's set, which does not contain them.
+    function test_perSourceChain_signatureFromAnotherChainRejected() public {
+        uint256 chainB = 7_000_001;
+        _govUpdateEnclave(chainB, _encSetFor(chainB, 3), 2);
+
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        p.sourceChainId = chainB;
+        uint256 nonce    = proxy.teeNonce(chainB); // 0
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, p, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3(); // RGB signers
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        // Must fail at the signer check (recovered RGB signer != chainB's set),
+        // NOT downstream in the Bridge — that is what proves signer-set isolation.
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.fundsOutCall(p, nonce, deadline, bitmap, sigs);
+    }
+
+    /// @dev Each source chain has an independent teeNonce lane: an RGB release
+    ///      advances only RGB's nonce, not another registered chain's.
+    function test_perSourceChain_teeNonceLanesIndependent() public {
+        uint256 chainB = 7_000_002;
+        _govUpdateEnclave(chainB, _encSetFor(chainB, 3), 2);
+
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), 0, 'RGB nonce starts at 0');
+        assertEq(proxy.teeNonce(chainB), 0, 'chainB nonce starts at 0');
+
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, p, proxy.teeNonce(RGB_CHAIN_ID), deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        proxy.fundsOutCall(p, 0, deadline, bitmap, sigs);
+
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), 1, 'RGB lane advanced');
+        assertEq(proxy.teeNonce(chainB), 0, 'chainB lane untouched');
+    }
+
+    // ---- registration / rotation ------------------------------------------
+
+    function test_perSourceChain_registerNewChain() public {
+        uint256 chainB = 8_000_001;
+        address[] memory sB = _encSetFor(chainB, 4);
+        _govUpdateEnclave(chainB, sB, 3); // 2*3 > 4
+
+        assertEq(proxy.enclaveThreshold(chainB), 3);
+        address[] memory got = proxy.getEnclaveSigners(chainB);
+        assertEq(got.length, 4);
+        assertEq(got[0], sB[0]);
+
+        uint256[] memory chains = proxy.getEnclaveSourceChains();
+        assertEq(chains.length, 2, 'RGB + chainB');
+        assertEq(chains[0], RGB_CHAIN_ID);
+        assertEq(chains[1], chainB);
+    }
+
+    /// @dev Federation rotation must be disjoint from *every* enclave chain.
+    function test_perSourceChain_federationRotationRejectsEnclaveOverlap() public {
+        uint256 chainB = 8_000_002;
+        address[] memory sB = _encSetFor(chainB, 3);
+        _govUpdateEnclave(chainB, sB, 2);
+
+        address[] memory newFed = new address[](3);
+        newFed[0] = sB[0]; // overlaps chainB
+        newFed[1] = fedA2;
+        newFed[2] = fedA3;
+
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateFederationSigners(domainSep, newFed, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateFederationSigners(newFed, 2, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, sB[0]));
+        proxy.executeProposal(id, abi.encode(newFed, 2));
+    }
+
+    /// @dev An enclave rotation for chain C must be disjoint from other enclave
+    ///      chains (here chain B).
+    function test_perSourceChain_enclaveRotationRejectsOtherChainOverlap() public {
+        uint256 chainB = 8_000_003;
+        address[] memory sB = _encSetFor(chainB, 3);
+        _govUpdateEnclave(chainB, sB, 2);
+
+        uint256 chainC = 8_000_004;
+        address[] memory sC = _encSetFor(chainC, 3);
+        sC[1] = sB[2]; // inject overlap with chainB
+
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, chainC, sC, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(chainC, sC, 2, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, sB[2]));
+        proxy.executeProposal(id, abi.encode(chainC, sC, 2));
+    }
+
+    /// @dev A partial rotation may keep some of the chain's own keys — the
+    ///      disjoint check self-excludes the chain being rotated.
+    function test_perSourceChain_partialRotationSelfExclusionAllowed() public {
+        address[] memory newRgb = new address[](2);
+        newRgb[0] = encA1; // keep an existing RGB signer
+        newRgb[1] = makeAddr('rgbFresh');
+        uint256 chainsBefore = proxy.getEnclaveSourceChains().length;
+        _govUpdateEnclave(RGB_CHAIN_ID, newRgb, 2);
+
+        address[] memory got = proxy.getEnclaveSigners(RGB_CHAIN_ID);
+        assertEq(got.length, 2);
+        assertEq(got[0], encA1, 'kept its own key via self-exclusion');
+        // Rotating an existing chain must not add a duplicate registry entry.
+        assertEq(proxy.getEnclaveSourceChains().length, chainsBefore, 'no duplicate source-chain entry on rotation');
+    }
+
+    /// @dev Registering more than MAX_ENCLAVE_SOURCE_CHAINS source chains is
+    ///      rejected at execute (bounds the cross-set disjoint loop).
+    function test_perSourceChain_maxEnclaveSourceChainsCap() public {
+        uint256 maxChains = proxy.MAX_ENCLAVE_SOURCE_CHAINS();
+        // RGB already occupies slot 1 — fill the rest.
+        for (uint256 k = 0; k < maxChains - 1; k++) {
+            uint256 chainId = 6_000_000 + k;
+            _govUpdateEnclave(chainId, _encSetFor(chainId, 2), 2);
+        }
+        assertEq(proxy.getEnclaveSourceChains().length, maxChains);
+
+        uint256 overflowChain = 6_999_999;
+        address[] memory s = _encSetFor(overflowChain, 2);
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, overflowChain, s, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        bytes32 id = proxy.proposeUpdateEnclaveSigners(overflowChain, s, 2, nonce, deadline, bitmap, sigs);
+        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(
+            IMultisigProxy.TooManyEnclaveSourceChains.selector, maxChains + 1, maxChains
+        ));
+        proxy.executeProposal(id, abi.encode(overflowChain, s, 2));
+    }
+
+    // ---- positive per-source authorization --------------------------------
+
+    /// @dev A per-source set's OWN keys authorize a release for that chain, and
+    ///      the correct nonce lane advances. RGB is rotated to keys we control
+    ///      so the full release (reusing RGB's configured route/liquidity) runs.
+    function test_perSourceChain_ownKeysAuthorizeRelease() public {
+        (address[] memory encAddrs, uint256[] memory encPks) = _encFromPks(0xEEE0000, 3);
+        _govUpdateEnclave(RGB_CHAIN_ID, encAddrs, 2);
+
+        uint256 balBefore = token.balanceOf(recipient);
+        IBridge.FundsOutParams memory p = _fundsOutParams();
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, p, nonce, deadline);
+        uint256[] memory signPks = new uint256[](2);
+        signPks[0] = encPks[0]; signPks[1] = encPks[1];
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, signPks);
+
+        proxy.fundsOutCall(p, nonce, deadline, 0x3, sigs);
+
+        assertGt(token.balanceOf(recipient), balBefore, 'chain-owned keys authorized the release');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'RGB nonce advanced');
+    }
+
+    /// @dev The LZ branch selects the enclave set + nonce lane by source chain:
+    ///      an RGB LZ release advances only RGB's lane and emits sourceChainId.
+    function test_perSourceChain_lz_selectsPerSourceLane() public {
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));                          // fresh ts (first gov action)
+        _govUpdateEnclave(7_100_001, _encSetFor(7_100_001, 3), 2); // second registered chain
+
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        uint256 nonce    = proxy.teeNonce(RGB_CHAIN_ID);
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        vm.expectEmit(true, true, false, false);
+        emit LzFundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap, params.dstEid, params.recipient, AMOUNT);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
+
+        assertEq(token.balanceOf(mockOft), AMOUNT, 'LZ release forwarded to OFT');
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, 'RGB LZ lane advanced');
+        assertEq(proxy.teeNonce(7_100_001), 0, 'other chain LZ lane untouched');
+    }
+
+    /// @dev lzFundsOutCall for an unregistered source chain reverts UnknownSourceChain.
+    function test_perSourceChain_lz_unregisteredSourceReverts() public {
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        params.sourceChainId = 424_242; // unregistered (checked before adapter/signatures)
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(424_242)));
+        proxy.lzFundsOutCall(params, 0, vm.getBlockTimestamp() + 1 hours, 0, new bytes[](0));
+    }
+
+    /// @dev An LZ release for chain B signed by RGB keys is rejected at the
+    ///      signer check (per-source selection), not downstream.
+    function test_perSourceChain_lz_signatureFromAnotherChainRejected() public {
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));
+        uint256 chainB = 7_200_001;
+        _govUpdateEnclave(chainB, _encSetFor(chainB, 3), 2);
+
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        params.sourceChainId = chainB;
+        uint256 nonce    = proxy.teeNonce(chainB); // 0
+        uint256 deadline = vm.getBlockTimestamp() + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3(); // RGB signers
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
+    }
+
+    // ---- governance binding / validation -----------------------------------
+
+    /// @dev The enclave-rotation proposal digest is bound to sourceChainId:
+    ///      a digest signed for RGB cannot authorize a rotation of chain B.
+    ///      Guards against regressing the sourceChainId out of the typehash.
+    function test_perSourceChain_proposeUpdateEnclaveDigestBoundToSourceChain() public {
+        uint256 chainB = 7_300_001;
+        address[] memory sB = _encSetFor(chainB, 2);
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        // Federation signs the digest for RGB_CHAIN_ID...
+        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, RGB_CHAIN_ID, sB, 2, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        // ...but the proposal is submitted for chainB -> digest mismatch.
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.proposeUpdateEnclaveSigners(chainB, sB, 2, nonce, deadline, bitmap, sigs);
+    }
+
+    /// @dev sourceChainId == 0 is reserved (threshold 0 is the "unregistered"
+    ///      sentinel), so it is rejected at construction.
+    function test_perSourceChain_constructorRejectsZeroSourceChain() public {
+        address[] memory enc = _validEnc();
+        address[] memory fed = _validFed();
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(0)));
+        new MultisigProxy(address(bridge), address(cm), enc, 2, 0, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+    }
+
+    /// @dev ...and rejected up front by proposeUpdateEnclaveSigners (before sigs).
+    function test_perSourceChain_proposeRejectsZeroSourceChain() public {
+        address[] memory sB = _encSetFor(1, 2);
+        uint256 nonce    = proxy.proposalNonce();
+        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+        bytes[] memory noSigs = new bytes[](0);
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(0)));
+        proxy.proposeUpdateEnclaveSigners(0, sB, 2, nonce, deadline, 0, noSigs);
+    }
+
+    // ---- gas boundary ------------------------------------------------------
+
+    /// @dev Boundary/gas: fill the registry to MAX_ENCLAVE_SOURCE_CHAINS (32),
+    ///      each with the maximum MAX_SIGNERS (20) enclave signers, then confirm
+    ///      an enclave rotation and federation rotations (3/5/10 signers) still
+    ///      execute well under a conservative block gas limit — the cross-set
+    ///      disjoint loop is the worst case. Thresholds must be a strict majority
+    ///      (2*t > n), so 20-signer sets use t=11 (t=3 would be rejected as
+    ///      sub-majority); the disjoint-loop gas is independent of the threshold.
+    function test_perSourceChain_gas_updateSignersAtMaxChainsAndMaxSigners() public {
+        uint256 BLOCK_GAS_LIMIT = 30_000_000; // conservative; Arbitrum allows far more
+        uint256 nChains  = proxy.MAX_ENCLAVE_SOURCE_CHAINS(); // 32
+        uint256 nSigners = proxy.MAX_SIGNERS();               // 20
+        uint256 t20      = 11;                                 // strict majority of 20
+
+        // Rotate RGB to 20 signers, then register (nChains - 1) more 20-signer
+        // chains so all 32 chains carry the maximum set.
+        _govUpdateEnclave(RGB_CHAIN_ID, _encSetFor(RGB_CHAIN_ID, nSigners), t20);
+        for (uint256 k = 0; k < nChains - 1; k++) {
+            uint256 chainId = 5_000_000 + k;
+            _govUpdateEnclave(chainId, _encSetFor(chainId, nSigners), t20);
+        }
+        assertEq(proxy.getEnclaveSourceChains().length, nChains, 'registry filled to the cap');
+
+        // --- enclave rotation of an existing 20-signer chain: disjoint runs
+        //     over the other 31 sets (~20 * 31 * 20 comparisons) + federation.
+        {
+            uint256 rotChain = 5_000_000;
+            address[] memory fresh = _encSetFor(9_999_999, nSigners); // disjoint namespace
+            uint256 nonce    = proxy.proposalNonce();
+            uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
+            bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, rotChain, fresh, t20, nonce, deadline);
+            (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+            bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+            bytes32 id = proxy.proposeUpdateEnclaveSigners(rotChain, fresh, t20, nonce, deadline, bitmap, sigs);
+            vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
+            uint256 g0 = gasleft();
+            proxy.executeProposal(id, abi.encode(rotChain, fresh, t20));
+            uint256 gEnc = g0 - gasleft();
+            emit log_named_uint('gas: updateEnclaveSigners @32chains x20 (rotate)', gEnc);
+            assertLt(gEnc, BLOCK_GAS_LIMIT, 'enclave rotation exceeds block gas limit');
+        }
+
+        // --- federation rotations for sizes 3, 5, 10: disjoint runs over all
+        //     32 enclave sets. Each rotation is signed by the current federation,
+        //     so we thread the pks forward.
+        (uint256[] memory origPks, uint256 origBitmap) = _fedSigSet2of3();
+
+        (address[] memory f3, uint256[] memory p3) = _fedFromPks(0xFED30000, 3);
+        uint256 g3 = _rotateFedMeasured(f3, 2, origPks, origBitmap);
+        emit log_named_uint('gas: updateFederationSigners size=3 @32x20', g3);
+        assertLt(g3, BLOCK_GAS_LIMIT, 'fed(3) rotation exceeds block gas limit');
+
+        (address[] memory f5, uint256[] memory p5) = _fedFromPks(0xFED50000, 5);
+        uint256 g5 = _rotateFedMeasured(f5, 3, _slice(p3, 2), _bitmapFor(2)); // signed by f3 (t=2)
+        emit log_named_uint('gas: updateFederationSigners size=5 @32x20', g5);
+        assertLt(g5, BLOCK_GAS_LIMIT, 'fed(5) rotation exceeds block gas limit');
+
+        (address[] memory f10, ) = _fedFromPks(0xFED100000, 10);
+        uint256 g10 = _rotateFedMeasured(f10, 6, _slice(p5, 3), _bitmapFor(3)); // signed by f5 (t=3)
+        emit log_named_uint('gas: updateFederationSigners size=10 @32x20', g10);
+        assertLt(g10, BLOCK_GAS_LIMIT, 'fed(10) rotation exceeds block gas limit');
     }
 }

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -42,7 +42,7 @@ library MultisigHelper {
     );
 
     bytes32 internal constant PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH = keccak256(
-        'ProposeUpdateEnclaveSigners(address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
+        'ProposeUpdateEnclaveSigners(uint256 sourceChainId,address[] newSigners,uint256 newThreshold,uint256 nonce,uint256 deadline)'
     );
 
     bytes32 internal constant PROPOSE_UPDATE_FEDERATION_SIGNERS_TYPEHASH = keccak256(
@@ -220,6 +220,7 @@ library MultisigHelper {
 
     function digestProposeUpdateEnclaveSigners(
         bytes32 domainSep,
+        uint256 sourceChainId,
         address[] memory newSigners,
         uint256 newThreshold,
         uint256 nonce,
@@ -227,7 +228,7 @@ library MultisigHelper {
     ) internal pure returns (bytes32) {
         return toTypedDataHash(domainSep, keccak256(abi.encode(
             PROPOSE_UPDATE_ENCLAVE_SIGNERS_TYPEHASH,
-            hashAddressArray(newSigners), newThreshold, nonce, deadline
+            sourceChainId, hashAddressArray(newSigners), newThreshold, nonce, deadline
         )));
     }
 


### PR DESCRIPTION
### Summary
Regression coverage for the R-I-04 fix: unsolicited direct transfers to
the CommissionManager are no longer counted as commission.

### Coverage
- CommissionManager unit: receiveTokenCommission credits exactly the passed
  amount (pool += credited); a pre-existing donation is not absorbed and stays
  as a stray balance; over-crediting past the on-chain balance reverts
  BalanceBelowRecordedPool; credited == 0 reverts NothingReceived.
- Bridge end-to-end: with a token donated directly to the CM, a token-commission
  fundsIn grows the pool by exactly the real fee (the Bridge measures its own
  transfer delta and passes it), leaving the donation untouched.