### PR TITLE
test(FP-FO4-01, FP-FO4-02, FP-FO4-03, FP-FO4-09): cover LZ fundsOut flow

### DIFF
--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -64,6 +64,8 @@ contract MockOutboundLZAdapter {
     }
 }
 
+contract NonPayableOft {}
+
 contract MultisigProxyTest is Test {
     using MultisigHelper for bytes32;
 
@@ -170,6 +172,22 @@ contract MultisigProxyTest is Test {
     uint256 constant BLOCK_HEIGHT      = 850_000;
     bytes32 constant COMMITMENT_HASH   = keccak256('test-btc-block-commitment');
     uint256 constant BTC_CONFIRMATIONS = 6;
+
+    struct LzSnapshot {
+        uint256 teeNonce;
+        uint256 bridgeToken;
+        uint256 adapterToken;
+        uint256 oftToken;
+        uint256 cmToken;
+        uint256 cmPool;
+        uint256 nativePool;
+        uint256 record;
+        uint256 proxyNative;
+        uint256 adapterNative;
+        uint256 oftNative;
+        uint256 adapterCalls;
+        bool burnConsumed;
+    }
 
     function setUp() public {
         encA1 = vm.addr(encPk1);
@@ -390,6 +408,64 @@ contract MultisigProxyTest is Test {
         bytes32 id = proxy.proposeUpdateLZAdapter(adapter, nonce, deadline, bitmap, MultisigHelper.signAll(vm, digest, pks));
         vm.warp(block.timestamp + TIMELOCK + 1);
         proxy.executeProposal(id, abi.encode(adapter));
+    }
+
+    function _snapshotLzState(MockOutboundLZAdapter adapter, address oft, uint256 burnId)
+        internal
+        view
+        returns (LzSnapshot memory s)
+    {
+        s.teeNonce      = proxy.teeNonce();
+        s.bridgeToken   = token.balanceOf(address(bridge));
+        s.adapterToken  = token.balanceOf(address(adapter));
+        s.oftToken      = token.balanceOf(oft);
+        s.cmToken       = token.balanceOf(address(cm));
+        s.cmPool        = cm.tokenCommissionPool(address(token));
+        s.nativePool    = cm.nativeCommissionPool();
+        s.record        = rgbModule.fundsInRecords(TX_ID);
+        s.proxyNative   = address(proxy).balance;
+        s.adapterNative = address(adapter).balance;
+        s.oftNative     = oft.balance;
+        s.adapterCalls  = adapter.sendOutCalls();
+        s.burnConsumed  = bridge.consumedBurnIds(burnId);
+    }
+
+    function _assertLzStateUnchanged(
+        LzSnapshot memory s,
+        MockOutboundLZAdapter adapter,
+        address oft,
+        uint256 burnId
+    ) internal view {
+        assertEq(proxy.teeNonce(),                 s.teeNonce,      'tee nonce unchanged');
+        assertEq(token.balanceOf(address(bridge)), s.bridgeToken,   'bridge token unchanged');
+        assertEq(token.balanceOf(address(adapter)), s.adapterToken, 'adapter token unchanged');
+        assertEq(token.balanceOf(oft),             s.oftToken,      'oft token unchanged');
+        assertEq(token.balanceOf(address(cm)),     s.cmToken,       'cm token unchanged');
+        assertEq(cm.tokenCommissionPool(address(token)), s.cmPool,  'cm pool unchanged');
+        assertEq(cm.nativeCommissionPool(),        s.nativePool,    'native pool unchanged');
+        assertEq(rgbModule.fundsInRecords(TX_ID),  s.record,        'record unchanged');
+        assertEq(address(proxy).balance,           s.proxyNative,   'proxy native unchanged');
+        assertEq(address(adapter).balance,         s.adapterNative, 'adapter native unchanged');
+        assertEq(oft.balance,                      s.oftNative,     'oft native unchanged');
+        assertEq(adapter.sendOutCalls(),           s.adapterCalls,  'adapter calls unchanged');
+        assertEq(bridge.consumedBurnIds(burnId),   s.burnConsumed,  'burn id unchanged');
+    }
+
+    function _expectLzCallRevertUnchanged(
+        IMultisigProxy.LzFundsOutParams memory params,
+        MockOutboundLZAdapter adapter,
+        address oft,
+        bytes memory expectedRevert
+    ) internal {
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
+        LzSnapshot memory snap = _snapshotLzState(adapter, oft, params.burnId);
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        vm.expectRevert(expectedRevert);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
+
+        _assertLzStateUnchanged(snap, adapter, oft, params.burnId);
     }
 
     // ========================================================================
@@ -2194,7 +2270,7 @@ contract MultisigProxyTest is Test {
             })
         );
 
-        (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount) =
+        (uint256 tokenCommission, uint256 nativeCommission,) =
             cm.calculateFundsOutCommission(RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token), AMOUNT);
         assertGt(tokenCommission, 0, 'token fee quoted');
         assertEq(nativeCommission, 0, 'native fee is zero');
@@ -2251,6 +2327,161 @@ contract MultisigProxyTest is Test {
         assertEq(address(proxy).balance,            proxyEthBefore,    'proxy native unchanged');
         assertEq(address(adapter).balance,          adapterEthBefore,  'adapter native unchanged');
         assertEq(mockOft.balance,                   oftEthBefore,      'oft native unchanged');
+    }
+
+    function test_lzFundsOutCall_successCannotReplayByNonceOrBurnId() public {
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));
+
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
+
+        assertEq(proxy.teeNonce(), nonce + 1, 'first call consumed tee nonce');
+        assertTrue(bridge.consumedBurnIds(BURN_ID), 'first call consumed burn id');
+        assertEq(adapter.sendOutCalls(), 1, 'first call sent once');
+        assertEq(token.balanceOf(mockOft), AMOUNT, 'first call delivered tokens');
+
+        vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
+        proxy.lzFundsOutCall(params, nonce, deadline, bitmap, sigs);
+
+        uint256 freshNonce = proxy.teeNonce();
+        bytes32 digest = MultisigHelper.digestTeeLzFundsOut(domainSep, params, freshNonce, deadline);
+        (uint256[] memory pks, uint256 freshBitmap) = _encSigSet2of3();
+        bytes[] memory freshSigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        vm.expectRevert(abi.encodeWithSelector(IBridge.BurnIdAlreadyConsumed.selector, BURN_ID));
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, freshNonce, deadline, freshBitmap, freshSigs);
+
+        assertEq(proxy.teeNonce(), freshNonce, 'failed burn replay does not consume tee nonce');
+        assertEq(adapter.sendOutCalls(), 1, 'no second adapter send');
+        assertEq(token.balanceOf(mockOft), AMOUNT, 'no second delivery');
+    }
+
+    function test_lzFundsOutCall_adapterRevertModes_rollBackBridgeState() public {
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));
+
+        IMultisigProxy.LzFundsOutParams memory params =
+            _lzFundsOutParams(AMOUNT, BURN_ID + 10, _fundsInIds());
+        params.recipient = bytes32(0);
+        _expectLzCallRevertUnchanged(params, adapter, mockOft, bytes('zero recipient'));
+
+        params = _lzFundsOutParams(AMOUNT, BURN_ID + 11, _fundsInIds());
+        params.minAmountLD = AMOUNT + 1;
+        _expectLzCallRevertUnchanged(params, adapter, mockOft, bytes('min too high'));
+
+        address nonPayableOft = address(new NonPayableOft());
+        MockOutboundLZAdapter failingFeeAdapter =
+            new MockOutboundLZAdapter(address(token), nonPayableOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(failingFeeAdapter));
+
+        params = _lzFundsOutParams(AMOUNT, BURN_ID + 12, _fundsInIds());
+        _expectLzCallRevertUnchanged(params, failingFeeAdapter, nonPayableOft, bytes('oft fee'));
+
+        vm.prank(address(proxy));
+        cm.setCommissionRule(
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            address(token),
+            CommissionConfig({
+                stablePercent: 8100,
+                multiplier: 90,
+                side: CommissionSide.FUNDS_OUT,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+        (uint256 tokenCommission,, uint256 netAmount) =
+            cm.calculateFundsOutCommission(RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token), AMOUNT);
+        assertEq(tokenCommission, AMOUNT, 'sanity: full token commission');
+        assertEq(netAmount, 0, 'sanity: zero delivered amount');
+
+        MockOutboundLZAdapter zeroAmountAdapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(zeroAmountAdapter));
+
+        params = _lzFundsOutParams(AMOUNT, BURN_ID + 13, _fundsInIds());
+        _expectLzCallRevertUnchanged(params, zeroAmountAdapter, mockOft, bytes('zero amount'));
+    }
+
+    function test_lzFundsOutCall_bridgeLegRevertModes_doNotCallAdapter() public {
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));
+
+        IMultisigProxy.LzFundsOutParams memory params =
+            _lzFundsOutParams(AMOUNT, BURN_ID + 20, _fundsInIds());
+        params.destinationChainId = SOURCE_CHAIN_ID + 99;
+        _expectLzCallRevertUnchanged(
+            params,
+            adapter,
+            mockOft,
+            abi.encodeWithSelector(IRouteRegistry.RouteNotEnabled.selector, RGB_CHAIN_ID, SOURCE_CHAIN_ID + 99)
+        );
+
+        uint256 unknownId = TX_ID + 999;
+        uint256[] memory unknownIds = new uint256[](1);
+        unknownIds[0] = unknownId;
+        params = _lzFundsOutParams(AMOUNT, BURN_ID + 21, unknownIds);
+        _expectLzCallRevertUnchanged(
+            params,
+            adapter,
+            mockOft,
+            abi.encodeWithSelector(RgbSettlementModule.FundsInNotFound.selector, unknownId)
+        );
+
+        uint256[] memory ids = _fundsInIds();
+        uint256[] memory wrongAmounts = new uint256[](1);
+        wrongAmounts[0] = rgbModule.fundsInRecords(TX_ID) - 1;
+        params = _lzFundsOutParams(AMOUNT, BURN_ID + 22, ids);
+        params.settlementData = abi.encode(ids, wrongAmounts);
+        _expectLzCallRevertUnchanged(
+            params,
+            adapter,
+            mockOft,
+            abi.encodeWithSelector(
+                RgbSettlementModule.AmountMismatch.selector,
+                TX_ID,
+                wrongAmounts[0],
+                rgbModule.fundsInRecords(TX_ID)
+            )
+        );
+
+        params = _lzFundsOutParams(AMOUNT, BURN_ID + 23, _fundsInIds());
+        params.sourceChainId = 0;
+        _expectLzCallRevertUnchanged(
+            params,
+            adapter,
+            mockOft,
+            abi.encodeWithSelector(IBridge.InvalidSourceChainId.selector)
+        );
+
+        params = _lzFundsOutParams(AMOUNT, BURN_ID + 24, _fundsInIds());
+        params.destinationChainId = 0;
+        _expectLzCallRevertUnchanged(
+            params,
+            adapter,
+            mockOft,
+            abi.encodeWithSelector(IBridge.InvalidDestinationChainId.selector)
+        );
+
+        params = _lzFundsOutParams(0, BURN_ID + 25, _fundsInIds());
+        _expectLzCallRevertUnchanged(
+            params,
+            adapter,
+            mockOft,
+            abi.encodeWithSelector(IBridge.ZeroAmount.selector)
+        );
     }
 
     // Flow-4 success coverage for duplicate RGB settlement ids when the first
@@ -2551,6 +2782,61 @@ contract MultisigProxyTest is Test {
         assertEq(token.balanceOf(address(adapter)), 0,         'adapter forwarded everything it received');
         assertEq(token.balanceOf(mockOft),          netAmount, 'oft received exactly the net delivered');
         assertTrue(netAmount != AMOUNT,                        'bound amount is distinct from signed gross');
+    }
+
+    // Current behavior: token commission accounting records the whole
+    // CommissionManager balance delta, including tokens sent there directly
+    // before the Bridge forwards the legitimate Flow-4 commission.
+    function test_lzFundsOutCall_unsolicitedCommissionManagerBalanceIncludedInPool_currentBehavior() public {
+        vm.prank(address(proxy));
+        cm.setCommissionRule(
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            address(token),
+            CommissionConfig({
+                stablePercent: 500,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_OUT,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        (uint256 tokenCommission,, uint256 netAmount) =
+            cm.calculateFundsOutCommission(RGB_CHAIN_ID, SOURCE_CHAIN_ID, address(token), AMOUNT);
+        assertGt(tokenCommission, 0, 'token fee quoted');
+
+        uint256 unsolicitedAmount = 3 ether;
+        token.mint(user, unsolicitedAmount);
+        vm.prank(user);
+        token.transfer(address(cm), unsolicitedAmount);
+
+        address mockOft = makeAddr('mockOft');
+        MockOutboundLZAdapter adapter =
+            new MockOutboundLZAdapter(address(token), mockOft, address(proxy), LZ_NATIVE_FEE);
+        _setLzAdapter(address(adapter));
+
+        IMultisigProxy.LzFundsOutParams memory params = _lzFundsOutParams(AMOUNT, BURN_ID, _fundsInIds());
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint256 nonce, uint256 bitmap, bytes[] memory sigs) = _signLzEnclave(params, deadline);
+
+        uint256 cmBefore     = token.balanceOf(address(cm));
+        uint256 cmPoolBefore = cm.tokenCommissionPool(address(token));
+
+        assertEq(cmBefore, unsolicitedAmount, 'pre unsolicited cm balance');
+        assertEq(cmPoolBefore, 0, 'pre cm pool');
+
+        vm.deal(address(this), LZ_NATIVE_FEE);
+        proxy.lzFundsOutCall{ value: LZ_NATIVE_FEE }(params, nonce, deadline, bitmap, sigs);
+
+        assertEq(token.balanceOf(address(cm)), unsolicitedAmount + tokenCommission, 'cm balance includes both');
+        assertEq(
+            cm.tokenCommissionPool(address(token)),
+            unsolicitedAmount + tokenCommission,
+            'pool includes unsolicited balance'
+        );
+        assertEq(token.balanceOf(mockOft), netAmount, 'oft received net release');
+        assertEq(token.balanceOf(address(adapter)), 0, 'adapter no residue');
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Covers planned properties `FP-FO4-01`, `FP-FO4-02`, `FP-FO4-03`, and `FP-FO4-09`.

- Adds replay protection coverage for `teeNonce` and `burnId`.
- Covers atomic rollback when the Bridge or adapter leg reverts.
- Documents the current unsolicited CommissionManager balance accounting behavior.
