### PR TITLE
fix(C-01): make outflow buckets TVL-relative via normalized shares

### DIFF
--- a/ethereum/.env.deploy.example
+++ b/ethereum/.env.deploy.example
@@ -68,24 +68,19 @@ ETH_USD_FEED=
 # 87000 leaves ~10 min slack).
 ETH_USD_HEARTBEAT=87000
 
-# --- Arbitrum Chainlink robustness (optional) ---
+# --- Arbitrum Chainlink robustness ---
 
-# Chainlink L2 Sequencer Uptime feed. When set, NATIVE quotes are rejected while
-# the sequencer is down and for the 3600 s grace period after a restart. Set on
-# Arbitrum whenever NATIVE commission is used; leave blank on non-L2 / tests.
+# Chainlink L2 Sequencer Uptime feed. Required whenever ETH_USD_FEED enables the
+# NATIVE commission path. Quotes are rejected while the sequencer is down and
+# for the 3600 s grace period after a restart.
 #   Arbitrum One  Sequencer Uptime  0xFdB631F5EE196F0ed6FAa767959853A9F217697D
 SEQUENCER_UPTIME_FEED=
 
-# Optional ETH/USD sanity band (circuit breaker), in the feed's decimals
-# (ETH/USD = 8). Set BOTH or NEITHER (else the deploy reverts); 0 < min < max.
+# ETH/USD sanity band (circuit breaker), in the feed's decimals (ETH/USD = 8).
+# Required whenever ETH_USD_FEED is set; configure BOTH values with 0 < min < max.
 # Example for an 8-decimal feed: $100 = 10000000000, $100k = 10000000000000.
 ETH_USD_MIN_PRICE=
 ETH_USD_MAX_PRICE=
-
-# When true, the deploy reverts unless ETH_USD_FEED, SEQUENCER_UPTIME_FEED, and
-# the price band are ALL set. Recommend =true for Arbitrum production so the
-# R-I-14 guards can never be silently absent; leave false for non-L2 / tests.
-REQUIRE_CHAINLINK_HARDENING=false
 
 # -----------------------------------------------------------------------------
 # MultisigProxy
@@ -103,7 +98,9 @@ FEDERATION_SIGNERS=
 ENCLAVE_THRESHOLD=2
 FEDERATION_THRESHOLD=2
 
-# Where withdrawTokenCommission() / withdrawNativeCommission() send funds.
+# Immutable CommissionManager withdrawal destination. Changing it requires a
+# new CommissionManager deployment (and, because Bridge pins CM immutably, a
+# coordinated Bridge migration).
 COMMISSION_RECIPIENT=
 
 # Timelock between propose and execute for federation proposals (seconds).

--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -29,10 +29,10 @@ Production bridge for UTEXO. Inherits `BridgeBase`, implements `IBridge`. Route-
 
 Constructor takes four addresses: the accepted ERC-20 token (immutable), the `RouteRegistry` (mutable — federation can rotate via `UpdateRouteRegistry`), the `CommissionManager` (immutable), and the initial LayerZero adapter (mutable; `address(0)` is allowed — wire it in later via federation governance). The bridge's own chain identifier is `block.chainid` — chain IDs are `uint256` throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
 
-- `fundsIn(amount, destinationChainId, destinationAddress, operationId, settlementData)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must equal the quoted native commission. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and dispatches to the route's `SettlementModule.onFundsIn(...)` via `RouteRegistry`. The `settlementData` blob is opaque to the bridge — its layout is dictated by the destination route's settlement module (empty for routes that don't consume extra data on inbound, e.g. RGB). Emits two events:
+- `fundsIn(amount, destinationChainId, destinationAddress, settlementData)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must be between the fresh quote and 5% above it. Exactly the fresh quote is collected and any surplus is refunded to the caller. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and dispatches to the route's `SettlementModule.onFundsIn(...)` via `RouteRegistry`. The `settlementData` blob is opaque to the bridge — its layout is dictated by the destination route's settlement module (empty for routes that don't consume extra data on inbound, e.g. RGB). Emits two events:
   - `FundsIn` (from `BridgeBase`) — minimal, uses `netAmount`.
   - `BridgeFundsIn` (from `IBridge`) — full, consumed by the UTEXO backend.
-- `fundsIn(amount, sourceChainId, destinationChainId, destinationAddress, operationId, settlementData)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating `msg.sender` on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` to the bridge. Otherwise identical semantics to `fundsIn`.
+- `fundsIn(amount, sourceChainId, sourceSender, destinationChainId, destinationAddress, settlementData)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating sender on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` and `sourceSender` to the bridge. For NATIVE commission routes, the source-agreed `msg.value` must remain within the immutable ±5% band around the fresh destination quote. Cross-domain refunds are deliberately unsupported, so the complete accepted value is collected as commission.
 - `setLZAdapter(adapter)` — `onlyOwner`. Rotates the address authorized to call the adapter overload. Set to `address(0)` to close the adapter path entirely.
 - `setRouteRegistry(newRouteRegistry)` — `onlyOwner`. Rotates the `RouteRegistry` Bridge talks to. Used to migrate to a redeployed registry (the registry's `bridge` is immutable, so a new registry deploy is the only way to rotate). Reverts on `address(0)`.
 - `fundsOut(recipient, amount, burnId, sourceChainId, destChainId, sourceAddress, proof, settlementData)` — `onlyOwner`, called via `MultisigProxy.execute()` or `MultisigProxy.executeBatch()`. The four scalar amounts (`amount`, `burnId`, `sourceChainId`, `destChainId`) are `uint256`; `recipient` is an address; `sourceAddress` is a string; `proof` and `settlementData` are opaque `bytes` blobs whose layouts are dictated by the route's `FinalityVerifier` and `SettlementModule` respectively. Checks `burnId` has not been consumed yet (single-use replay guard, marks it consumed before any external interaction), calls `RouteRegistry.beforeFundsOut(...)` which routes into `FinalityVerifier.verify(proof)` and `SettlementModule.beforeFundsOut(settlementData, amount)`, quotes commission from `CommissionManager` using `(sourceChainId, destChainId, TOKEN)`, forwards any token commission to the pool, and releases `netAmount` to the recipient. Emits `BridgeFundsOut`. NATIVE commission on `fundsOut` is disallowed (the caller is the multisig, not a user) — the contract reverts `NativeCommissionNotAllowedOnFundsOut`.
@@ -76,7 +76,7 @@ Standalone fee contract. Holds protocol commissions separately from bridge liqui
 - **Config** selects per route: `side` (`FUNDS_IN` vs `FUNDS_OUT`), `currency` (`TOKEN` vs `NATIVE`), `stablePercent` (×100, capped at 9000 = 90%), and `multiplier`. Global defaults apply to any route without an override.
 - **NATIVE quotes** use a Chainlink ETH/USD aggregator (`setEthUsdFeed(feed, heartbeat)`) and the token's `decimals()`. Heartbeat enforces staleness; absent feed ⇒ NATIVE quotes revert.
 - **Ingress:** `receiveTokenCommission(token)` and `receive()` are gated by `onlyBridge` — only `Bridge` may credit commissions. Pools are updated from balance deltas, so fee-on-transfer tokens are supported.
-- **Owner** (`MultisigProxy` in production) configures rules, updates `bridgeAddress`, wires the ETH/USD feed, and withdraws accumulated pools. `renounceOwnership` is blocked.
+- **Owner** (`MultisigProxy` in production) configures rules, updates `bridgeAddress`, wires the ETH/USD feed, and withdraws accumulated pools. Every token/native withdrawal pays the immutable constructor-configured `commissionRecipient`; withdrawal functions do not accept a free recipient. `renounceOwnership` is blocked.
 
 ### MultisigProxy (`src/MultisigProxy.sol`)
 
@@ -93,12 +93,11 @@ Federation-controlled operations (`OperationType`):
 | `UpdateEnclaveSigners` | self | Rotate TEE signer set / threshold |
 | `UpdateFederationSigners` | self | Rotate federation signer set / threshold |
 | `UpdateBridge` | self | Migrate to a redeployed Bridge |
-| `SetCommissionRecipient` | self | Change destination address for CM withdrawals |
 | `SetTeeAllowedCall` | self | Add/remove a `(target, selector)` pair from the TEE allowlist |
 | `SetTimelockDuration` | self | Adjust the timelock window |
 | `AdminExecuteCommissionManager` | CommissionManager | Generic call into CM (route rules, global defaults, ETH/USD feed, `transferOwnership`, …) |
-| `WithdrawTokenCommissionCM` | CommissionManager | Withdraw ERC-20 commission to `commissionRecipient` |
-| `WithdrawNativeCommissionCM` | CommissionManager | Withdraw native commission to `commissionRecipient` |
+| `WithdrawTokenCommissionCM` | CommissionManager | Withdraw ERC-20 commission to CM's immutable `commissionRecipient` |
+| `WithdrawNativeCommissionCM` | CommissionManager | Withdraw native commission to CM's immutable `commissionRecipient` |
 | `UpdateCommissionManager` | self | Migrate to a redeployed CommissionManager |
 | `AdminExecuteAdapter` | LZAdapter | Generic call into the registered LayerZero adapter (`setTrustedEntrypoint`, `refundStuckFunds`, …). Reverts `ZeroTarget` if `MultisigProxy.lzAdapter` is unset. |
 | `UpdateLZAdapter` | self | Rotate `MultisigProxy.lzAdapter` — the routing target for `AdminExecuteAdapter`. Setting to `address(0)` closes the adapter-admin path. |
@@ -182,7 +181,7 @@ set -a && source .env.interact && set +a   # before interact scripts
 - `LZ_ADAPTER` — initial LayerZero adapter address (optional; pass `0x0` if the adapter has not been deployed yet, then wire it in via federation governance after the adapter ships)
 - `ROUTE_REGISTRY_ADDRESS` — `RouteRegistry` address (step-by-step Bridge redeploys only; `DeployAll` predicts it)
 - `COMMISSION_MANAGER` — `CommissionManager` address (step-by-step deploys only)
-- `COMMISSION_RECIPIENT` — destination for CM withdrawals
+- `COMMISSION_RECIPIENT` — immutable destination for every CM withdrawal; choose a long-lived treasury address
 - `ETH_USD_FEED` / `ETH_USD_HEARTBEAT` — Chainlink ETH/USD aggregator + staleness window (required if any route uses NATIVE commission)
 - `ENCLAVE_SIGNERS` / `FEDERATION_SIGNERS` — comma-separated addresses, ordered by bitmap bit index
 - `ENCLAVE_THRESHOLD` / `FEDERATION_THRESHOLD` — M-of-N thresholds
@@ -214,7 +213,7 @@ forge script script/deploy/DeployAll.s.sol \
 
 Predicts the Bridge address from the deployer's future nonce, deploys in order:
 
-1. `CommissionManager` (pinned to the predicted Bridge)
+1. `CommissionManager` (pinned to the predicted Bridge and immutable commission recipient)
 2. `RouteRegistry` (pinned to the predicted Bridge, deployer-owned for this batch)
 3. `Bridge` (with the live `RouteRegistry` + `CommissionManager`)
 4. `RGBVerifier` (wraps the BtcRelay)
@@ -276,16 +275,17 @@ forge script script/interact/BridgeFundsIn.s.sol --rpc-url $RPC_URL --broadcast
 1. Verify Bridge ownership: `Bridge.owner()` returns the `MultisigProxy` address.
 2. Verify RouteRegistry ownership: `RouteRegistry.owner()` returns the `MultisigProxy` address.
 3. Verify CommissionManager ownership: `CommissionManager.owner()` returns the `MultisigProxy` address.
-4. Verify Bridge ↔ Registry linkage: `Bridge.routeRegistry()` returns the live `RouteRegistry`; `RouteRegistry.bridge()` returns the live `Bridge`.
-5. Verify Bridge ↔ CM linkage: `CommissionManager.bridgeAddress()` returns the live `Bridge`; `Bridge.commissionManager()` returns the live `CommissionManager`.
-6. Verify LZ adapter wiring: `Bridge.lzAdapter()` and `MultisigProxy.lzAdapter()` both return `address(0)` immediately after deploy. Once the adapter is live, federation must run two timelocked proposals:
+4. Verify immutable commission destination: `CommissionManager.commissionRecipient()` returns the intended treasury.
+5. Verify Bridge ↔ Registry linkage: `Bridge.routeRegistry()` returns the live `RouteRegistry`; `RouteRegistry.bridge()` returns the live `Bridge`.
+6. Verify Bridge ↔ CM linkage: `CommissionManager.bridgeAddress()` returns the live `Bridge`; `Bridge.commissionManager()` returns the live `CommissionManager`.
+7. Verify LZ adapter wiring: `Bridge.lzAdapter()` and `MultisigProxy.lzAdapter()` both return `address(0)` immediately after deploy. Once the adapter is live, federation must run two timelocked proposals:
    - `proposeAdminExecute` on the proxy with calldata `Bridge.setLZAdapter(adapter)` — opens the adapter `fundsIn` data path.
    - `proposeUpdateLZAdapter(adapter)` — opens the `AdminExecuteAdapter` governance path on the proxy.
-7. Verify enclave signers: `MultisigProxy.getEnclaveSigners()` returns the TEE addresses.
-8. Verify federation signers: `MultisigProxy.getFederationSigners()` returns the governance addresses.
-9. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` for the 8-arg `fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)` selector.
-10. **Register routes.** For each supported `(sourceChainId, destChainId)` pair, federation runs `MultisigProposeSetRoute` and — after the timelock — `executeProposal` with the printed `opData`. Verify with `RouteRegistry.routes(src, dst)` that the entry is `enabled` and the plugin addresses match.
-11. Test `fundsIn` with a small amount (zero commission by default) on a registered route to confirm token transfer and event emission.
+8. Verify enclave signers: `MultisigProxy.getEnclaveSigners()` returns the TEE addresses.
+9. Verify federation signers: `MultisigProxy.getFederationSigners()` returns the governance addresses.
+10. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` for the 8-arg `fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)` selector.
+11. **Register routes.** For each supported `(sourceChainId, destChainId)` pair, federation runs `MultisigProposeSetRoute` and — after the timelock — `executeProposal` with the printed `opData`. Verify with `RouteRegistry.routes(src, dst)` that the entry is `enabled` and the plugin addresses match.
+12. Test `fundsIn` with a small amount (zero commission by default) on a registered route to confirm token transfer and event emission.
 
 ## Project structure
 

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -70,17 +70,12 @@ import {RgbOutboundSettlementModule} from "../../src/settlement/RgbOutboundSettl
 ///                       (freshness) block; must be >= 1.
 ///   MIN_CONFIRMATION_GAP     (5) — RGBVerifier: min depth gap between the
 ///                       source and latest blocks.
-///   SEQUENCER_UPTIME_FEED — (Arbitrum, R-I-14) Chainlink L2 Sequencer Uptime
-///                       feed. When set, NATIVE quotes reject prices during
-///                       sequencer downtime and the post-restart grace period.
-///                       SHOULD be set on Arbitrum when NATIVE commission is used.
-///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — (R-I-14) optional ETH/USD sanity
-///                       band in feed decimals (e.g. 100e8 / 100000e8). Set both
-///                       or neither; else 0 < min < max.
-///   REQUIRE_CHAINLINK_HARDENING (false) — when true, the deploy reverts unless
-///                       ETH_USD_FEED, SEQUENCER_UPTIME_FEED, and the price band
-///                       are all set. Recommended for Arbitrum production so the
-///                       R-I-14 guards can never be silently absent.
+///   SEQUENCER_UPTIME_FEED — Required whenever ETH_USD_FEED is set. Chainlink
+///                       Arbitrum L2 Sequencer Uptime feed used to reject NATIVE
+///                       quotes during downtime and the post-restart grace.
+///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — Required whenever ETH_USD_FEED is
+///                       set. ETH/USD sanity band in feed decimals
+///                       (e.g. 100e8 / 100000e8).
 ///
 /// Usage:
 ///   forge script script/deploy/DeployAll.s.sol \
@@ -122,7 +117,6 @@ contract DeployAll is Script {
         address seqFeed = vm.envOr("SEQUENCER_UPTIME_FEED", address(0));
         uint256 ethUsdMinPrice = vm.envOr("ETH_USD_MIN_PRICE", uint256(0));
         uint256 ethUsdMaxPrice = vm.envOr("ETH_USD_MAX_PRICE", uint256(0));
-        bool reqHardening = vm.envOr("REQUIRE_CHAINLINK_HARDENING", false);
         uint256 initialChainBurstBps = vm.envUint("INITIAL_CHAIN_BURST_BPS");
         uint256 initialChainRefillBps = vm.envUint("INITIAL_CHAIN_REFILL_BPS_PER_WINDOW");
         uint256 globalBurstBps = vm.envUint("GLOBAL_BURST_BPS");
@@ -135,11 +129,11 @@ contract DeployAll is Script {
             (ethUsdMinPrice == 0) == (ethUsdMaxPrice == 0),
             "set both ETH_USD_MIN_PRICE and ETH_USD_MAX_PRICE, or neither"
         );
-        // Opt-in prod guard (set REQUIRE_CHAINLINK_HARDENING=true for Arbitrum):
-        // when NATIVE commission is enabled, the sequencer feed and price band
-        // must be wired too, so the R-I-14 protections are not silently absent.
-        if (reqHardening) {
-            require(ethUsdFeed != address(0), "hardening: ETH_USD_FEED must be set");
+        require(ethUsdMaxPrice == 0 || ethUsdMinPrice < ethUsdMaxPrice, "ETH_USD_MIN_PRICE must be below MAX");
+        // R-I-14: enabling the NATIVE oracle path requires the full Arbitrum
+        // hardening configuration. There is no production opt-out.
+        if (ethUsdFeed != address(0)) {
+            require(ethUsdHb != 0, "ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided");
             require(seqFeed != address(0), "hardening: SEQUENCER_UPTIME_FEED must be set");
             require(ethUsdMaxPrice != 0, "hardening: ETH_USD_MIN/MAX_PRICE must be set");
         }
@@ -157,7 +151,7 @@ contract DeployAll is Script {
         vm.startBroadcast(pk);
 
         // ---- 2. CommissionManager (nonce n) ------------------------------
-        cm = new CommissionManager(predictedBridge);
+        cm = new CommissionManager(predictedBridge, commission);
 
         // ---- 3. RouteRegistry (nonce n+1) --------------------------------
         // Owned by `deployer` for this batch; transferred to the proxy below
@@ -182,7 +176,7 @@ contract DeployAll is Script {
 
         // ---- 6. MultisigProxy (nonce n+7) --------------------------------
         proxy = new MultisigProxy(
-            address(bridge), address(cm), enc, encThr, initialSrcChain, fed, fedThr, commission, timelock, minTimelock
+            address(bridge), address(cm), enc, encThr, initialSrcChain, fed, fedThr, timelock, minTimelock
         );
 
         // ---- 7. Install initial outflow policies before ownership transfer -
@@ -193,21 +187,15 @@ contract DeployAll is Script {
         bridge.setOutflowLimit(initialSrcChain, initialChainBurstBps, initialChainRefillBps);
         bridge.setGlobalOutflowLimit(globalBurstBps, globalRefillBps);
 
-        // ---- 8. Wire optional ETH/USD feed before CM ownership transfer --
-        if (ethUsdFeed != address(0)) {
-            require(ethUsdHb != 0, "ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided");
-            cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
-        }
-
-        // ---- 8b. Wire optional R-I-14 Arbitrum hardening (owner-only, before
-        //          the ownership transfer): the L2 sequencer-uptime feed and the
-        //          ETH/USD sanity band. On Arbitrum these SHOULD be set whenever
-        //          the NATIVE commission path (ETH_USD_FEED) is used.
+        // ---- 8. Wire R-I-14 dependencies before enabling ETH/USD quotes ----
         if (seqFeed != address(0)) {
             cm.setSequencerUptimeFeed(seqFeed);
         }
         if (ethUsdMaxPrice != 0) {
             cm.setEthUsdPriceBounds(ethUsdMinPrice, ethUsdMaxPrice);
+        }
+        if (ethUsdFeed != address(0)) {
+            cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
         }
 
         // ---- 9. Start two-step ownership handover to federation ----------
@@ -223,6 +211,7 @@ contract DeployAll is Script {
 
         // ---- 10. Summary -------------------------------------------------
         console2.log("CommissionManager deployed at:  ", address(cm));
+        console2.log("Immutable commission recipient:", cm.commissionRecipient());
         console2.log("RouteRegistry deployed at:      ", address(routeRegistry));
         console2.log("Bridge deployed at:             ", address(bridge));
         console2.log("RGBVerifier deployed at:        ", address(rgbVerifier));

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -30,6 +30,8 @@ import {RgbOutboundSettlementModule} from "../../src/settlement/RgbOutboundSettl
 ///   n + 6  → RgbOutboundSettlementModule (debit-RGB / non-RGB-credit routes,
 ///                                 e.g. RGB → Arch; wraps RgbSettlementModule)
 ///   n + 7  → MultisigProxy
+///          → Bridge.setOutflowLimit for INITIAL_ENCLAVE_SOURCE_CHAIN_ID
+///          → Bridge.setGlobalOutflowLimit
 ///          → (optional) CommissionManager config txs, each present only when
 ///            its env is set: setEthUsdFeed, setSequencerUptimeFeed,
 ///            setEthUsdPriceBounds. These shift the transferOwnership nonces
@@ -52,7 +54,9 @@ import {RgbOutboundSettlementModule} from "../../src/settlement/RgbOutboundSettl
 ///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD, INITIAL_ENCLAVE_SOURCE_CHAIN_ID,
 ///   FEDERATION_SIGNERS, FEDERATION_THRESHOLD,
 ///   COMMISSION_RECIPIENT, TIMELOCK_DURATION, MIN_TIMELOCK,
-///   MIN_FUNDS_IN_AMOUNT
+///   MIN_FUNDS_IN_AMOUNT,
+///   INITIAL_CHAIN_BURST_BPS, INITIAL_CHAIN_REFILL_BPS_PER_WINDOW,
+///   GLOBAL_BURST_BPS, GLOBAL_REFILL_BPS_PER_WINDOW
 ///
 /// Env (optional):
 ///   ETH_USD_FEED      — Chainlink ETH/USD aggregator (wired in before CM
@@ -82,6 +86,8 @@ import {RgbOutboundSettlementModule} from "../../src/settlement/RgbOutboundSettl
 ///   forge script script/deploy/DeployAll.s.sol \
 ///     --rpc-url $RPC_URL --broadcast --verify
 contract DeployAll is Script {
+    uint256 private constant MAX_OUTFLOW_POLICY_BPS = 2_000;
+
     function run()
         external
         returns (
@@ -117,6 +123,10 @@ contract DeployAll is Script {
         uint256 ethUsdMinPrice = vm.envOr("ETH_USD_MIN_PRICE", uint256(0));
         uint256 ethUsdMaxPrice = vm.envOr("ETH_USD_MAX_PRICE", uint256(0));
         bool reqHardening = vm.envOr("REQUIRE_CHAINLINK_HARDENING", false);
+        uint256 initialChainBurstBps = vm.envUint("INITIAL_CHAIN_BURST_BPS");
+        uint256 initialChainRefillBps = vm.envUint("INITIAL_CHAIN_REFILL_BPS_PER_WINDOW");
+        uint256 globalBurstBps = vm.envUint("GLOBAL_BURST_BPS");
+        uint256 globalRefillBps = vm.envUint("GLOBAL_REFILL_BPS_PER_WINDOW");
 
         // ---- 1a. Misconfiguration checks (fail-fast, before any broadcast) ---
         // Price band is all-or-nothing: a half-set band would otherwise be
@@ -133,6 +143,10 @@ contract DeployAll is Script {
             require(seqFeed != address(0), "hardening: SEQUENCER_UPTIME_FEED must be set");
             require(ethUsdMaxPrice != 0, "hardening: ETH_USD_MIN/MAX_PRICE must be set");
         }
+        require(
+            _validOutflowPolicy(initialChainBurstBps, initialChainRefillBps), "invalid initial chain outflow policy"
+        );
+        require(_validOutflowPolicy(globalBurstBps, globalRefillBps), "invalid global outflow policy");
 
         address deployer = vm.addr(pk);
         uint64 startNonce = vm.getNonce(deployer);
@@ -171,13 +185,21 @@ contract DeployAll is Script {
             address(bridge), address(cm), enc, encThr, initialSrcChain, fed, fedThr, commission, timelock, minTimelock
         );
 
-        // ---- 7. Wire optional ETH/USD feed before CM ownership transfer --
+        // ---- 7. Install initial outflow policies before ownership transfer -
+        // Percentage policies are valid at zero liquidity. Installing both
+        // buckets while the deployer still owns Bridge means the initial route
+        // is ready for fundsOut as soon as routes and ownership are activated;
+        // it cannot be stranded behind a fresh timelocked admin proposal.
+        bridge.setOutflowLimit(initialSrcChain, initialChainBurstBps, initialChainRefillBps);
+        bridge.setGlobalOutflowLimit(globalBurstBps, globalRefillBps);
+
+        // ---- 8. Wire optional ETH/USD feed before CM ownership transfer --
         if (ethUsdFeed != address(0)) {
             require(ethUsdHb != 0, "ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided");
             cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
         }
 
-        // ---- 7b. Wire optional R-I-14 Arbitrum hardening (owner-only, before
+        // ---- 8b. Wire optional R-I-14 Arbitrum hardening (owner-only, before
         //          the ownership transfer): the L2 sequencer-uptime feed and the
         //          ETH/USD sanity band. On Arbitrum these SHOULD be set whenever
         //          the NATIVE commission path (ETH_USD_FEED) is used.
@@ -188,7 +210,7 @@ contract DeployAll is Script {
             cm.setEthUsdPriceBounds(ethUsdMinPrice, ethUsdMaxPrice);
         }
 
-        // ---- 8. Start two-step ownership handover to federation ----------
+        // ---- 9. Start two-step ownership handover to federation ----------
         // Ownable2Step: these only set pendingOwner = proxy. The federation
         // completes the handoff post-deploy by accepting via governance
         // (AdminExecute / AdminExecuteCommissionManager / AdminExecuteRouteRegistry
@@ -199,7 +221,7 @@ contract DeployAll is Script {
 
         vm.stopBroadcast();
 
-        // ---- 9. Summary --------------------------------------------------
+        // ---- 10. Summary -------------------------------------------------
         console2.log("CommissionManager deployed at:  ", address(cm));
         console2.log("RouteRegistry deployed at:      ", address(routeRegistry));
         console2.log("Bridge deployed at:             ", address(bridge));
@@ -211,6 +233,10 @@ contract DeployAll is Script {
         console2.log("NullVerifier deployed at:       ", address(nullVerifier));
         console2.log("RgbOutboundSettlementModule at: ", address(outboundModule));
         console2.log("MultisigProxy deployed at:      ", address(proxy));
+        console2.log("Initial chain bucket burst bps: ", initialChainBurstBps);
+        console2.log("Initial chain bucket refill bps:", initialChainRefillBps);
+        console2.log("Global bucket burst bps:        ", globalBurstBps);
+        console2.log("Global bucket refill bps:       ", globalRefillBps);
         if (ethUsdFeed != address(0)) {
             console2.log("ETH/USD feed wired:             ", ethUsdFeed);
             console2.log("ETH/USD heartbeat (s):          ", ethUsdHb);
@@ -229,7 +255,7 @@ contract DeployAll is Script {
             console2.log("ETH/USD price band max:         ", ethUsdMaxPrice);
         }
 
-        // ---- 10. Invariant checks ---------------------------------------
+        // ---- 11. Invariant checks ---------------------------------------
         require(address(bridge) == predictedBridge, "Bridge address prediction mismatch");
         require(routeRegistry.bridge() == address(bridge), "RouteRegistry.bridge mismatch");
         require(rgbModule.routeRegistry() == address(routeRegistry), "RgbSettlementModule.routeRegistry mismatch");
@@ -242,6 +268,11 @@ contract DeployAll is Script {
         );
         require(bridge.routeRegistry() == address(routeRegistry), "Bridge.routeRegistry mismatch");
         require(cm.bridgeAddress() == address(bridge), "CM.bridgeAddress mismatch");
+        (uint128 chainTokens,, bool chainEnabled, uint128 chainCapacity, uint128 chainRate) =
+            bridge.chainBuckets(initialSrcChain);
+        require(chainEnabled && chainTokens == chainCapacity && chainRate != 0, "initial chain bucket not configured");
+        (uint128 globalTokens,, bool globalEnabled, uint128 globalCapacity, uint128 globalRate) = bridge.globalBucket();
+        require(globalEnabled && globalTokens == globalCapacity && globalRate != 0, "global bucket not configured");
         // Two-step: ownership stays with `deployer` until the federation
         // accepts; assert the pending transfer to the proxy was initiated.
         require(
@@ -267,7 +298,7 @@ contract DeployAll is Script {
             );
         }
 
-        // ---- 11. Post-deploy reminder -----------------------------------
+        // ---- 12. Post-deploy reminder -----------------------------------
         console2.log("");
         console2.log("Ownership handoff is two-step: deployer still owns Bridge/CM/");
         console2.log("RouteRegistry until the federation accepts via governance:");
@@ -279,5 +310,13 @@ contract DeployAll is Script {
         console2.log("  MultisigProxy.proposeSetRoute(src, dst, true, verifier, module)");
         console2.log("for each supported (sourceChainId, destChainId) pair");
         console2.log("before any fundsIn / fundsOut traffic is accepted.");
+        console2.log("For every additional fundsOut source chain, federation must also");
+        console2.log("install setOutflowLimit(chainId, burstBps, refillBpsPerWindow)");
+        console2.log("before enabling traffic for that chain.");
+    }
+
+    function _validOutflowPolicy(uint256 burstBps, uint256 refillBpsPerWindow) private pure returns (bool) {
+        return burstBps != 0 && refillBpsPerWindow != 0 && burstBps <= MAX_OUTFLOW_POLICY_BPS
+            && refillBpsPerWindow <= MAX_OUTFLOW_POLICY_BPS && burstBps + refillBpsPerWindow <= MAX_OUTFLOW_POLICY_BPS;
     }
 }

--- a/ethereum/script/deploy/DeployCommissionManager.s.sol
+++ b/ethereum/script/deploy/DeployCommissionManager.s.sol
@@ -10,6 +10,7 @@ import {CommissionManager} from "../../src/CommissionManager.sol";
 /// Env:
 ///   PRIVATE_KEY       — deployer private key (becomes CM owner; transfer to multisig afterwards)
 ///   BRIDGE_ADDRESS    — Bridge contract that will send commissions (non-zero)
+///   COMMISSION_RECIPIENT — immutable destination for every commission withdrawal
 ///
 ///   ETH_USD_FEED      — Optional Chainlink ETH/USD aggregator address. When
 ///                       supplied (non-zero) the script also calls
@@ -21,14 +22,11 @@ import {CommissionManager} from "../../src/CommissionManager.sol";
 ///                       the feed answer is considered stale. Arbitrum One
 ///                       ETH/USD heartbeats at 86400 s — use ~87000 with a
 ///                       small buffer.
-///   SEQUENCER_UPTIME_FEED — Optional (Arbitrum, R-I-14) Chainlink L2 Sequencer
-///                       Uptime feed. When set, NATIVE quotes reject prices
-///                       during sequencer downtime + the post-restart grace.
-///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — Optional (R-I-14) ETH/USD sanity
-///                       band in feed decimals; set both or neither.
-///   REQUIRE_CHAINLINK_HARDENING (false) — when true, revert unless ETH_USD_FEED,
-///                       SEQUENCER_UPTIME_FEED, and the price band are all set
-///                       (recommended for Arbitrum production).
+///   SEQUENCER_UPTIME_FEED — Required whenever ETH_USD_FEED is set. Chainlink
+///                       Arbitrum L2 Sequencer Uptime feed used to reject NATIVE
+///                       quotes during downtime + the post-restart grace period.
+///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — Required whenever ETH_USD_FEED is
+///                       set. ETH/USD sanity band in the price feed's decimals.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployCommissionManager.s.sol \
@@ -37,43 +35,44 @@ contract DeployCommissionManager is Script {
     function run() external returns (CommissionManager cm) {
         uint256 pk = vm.envUint("PRIVATE_KEY");
         address bridgeAddress = vm.envAddress("BRIDGE_ADDRESS");
+        address commissionRecipient = vm.envAddress("COMMISSION_RECIPIENT");
         address ethUsdFeed = vm.envOr("ETH_USD_FEED", address(0));
         uint256 ethUsdHb = vm.envOr("ETH_USD_HEARTBEAT", uint256(0));
         address seqFeed = vm.envOr("SEQUENCER_UPTIME_FEED", address(0));
         uint256 ethUsdMinPrice = vm.envOr("ETH_USD_MIN_PRICE", uint256(0));
         uint256 ethUsdMaxPrice = vm.envOr("ETH_USD_MAX_PRICE", uint256(0));
-        bool reqHardening = vm.envOr("REQUIRE_CHAINLINK_HARDENING", false);
 
         // Misconfiguration checks (fail-fast, before broadcast). Price band is
-        // all-or-nothing (a half-set band would be silently ignored). The opt-in
-        // prod guard enforces the full R-I-14 config when NATIVE is enabled.
+        // all-or-nothing. Hardening is mandatory whenever the NATIVE
+        // oracle path is enabled; there is no production opt-out.
         require(
             (ethUsdMinPrice == 0) == (ethUsdMaxPrice == 0),
             "set both ETH_USD_MIN_PRICE and ETH_USD_MAX_PRICE, or neither"
         );
-        if (reqHardening) {
-            require(ethUsdFeed != address(0), "hardening: ETH_USD_FEED must be set");
+        require(ethUsdMaxPrice == 0 || ethUsdMinPrice < ethUsdMaxPrice, "ETH_USD_MIN_PRICE must be below MAX");
+        if (ethUsdFeed != address(0)) {
+            require(ethUsdHb != 0, "ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided");
             require(seqFeed != address(0), "hardening: SEQUENCER_UPTIME_FEED must be set");
             require(ethUsdMaxPrice != 0, "hardening: ETH_USD_MIN/MAX_PRICE must be set");
         }
 
         vm.startBroadcast(pk);
-        cm = new CommissionManager(bridgeAddress);
-        if (ethUsdFeed != address(0)) {
-            require(ethUsdHb != 0, "ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided");
-            cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
-        }
-        // R-I-14 Arbitrum hardening (owner-only; deployer is owner here).
+        cm = new CommissionManager(bridgeAddress, commissionRecipient);
+        // Install the safety dependencies before enabling ETH/USD quotes.
         if (seqFeed != address(0)) {
             cm.setSequencerUptimeFeed(seqFeed);
         }
         if (ethUsdMaxPrice != 0) {
             cm.setEthUsdPriceBounds(ethUsdMinPrice, ethUsdMaxPrice);
         }
+        if (ethUsdFeed != address(0)) {
+            cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
+        }
         vm.stopBroadcast();
 
         console2.log("CommissionManager deployed at:", address(cm));
         console2.log("Bridge address:               ", cm.bridgeAddress());
+        console2.log("Immutable commission recipient:", cm.commissionRecipient());
         console2.log("Owner (deployer):             ", cm.owner());
         if (ethUsdFeed != address(0)) {
             console2.log("ETH/USD feed wired:           ", ethUsdFeed);

--- a/ethereum/script/deploy/DeployMultisigProxy.s.sol
+++ b/ethereum/script/deploy/DeployMultisigProxy.s.sol
@@ -17,7 +17,6 @@ import {MultisigProxy} from "../../src/MultisigProxy.sol";
 ///   INITIAL_ENCLAVE_SOURCE_CHAIN_ID — source chain id the initial enclave set authorises (non-zero)
 ///   FEDERATION_SIGNERS    — comma-separated governance signer addresses
 ///   FEDERATION_THRESHOLD  — M for federation M-of-N
-///   COMMISSION_RECIPIENT  — destination for commission withdrawals
 ///   TIMELOCK_DURATION     — seconds between propose and execute (e.g. 3600)
 ///
 /// Usage:
@@ -34,13 +33,12 @@ contract DeployMultisigProxy is Script {
         uint256 initialSrcChain = vm.envUint("INITIAL_ENCLAVE_SOURCE_CHAIN_ID");
         address[] memory fed = vm.envAddress("FEDERATION_SIGNERS", ",");
         uint256 fedThr = vm.envUint("FEDERATION_THRESHOLD");
-        address commission = vm.envAddress("COMMISSION_RECIPIENT");
         uint256 timelock = vm.envUint("TIMELOCK_DURATION");
         uint256 minTimelock = vm.envUint("MIN_TIMELOCK");
 
         vm.startBroadcast(pk);
         proxy = new MultisigProxy(
-            bridgeAddr, commissionManager, enc, encThr, initialSrcChain, fed, fedThr, commission, timelock, minTimelock
+            bridgeAddr, commissionManager, enc, encThr, initialSrcChain, fed, fedThr, timelock, minTimelock
         );
         vm.stopBroadcast();
 

--- a/ethereum/script/interact/BridgeFundsIn.s.sol
+++ b/ethereum/script/interact/BridgeFundsIn.s.sol
@@ -9,9 +9,13 @@ import {ICommissionManager} from "../../src/interfaces/ICommissionManager.sol";
 /// @title BridgeFundsIn
 /// @notice Approves and calls the public `Bridge.fundsIn()` overload as the
 ///         current signer. Quotes the native commission from CommissionManager
-///         and attaches it as `msg.value`. `sourceChainId` is filled with
-///         `block.chainid` by the Bridge — the script just reads it back to
-///         drive the quote.
+///         and attaches the quote plus `NATIVE_BUFFER_BPS` of headroom to absorb
+///         limited ETH/USD drift between quoting and execution. The call still
+///         reverts if the fresh quote exceeds the attached value or the attached
+///         value falls outside the Bridge's immutable tolerance. Bridge charges
+///         exactly the quote it computes at execution and refunds the unused
+///         buffer. `sourceChainId` is filled with `block.chainid` by the Bridge —
+///         the script just reads it back to drive the quote.
 ///
 ///         The canonical `operationId` is derived on-chain by the Bridge and
 ///         returned; this script logs it. The RGB route carries the RGB OpId
@@ -22,6 +26,11 @@ import {ICommissionManager} from "../../src/interfaces/ICommissionManager.sol";
 ///   PRIVATE_KEY, BRIDGE_ADDRESS, AMOUNT (wei),
 ///   DESTINATION_CHAIN_ID, DESTINATION_ADDRESS, RGB_OP_ID
 contract BridgeFundsIn is Script {
+    /// @dev Drift headroom attached on top of the quote. Kept below the
+    ///      Bridge's `NATIVE_COMMISSION_TOLERANCE_BPS` so a quote that is still
+    ///      current is never rejected for overpaying.
+    uint256 private constant NATIVE_BUFFER_BPS = 200; // 2%
+
     function run() external {
         uint256 pk = vm.envUint("PRIVATE_KEY");
         address bridgeAddr = vm.envAddress("BRIDGE_ADDRESS");
@@ -36,18 +45,27 @@ contract BridgeFundsIn is Script {
         ICommissionManager cm = bridge.commissionManager();
         (, uint256 nativeCommission,) = cm.calculateFundsInCommission(block.chainid, destChainId, token, amount);
 
-        console2.log("Native commission (wei):", nativeCommission);
+        // Attach the quote plus drift headroom. Bridge charges the quote it
+        // computes at execution and refunds the rest, so this is a ceiling on
+        // what may be spent, not the amount actually paid.
+        uint256 nativeValue = nativeCommission + (nativeCommission * NATIVE_BUFFER_BPS) / 10_000;
+
+        console2.log("Native commission quote (wei):", nativeCommission);
+        console2.log("Native value attached (wei):  ", nativeValue);
+
+        uint256 balanceBefore = vm.addr(pk).balance;
 
         vm.startBroadcast(pk);
         IERC20(token).approve(bridgeAddr, amount);
         // RGB route: `settlementData` carries the RGB OpId as `abi.encode(uint256)`;
         // the settlement module decodes it and surfaces it in the FundsIn event.
         // Other routes define their own blob layout.
-        bytes32 operationId = bridge.fundsIn{value: nativeCommission}(amount, destChainId, dAddr, abi.encode(rgbOpId));
+        bytes32 operationId = bridge.fundsIn{value: nativeValue}(amount, destChainId, dAddr, abi.encode(rgbOpId));
         vm.stopBroadcast();
 
         console2.log("fundsIn succeeded. Derived operationId:");
         console2.logBytes32(operationId);
+        console2.log("Native spent incl. gas (wei): ", balanceBefore - vm.addr(pk).balance);
         console2.log("Bridge balance:", IERC20(token).balanceOf(bridgeAddr));
     }
 }

--- a/ethereum/script/interact/EmergencyPause.s.sol
+++ b/ethereum/script/interact/EmergencyPause.s.sol
@@ -23,16 +23,26 @@ contract EmergencyPause is Script {
         uint256 offset = vm.envUint("DEADLINE_OFFSET");
 
         MultisigProxy proxy = MultisigProxy(proxyAddr);
-        uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + offset;
-
-        bytes32 digest = MultisigHelper.digestEmergencyPause(proxy.DOMAIN_SEPARATOR(), nonce, deadline);
+        (uint256 nonce, bytes32 digest) = _prepareEmergencyPause(proxy, deadline);
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, ks);
 
         vm.startBroadcast(pk);
         proxy.emergencyPause(nonce, deadline, bitmap, sigs);
         vm.stopBroadcast();
 
-        console2.log("emergencyPause submitted. New proposalNonce:", proxy.proposalNonce());
+        console2.log("emergencyPause submitted. New emergencyNonce:", proxy.emergencyNonce());
+    }
+
+    /// @dev Emergency actions have an independent nonce lane. Keeping nonce
+    ///      lookup and digest construction together prevents the production
+    ///      script from accidentally signing with the regular proposal nonce.
+    function _prepareEmergencyPause(MultisigProxy proxy, uint256 deadline)
+        internal
+        view
+        returns (uint256 nonce, bytes32 digest)
+    {
+        nonce = proxy.emergencyNonce();
+        digest = MultisigHelper.digestEmergencyPause(proxy.DOMAIN_SEPARATOR(), nonce, deadline);
     }
 }

--- a/ethereum/script/interact/EmergencyUnpause.s.sol
+++ b/ethereum/script/interact/EmergencyUnpause.s.sol
@@ -18,16 +18,26 @@ contract EmergencyUnpause is Script {
         uint256 offset = vm.envUint("DEADLINE_OFFSET");
 
         MultisigProxy proxy = MultisigProxy(proxyAddr);
-        uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + offset;
-
-        bytes32 digest = MultisigHelper.digestEmergencyUnpause(proxy.DOMAIN_SEPARATOR(), nonce, deadline);
+        (uint256 nonce, bytes32 digest) = _prepareEmergencyUnpause(proxy, deadline);
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, ks);
 
         vm.startBroadcast(pk);
         proxy.emergencyUnpause(nonce, deadline, bitmap, sigs);
         vm.stopBroadcast();
 
-        console2.log("emergencyUnpause submitted. New proposalNonce:", proxy.proposalNonce());
+        console2.log("emergencyUnpause submitted. New emergencyNonce:", proxy.emergencyNonce());
+    }
+
+    /// @dev Emergency actions have an independent nonce lane. Keeping nonce
+    ///      lookup and digest construction together prevents the production
+    ///      script from accidentally signing with the regular proposal nonce.
+    function _prepareEmergencyUnpause(MultisigProxy proxy, uint256 deadline)
+        internal
+        view
+        returns (uint256 nonce, bytes32 digest)
+    {
+        nonce = proxy.emergencyNonce();
+        digest = MultisigHelper.digestEmergencyUnpause(proxy.DOMAIN_SEPARATOR(), nonce, deadline);
     }
 }

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -76,6 +76,18 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     /// @notice Basis-point denominator for the immutable rolling safety limits.
     uint256 public constant BPS_DENOMINATOR = 10_000;
 
+    /// @notice Headroom allowed between the native value supplied to `fundsIn`
+    ///         and the fresh destination-side oracle quote, to absorb ETH/USD
+    ///         drift between quoting and execution.
+    ///
+    ///         Direct deposits may attach up to 5% above the quote as a buffer;
+    ///         exactly the quote is collected and the remainder is refunded, so
+    ///         the band is one-sided and costs neither party. LayerZero deposits
+    ///         carry a source-agreed value that cannot be refunded across
+    ///         domains, so there the band is symmetric — 5% either side — and
+    ///         whatever arrives inside it is collected in full.
+    uint256 public constant NATIVE_COMMISSION_TOLERANCE_BPS = 500;
+
     /// @notice Minimum rolling interval covered by the immutable safety
     ///         limiter. The bounded ring implementation retains usage for
     ///         24-25 hours, never less than this value.
@@ -393,7 +405,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         string calldata destinationAddress,
         bytes calldata settlementData
     ) external payable override whenNotPaused nonReentrant returns (bytes32 operationId) {
-        // Direct EVM deposit: the source sender IS the caller.
+        // Direct EVM deposit: the source sender IS the caller, so a native
+        // surplus can be returned to them — `refundNativeSurplus = true`.
         address caller = _msgSender();
         operationId = _fundsIn(
             caller,
@@ -402,7 +415,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             block.chainid,
             destinationChainId,
             destinationAddress,
-            settlementData
+            settlementData,
+            true
         );
     }
 
@@ -418,8 +432,20 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // LZ deposit: tokens are pulled from the adapter (`_msgSender()`), but
         // the identity bound into `operationId` is the authenticated
         // `sourceSender` forwarded from the source-chain entrypoint.
+        //
+        // `refundNativeSurplus = false`: `msg.value` is the source-agreed
+        // `expectedComposeValue`, and the payer lives on the source chain — the
+        // adapter is only its courier, so refunding `_msgSender()` would pay the
+        // wrong party. The symmetric drift band absorbs the deviation instead.
         operationId = _fundsIn(
-            _msgSender(), sourceSender, amount, sourceChainId, destinationChainId, destinationAddress, settlementData
+            _msgSender(),
+            sourceSender,
+            amount,
+            sourceChainId,
+            destinationChainId,
+            destinationAddress,
+            settlementData,
+            false
         );
     }
 
@@ -813,7 +839,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         uint256 sourceChainId,
         uint256 destinationChainId,
         string memory destinationAddress,
-        bytes calldata settlementData
+        bytes calldata settlementData,
+        bool refundNativeSurplus
     ) private returns (bytes32 operationId) {
         if (amount < minFundsInAmount) {
             revert AmountBelowMinimum(amount, minFundsInAmount);
@@ -828,20 +855,55 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (sourceChainId == 0) revert InvalidSourceChainId();
         if (destinationChainId == 0) revert InvalidDestinationChainId();
 
-        // Commission is quoted from the nominal `amount` so the native-commission
-        // quote (and the lower-bound `msg.value` check below) stays predictable
-        // for the caller. The nominal net is intentionally discarded — the
-        // credited net is derived from the ACTUAL received amount after the transfer.
+        // Commission is freshly quoted from the nominal `amount`. For direct
+        // calls `msg.value` is the user's submitted quote; for LayerZero it is
+        // the source-agreed expectedComposeValue authenticated by the adapter.
+        // The nominal net is intentionally discarded — the credited net is
+        // derived from the ACTUAL received amount after the transfer.
         (uint256 tokenCommission, uint256 nativeCommission,) =
             commissionManager.calculateFundsInCommission(sourceChainId, destinationChainId, TOKEN, amount);
 
-        // Native payment: require at least the freshly-quoted commission
-        // — an oracle move up between quote and execution reverts here. Any
-        // overpayment from a favorable move is collected as commission below
-        // (not refunded), so the rule is uniform for direct and LZ deposits.
-        // TOKEN-commission routes (nativeCommission == 0) accept no native.
-        if (msg.value < nativeCommission) revert NativeValueMismatch();
-        if (nativeCommission == 0 && msg.value != 0) revert NativeValueMismatch();
+        // Bound `msg.value` against the fresh quote, then decide how much of it
+        // is actually commission. Both paths accept the same 5% headroom above
+        // the quote; they differ in what happens to that headroom, because only
+        // one of them can pay it back.
+        //
+        //  - Direct deposit (`refundNativeSurplus`): the surplus is a drift
+        //    buffer. The floor is the quote itself and exactly the quote is
+        //    collected, so the protocol never under-collects and the caller is
+        //    never charged more than quoted — the surplus is returned below.
+        //  - LZ deposit: the payer is on the source chain and unreachable, so no
+        //    refund is possible. A symmetric band absorbs drift in both
+        //    directions and the whole source-agreed value is collected.
+        //
+        // TOKEN-commission routes (nativeCommission == 0) still accept no native.
+        // `minimum` and `nativeToCollect` are set together per branch on purpose:
+        // the trailing refund computes `msg.value - nativeToCollect`, so a floor
+        // below what is collected would underflow. Pairing them here makes that
+        // invariant structural rather than something a later edit must remember.
+        uint256 nativeToCollect;
+        if (nativeCommission == 0) {
+            if (msg.value != 0) revert NativeValueMismatch();
+        } else {
+            uint256 minimum;
+            if (refundNativeSurplus) {
+                minimum = nativeCommission;
+                nativeToCollect = nativeCommission;
+            } else {
+                minimum = Math.mulDiv(
+                    nativeCommission,
+                    BPS_DENOMINATOR - NATIVE_COMMISSION_TOLERANCE_BPS,
+                    BPS_DENOMINATOR,
+                    Math.Rounding.Ceil
+                );
+                nativeToCollect = msg.value;
+            }
+            uint256 maximum =
+                Math.mulDiv(nativeCommission, BPS_DENOMINATOR + NATIVE_COMMISSION_TOLERANCE_BPS, BPS_DENOMINATOR);
+            if (msg.value < minimum || msg.value > maximum) {
+                revert NativeCommissionOutOfBounds(msg.value, minimum, maximum);
+            }
+        }
 
         // Build the canonical context. The per-`(sourceChainId, sourceSender)`
         // nonce is consumed here — before any external call, so a downstream
@@ -875,10 +937,11 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         uint256 received = IERC20(TOKEN).balanceOf(address(this)) - balanceBefore;
 
         // The token commission is forwarded out of `received`; guard the
-        // subtraction so a token fee that eats more than the commission reverts
-        // cleanly instead of underflowing. A zero net (received == commission) is
-        // left to the existing zero-amount / dust handling, unchanged here.
-        if (received < tokenCommission) revert InsufficientReceived(received, tokenCommission);
+        // subtraction so a token fee that consumes all (or more) of the actual
+        // receipt reverts instead of creating a zero-net settlement or
+        // underflowing. Equality is reachable with fee-on-transfer tokens even
+        // though the nominal commission configuration is strictly below 100%.
+        if (received <= tokenCommission) revert InsufficientReceived(received, tokenCommission);
         ctx.netAmount = received - tokenCommission;
 
         // Forward token commission BEFORE the settlement hook so that any
@@ -901,12 +964,12 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         lockedLiquidity[destinationChainId] += ctx.netAmount;
         totalLockedLiquidity += ctx.netAmount;
 
-        // Forward the FULL native value to the CommissionManager pool. Any
-        // surplus over the quoted `nativeCommission` (favorable oracle drift) is
-        // collected as commission rather than refunded, so no native is
-        // ever left stranded in the Bridge.
-        if (msg.value != 0) {
-            (bool ok,) = address(commissionManager).call{value: msg.value}("");
+        // Forward the native commission actually owed — exactly the fresh quote
+        // on the direct path, the bounded source-agreed value on the LZ path.
+        // Any remainder is returned to the caller at the end of this function,
+        // so no native is ever retained in Bridge.
+        if (nativeToCollect != 0) {
+            (bool ok,) = address(commissionManager).call{value: nativeToCollect}("");
             if (!ok) revert NativeValueMismatch();
         }
 
@@ -921,11 +984,22 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             ctx.grossAmount,
             ctx.netAmount,
             tokenCommission,
-            msg.value, // actual native collected (== nativeCommission + any drift surplus)
+            nativeToCollect, // native commission actually credited to the pool
             ctx.sourceChainId,
             ctx.destChainId,
             ctx.destAddress
         );
+
+        // Return the drift buffer LAST: after every state write and after the
+        // commission transfer, so the recipient's fallback observes only settled
+        // state. Reachable on the direct path only — the LZ path collects its
+        // whole source-agreed value, leaving nothing to refund. The overloads are
+        // `nonReentrant`, so this trailing call cannot re-enter.
+        uint256 surplus = msg.value - nativeToCollect;
+        if (surplus != 0) {
+            (bool refunded,) = payable(from).call{value: surplus}("");
+            if (!refunded) revert NativeRefundFailed(from, surplus);
+        }
 
         operationId = ctx.operationId;
     }

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.35;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {BridgeBase} from "./BridgeBase.sol";
 import {IBridge} from "./interfaces/IBridge.sol";
@@ -11,6 +12,7 @@ import {ICommissionManager} from "./interfaces/ICommissionManager.sol";
 import {IRouteRegistry} from "./interfaces/IRouteRegistry.sol";
 import {FundsInContext, FundsOutContext} from "./interfaces/RouteTypes.sol";
 import {OutflowRateLimiter} from "./libraries/OutflowRateLimiter.sol";
+import {RollingOutflowLimiter} from "./libraries/RollingOutflowLimiter.sol";
 
 /// @title Bridge
 /// @notice Production bridge for locking USDT0 on Arbitrum and unlocking it
@@ -37,6 +39,7 @@ import {OutflowRateLimiter} from "./libraries/OutflowRateLimiter.sol";
 contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     using SafeERC20 for IERC20;
     using OutflowRateLimiter for OutflowRateLimiter.Bucket;
+    using RollingOutflowLimiter for RollingOutflowLimiter.Window;
 
     // =========================================================================
     // State
@@ -69,6 +72,25 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     ///         `fundsIn` too as defence-in-depth: current inbound modules ignore
     ///         `settlementData`, but a future module could iterate it.
     uint256 public constant MAX_SETTLEMENT_DATA_LENGTH = 4096;
+
+    /// @notice Basis-point denominator for the immutable rolling safety limits.
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @notice Minimum rolling interval covered by the immutable safety
+    ///         limiter. The bounded ring implementation retains usage for
+    ///         24-25 hours, never less than this value.
+    uint256 public constant OUTFLOW_SAFETY_WINDOW = 24 hours;
+
+    /// @notice A source chain can move at most 20% of its reference liquidity
+    ///         during one rolling safety window. Compile-time constant: neither
+    ///         federation governance nor the enclave lane can raise it.
+    uint256 public constant MAX_CHAIN_OUTFLOW_BPS = 2_000;
+
+    /// @notice Physical token outflow across all source chains can consume at
+    ///         most 20% of global reference TVL during one rolling safety
+    ///         window. Compile-time constant and independent of configurable
+    ///         token-bucket settings.
+    uint256 public constant MAX_GLOBAL_OUTFLOW_BPS = 2_000;
 
     /// @notice Domain-separated type hash for the on-chain `operationId`
     ///         derivation. Binds the id to this contract, the deposit context
@@ -143,6 +165,13 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     ///         bridged toward that chain.
     mapping(uint256 chainId => uint256 locked) public lockedLiquidity;
 
+    /// @notice Total accounted bridge liquidity across all isolated chain
+    ///         buckets. Direct token donations are deliberately excluded so
+    ///         they cannot inflate the immutable global safety allowance.
+    ///         `fundsIn` increases it, `fundsOut` decreases it and
+    ///         `rebalanceLiquidity` preserves it.
+    uint256 public totalLockedLiquidity;
+
     /// @notice Per-source-chain outflow rate limiter. Bounds
     ///         how fast `fundsOut` can drain a single chain's liquidity.
     mapping(uint256 chainId => OutflowRateLimiter.Bucket) public chainBuckets;
@@ -152,6 +181,12 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     ///         shared TEE could otherwise drain every chain's per-chain bucket
     ///         in the same window (aggregate = sum of per-chain caps).
     OutflowRateLimiter.Bucket public globalBucket;
+
+    /// @dev Immutable-security rolling usage. Federation-configurable token
+    ///      buckets may only make outflow stricter; these windows cannot be
+    ///      reconfigured or disabled.
+    mapping(uint256 chainId => RollingOutflowLimiter.Window) private _chainSafetyWindows;
+    RollingOutflowLimiter.Window private _globalSafetyWindow;
 
     /// @inheritdoc IBridge
     /// @dev Always non-zero (validated at the constructor and setter). Mutable
@@ -280,6 +315,18 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         return OutflowRateLimiter.currentState(globalBucket).tokens;
     }
 
+    /// @inheritdoc IBridge
+    function availableChainSafetyOutflow(uint256 chainId) external view override returns (uint256) {
+        uint256 spent = _chainSafetyWindows[chainId].current();
+        return _remainingSafetyAllowance(lockedLiquidity[chainId], spent, MAX_CHAIN_OUTFLOW_BPS);
+    }
+
+    /// @inheritdoc IBridge
+    function availableGlobalSafetyOutflow() external view override returns (uint256) {
+        uint256 spent = _globalSafetyWindow.current();
+        return _remainingSafetyAllowance(totalLockedLiquidity, spent, MAX_GLOBAL_OUTFLOW_BPS);
+    }
+
     // =========================================================================
     // External — user-facing
     // =========================================================================
@@ -350,7 +397,10 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (fundsOutParams.amount > srcLiquidity) {
             revert InsufficientChainLiquidity(fundsOutParams.sourceChainId, fundsOutParams.amount, srcLiquidity);
         }
+
         lockedLiquidity[fundsOutParams.sourceChainId] = srcLiquidity - fundsOutParams.amount;
+        uint256 totalLiquidity = totalLockedLiquidity;
+        totalLockedLiquidity = totalLiquidity - fundsOutParams.amount;
 
         // Outflow rate limit. Consume both the per-source-chain
         // bucket and the global aggregate bucket; either being short reverts the
@@ -387,6 +437,15 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
                 fundsOutParams.proof,
                 fundsOutParams.settlementData
             );
+
+        // Immutable TVL-relative safety limits. These aggregate every release
+        // over a rolling 24h+ window, so neither one full-pool transaction nor a
+        // same-window sequence of smaller transactions can bypass the ceiling.
+        // They run after the existing bucket and route checks to preserve those
+        // paths' fail-fast errors; any failure here still atomically rolls back
+        // all earlier state and plugin calls.
+        _consumeChainSafetyOutflow(fundsOutParams.sourceChainId, srcLiquidity, fundsOutParams.amount);
+        _consumeGlobalSafetyOutflow(totalLiquidity, fundsOutParams.amount);
 
         // Forward token commission to the CommissionManager pool.
         if (tokenCommission != 0) _forwardTokenCommission(tokenCommission);
@@ -457,6 +516,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (params.amount > srcLiquidity) {
             revert InsufficientChainLiquidity(params.sourceChainId, params.amount, srcLiquidity);
         }
+
         lockedLiquidity[params.sourceChainId] = srcLiquidity - params.amount;
 
         // Per-source-chain outflow rate limit: release capacity is migrating
@@ -506,6 +566,14 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             );
 
         lockedLiquidity[params.destinationChainId] += params.amount;
+
+        // Rebalance moves release capacity away from the source chain and
+        // therefore consumes the same immutable per-chain safety allowance as a
+        // physical release. It intentionally does not consume global allowance:
+        // no token leaves custody, and the eventual fundsOut will consume it.
+        // Kept after route validation so route-specific errors retain priority;
+        // a safety-limit revert rolls the complete rebalance back atomically.
+        _consumeChainSafetyOutflow(params.sourceChainId, srcLiquidity, params.amount);
 
         // RGB-only correlation event, same contract as `_fundsIn`: the RGB
         // listener authorises a mint against `FundsIn` and needs no awareness
@@ -749,6 +817,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // the accumulated locked liquidity. Credited from the ACTUAL received
         // amount so the ledger can never exceed real custody.
         lockedLiquidity[destinationChainId] += ctx.netAmount;
+        totalLockedLiquidity += ctx.netAmount;
 
         // Forward the FULL native value to the CommissionManager pool. Any
         // surplus over the quoted `nativeCommission` (favorable oracle drift) is
@@ -796,6 +865,45 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         IERC20(TOKEN).safeTransfer(cm, amount);
         uint256 credited = IERC20(TOKEN).balanceOf(cm) - balBefore;
         commissionManager.receiveTokenCommission(TOKEN, credited);
+    }
+
+    /// @dev Consume immutable per-chain rolling allowance. The reference
+    ///      liquidity is `current + already spent`, which stays constant while
+    ///      releases consume liquidity inside the same window. This prevents a
+    ///      sequence of individually-small withdrawals from geometrically
+    ///      draining the bucket.
+    function _consumeChainSafetyOutflow(uint256 chainId, uint256 currentLiquidity, uint256 amount) private {
+        RollingOutflowLimiter.Window storage window = _chainSafetyWindows[chainId];
+        uint256 spent = window.current();
+        uint256 limit = _safetyLimit(currentLiquidity, spent, MAX_CHAIN_OUTFLOW_BPS);
+        if (spent + amount > limit) revert ChainSafetyLimitExceeded(chainId, amount, spent, limit);
+
+        uint256 updatedSpent = window.consume(amount);
+        emit ChainSafetyOutflowConsumed(chainId, amount, updatedSpent, limit);
+    }
+
+    /// @dev Consume immutable aggregate rolling allowance for physical token
+    ///      outflow. Rebalances do not call this function.
+    function _consumeGlobalSafetyOutflow(uint256 currentLiquidity, uint256 amount) private {
+        uint256 spent = _globalSafetyWindow.current();
+        uint256 limit = _safetyLimit(currentLiquidity, spent, MAX_GLOBAL_OUTFLOW_BPS);
+        if (spent + amount > limit) revert GlobalSafetyLimitExceeded(amount, spent, limit);
+
+        uint256 updatedSpent = _globalSafetyWindow.consume(amount);
+        emit GlobalSafetyOutflowConsumed(amount, updatedSpent, limit);
+    }
+
+    function _remainingSafetyAllowance(uint256 currentLiquidity, uint256 spent, uint256 maxBps)
+        private
+        pure
+        returns (uint256)
+    {
+        uint256 limit = _safetyLimit(currentLiquidity, spent, maxBps);
+        return spent < limit ? limit - spent : 0;
+    }
+
+    function _safetyLimit(uint256 currentLiquidity, uint256 spent, uint256 maxBps) private pure returns (uint256) {
+        return Math.mulDiv(currentLiquidity + spent, maxBps, BPS_DENOMINATOR);
     }
 
     /// @dev Canonical `operationId` = domain-separated hash of the deposit

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -92,6 +92,18 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     ///         token-bucket settings.
     uint256 public constant MAX_GLOBAL_OUTFLOW_BPS = 2_000;
 
+    /// @notice Share denominator for the outflow token buckets. Bucket
+    ///         allowance is held in shares of reference liquidity rather than
+    ///         absolute token units — `SHARE_UNIT` shares are 100% of the
+    ///         reference — so a bucket configured once keeps its meaning as
+    ///         liquidity grows or shrinks, with no governance retuning.
+    uint256 public constant SHARE_UNIT = 1e18;
+
+    /// @notice Window over which a bucket's `refillBpsPerWindow` accrues in
+    ///         full. Compile-time constant: federation cannot shorten it to
+    ///         make allowance return faster.
+    uint256 public constant BUCKET_REFILL_WINDOW = 24 hours;
+
     /// @notice Domain-separated type hash for the on-chain `operationId`
     ///         derivation. Binds the id to this contract, the deposit context
     ///         and a formula version, so ids cannot collide across deployments
@@ -172,14 +184,19 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     ///         `rebalanceLiquidity` preserves it.
     uint256 public totalLockedLiquidity;
 
-    /// @notice Per-source-chain outflow rate limiter. Bounds
-    ///         how fast `fundsOut` can drain a single chain's liquidity.
+    /// @notice Per-source-chain outflow rate limiter. Bounds how fast
+    ///         `fundsOut` can drain a single chain's liquidity. The public
+    ///         getter exposes raw bucket `tokens`, `capacity`, and `rate` in
+    ///         normalized shares, not token units; use `availableOutflow` for
+    ///         the current token-denominated allowance.
     mapping(uint256 chainId => OutflowRateLimiter.Bucket) public chainBuckets;
 
-    /// @notice Global (aggregate) outflow rate limiter. Bounds
-    ///         total `fundsOut` across all source chains, since a compromised
-    ///         shared TEE could otherwise drain every chain's per-chain bucket
-    ///         in the same window (aggregate = sum of per-chain caps).
+    /// @notice Global (aggregate) outflow rate limiter. Bounds total `fundsOut`
+    ///         across all source chains, since a compromised shared TEE could
+    ///         otherwise drain every chain's per-chain bucket in the same
+    ///         window (aggregate = sum of per-chain caps). Its public getter
+    ///         also reports raw normalized-share units; use
+    ///         `availableGlobalOutflow` for token units.
     OutflowRateLimiter.Bucket public globalBucket;
 
     /// @dev Immutable-security rolling usage. Federation-configurable token
@@ -288,43 +305,81 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
 
     /// @inheritdoc IBridge
     /// @dev Owner is `MultisigProxy`; federation gates this on its timelock flow.
-    function setOutflowLimit(uint256 chainId, uint256 capacity, uint256 refillRate) external override onlyOwner {
+    ///      Validation is liquidity-independent, so a policy can be installed
+    ///      before any deposit exists — including at deployment.
+    function setOutflowLimit(uint256 chainId, uint256 burstBps, uint256 refillBpsPerWindow)
+        external
+        override
+        onlyOwner
+    {
         if (chainId == 0) revert InvalidOutflowLimit();
-        OutflowRateLimiter.Settings memory cfg = _buildOutflowConfig(capacity, refillRate);
+        _validateOutflowBps(burstBps, refillBpsPerWindow, MAX_CHAIN_OUTFLOW_BPS);
+
+        OutflowRateLimiter.Settings memory cfg = _buildOutflowConfig(burstBps, refillBpsPerWindow);
         OutflowRateLimiter.validate(cfg, false);
         chainBuckets[chainId].configurePrimed(cfg);
-        emit OutflowLimitUpdated(chainId, capacity, refillRate, chainBuckets[chainId].tokens);
+        emit OutflowLimitUpdated(chainId, burstBps, refillBpsPerWindow, chainBuckets[chainId].tokens);
     }
 
     /// @inheritdoc IBridge
     /// @dev Owner is `MultisigProxy`; federation gates this on its timelock flow.
-    function setGlobalOutflowLimit(uint256 capacity, uint256 refillRate) external override onlyOwner {
-        OutflowRateLimiter.Settings memory cfg = _buildOutflowConfig(capacity, refillRate);
+    function setGlobalOutflowLimit(uint256 burstBps, uint256 refillBpsPerWindow) external override onlyOwner {
+        _validateOutflowBps(burstBps, refillBpsPerWindow, MAX_GLOBAL_OUTFLOW_BPS);
+
+        OutflowRateLimiter.Settings memory cfg = _buildOutflowConfig(burstBps, refillBpsPerWindow);
         OutflowRateLimiter.validate(cfg, false);
         globalBucket.configurePrimed(cfg);
-        emit GlobalOutflowLimitUpdated(capacity, refillRate, globalBucket.tokens);
+        emit GlobalOutflowLimitUpdated(burstBps, refillBpsPerWindow, globalBucket.tokens);
     }
 
     /// @inheritdoc IBridge
     function availableOutflow(uint256 chainId) external view override returns (uint256) {
-        return OutflowRateLimiter.currentState(chainBuckets[chainId]).tokens;
+        uint256 shares = OutflowRateLimiter.currentState(chainBuckets[chainId]).tokens;
+        return _fromShares(shares, _chainReference(chainId));
     }
 
     /// @inheritdoc IBridge
     function availableGlobalOutflow() external view override returns (uint256) {
-        return OutflowRateLimiter.currentState(globalBucket).tokens;
+        uint256 shares = OutflowRateLimiter.currentState(globalBucket).tokens;
+        return _fromShares(shares, _globalReference());
     }
 
     /// @inheritdoc IBridge
     function availableChainSafetyOutflow(uint256 chainId) external view override returns (uint256) {
         uint256 spent = _chainSafetyWindows[chainId].current();
-        return _remainingSafetyAllowance(lockedLiquidity[chainId], spent, MAX_CHAIN_OUTFLOW_BPS);
+        return _remainingSafetyAllowance(lockedLiquidity[chainId] + spent, spent, MAX_CHAIN_OUTFLOW_BPS);
     }
 
     /// @inheritdoc IBridge
     function availableGlobalSafetyOutflow() external view override returns (uint256) {
         uint256 spent = _globalSafetyWindow.current();
-        return _remainingSafetyAllowance(totalLockedLiquidity, spent, MAX_GLOBAL_OUTFLOW_BPS);
+        return _remainingSafetyAllowance(totalLockedLiquidity + spent, spent, MAX_GLOBAL_OUTFLOW_BPS);
+    }
+
+    /// @inheritdoc IBridge
+    function chainOutflowReference(uint256 chainId) external view override returns (uint256) {
+        return _chainReference(chainId);
+    }
+
+    /// @inheritdoc IBridge
+    function globalOutflowReference() external view override returns (uint256) {
+        return _globalReference();
+    }
+
+    /// @inheritdoc IBridge
+    function effectiveAvailableOutflow(uint256 chainId) external view override returns (uint256) {
+        uint256 chainSpent = _chainSafetyWindows[chainId].current();
+        uint256 chainRef = lockedLiquidity[chainId] + chainSpent;
+        uint256 globalSpent = _globalSafetyWindow.current();
+        uint256 globalRef = totalLockedLiquidity + globalSpent;
+
+        uint256 allowed = lockedLiquidity[chainId];
+        allowed =
+            Math.min(allowed, _fromShares(OutflowRateLimiter.currentState(chainBuckets[chainId]).tokens, chainRef));
+        allowed = Math.min(allowed, _fromShares(OutflowRateLimiter.currentState(globalBucket).tokens, globalRef));
+        allowed = Math.min(allowed, _remainingSafetyAllowance(chainRef, chainSpent, MAX_CHAIN_OUTFLOW_BPS));
+        allowed = Math.min(allowed, _remainingSafetyAllowance(globalRef, globalSpent, MAX_GLOBAL_OUTFLOW_BPS));
+        return allowed;
     }
 
     // =========================================================================
@@ -402,6 +457,18 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         uint256 totalLiquidity = totalLockedLiquidity;
         totalLockedLiquidity = totalLiquidity - fundsOutParams.amount;
 
+        // Reference liquidity for both limiter layers: pre-debit liquidity plus
+        // usage already recorded in the rolling window. That sum is invariant as
+        // releases drain liquidity inside one window, so a sequence of small
+        // withdrawals cannot geometrically outpace the ceiling. Both the token
+        // buckets and the immutable safety limits below are denominated against
+        // the SAME reference, so the two layers never disagree about what a
+        // percentage means.
+        uint256 chainSpent = _chainSafetyWindows[fundsOutParams.sourceChainId].current();
+        uint256 chainReference = srcLiquidity + chainSpent;
+        uint256 globalSpent = _globalSafetyWindow.current();
+        uint256 globalReference = totalLiquidity + globalSpent;
+
         // Outflow rate limit. Consume both the per-source-chain
         // bucket and the global aggregate bucket; either being short reverts the
         // whole call (and rolls back the consume above). Both are debited before
@@ -410,8 +477,10 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // aggregate bucket (aggregate-scoped errors via the address(0) sentinel).
         // The limiter is fail-closed: an unconfigured chain/global bucket
         // rejects the release instead of falling back to unlimited outflow.
-        chainBuckets[fundsOutParams.sourceChainId].spend(fundsOutParams.amount, TOKEN);
-        globalBucket.spend(fundsOutParams.amount, address(0));
+        // Amounts are converted to shares of the reference, so a bucket keeps
+        // its configured percentage meaning as liquidity moves.
+        chainBuckets[fundsOutParams.sourceChainId].spend(_toShares(fundsOutParams.amount, chainReference), TOKEN);
+        globalBucket.spend(_toShares(fundsOutParams.amount, globalReference), address(0));
 
         // Quote commission. NATIVE on fundsOut is unrepresentable: the
         // CommissionManager setters reject a (NATIVE, FUNDS_OUT) rule at config,
@@ -444,8 +513,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // They run after the existing bucket and route checks to preserve those
         // paths' fail-fast errors; any failure here still atomically rolls back
         // all earlier state and plugin calls.
-        _consumeChainSafetyOutflow(fundsOutParams.sourceChainId, srcLiquidity, fundsOutParams.amount);
-        _consumeGlobalSafetyOutflow(totalLiquidity, fundsOutParams.amount);
+        _consumeChainSafetyOutflow(fundsOutParams.sourceChainId, chainSpent, chainReference, fundsOutParams.amount);
+        _consumeGlobalSafetyOutflow(globalSpent, globalReference, fundsOutParams.amount);
 
         // Forward token commission to the CommissionManager pool.
         if (tokenCommission != 0) _forwardTokenCommission(tokenCommission);
@@ -523,8 +592,11 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // away from this chain, so it spends the chain bucket like a release.
         // The global bucket is intentionally NOT spent — it bounds physical
         // token egress, and no tokens leave here; the eventual exit pays the
-        // global bucket inside `fundsOut`.
-        chainBuckets[params.sourceChainId].spend(params.amount, TOKEN);
+        // global bucket inside `fundsOut`. Same reference as the immutable
+        // per-chain safety limit consumed below.
+        uint256 chainSpent = _chainSafetyWindows[params.sourceChainId].current();
+        uint256 chainReference = srcLiquidity + chainSpent;
+        chainBuckets[params.sourceChainId].spend(_toShares(params.amount, chainReference), TOKEN);
 
         // Debit-leg verification: route verifier (view-only source proof)
         // first, then the settlement module's release check. `recipient` is
@@ -573,7 +645,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // no token leaves custody, and the eventual fundsOut will consume it.
         // Kept after route validation so route-specific errors retain priority;
         // a safety-limit revert rolls the complete rebalance back atomically.
-        _consumeChainSafetyOutflow(params.sourceChainId, srcLiquidity, params.amount);
+        _consumeChainSafetyOutflow(params.sourceChainId, chainSpent, chainReference, params.amount);
 
         // RGB-only correlation event, same contract as `_fundsIn`: the RGB
         // listener authorises a mint against `FundsIn` and needs no awareness
@@ -701,22 +773,32 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         );
     }
 
-    /// @dev Build an enabled outflow-limit config from uint256 inputs, safely
-    ///      narrowing to the library's uint128 fields. USDT0 amounts fit in
-    ///      uint128; a value above that is a misconfiguration and reverts.
+    /// @dev Translate a basis-point policy into the limiter's share-denominated
+    ///      settings. `capacity` is the burst expressed in shares of reference
+    ///      liquidity, `rate` the per-second share accrual that fills
+    ///      `refillBpsPerWindow` over one `BUCKET_REFILL_WINDOW`. Integer
+    ///      division rounds the rate down, so exact-window refill is
+    ///      conservative by less than one share-per-second remainder.
+    ///      Both fit in uint128 by construction: the largest representable
+    ///      capacity is `SHARE_UNIT` (1e18) and rate is strictly smaller, so the
+    ///      absolute-amount overflow check the old signature needed is gone.
+    ///      Precision lives in `SHARE_UNIT`, not in a carried remainder: at
+    ///      1500 bps the truncated rate loses ~6e-14 relative per second, which
+    ///      is why no fractional-remainder accounting is required.
     ///      `OutflowRateLimiter.validate` then enforces `0 < rate < capacity`.
-    function _buildOutflowConfig(uint256 capacity, uint256 refillRate)
+    function _buildOutflowConfig(uint256 burstBps, uint256 refillBpsPerWindow)
         private
         pure
         returns (OutflowRateLimiter.Settings memory)
     {
-        if (capacity > type(uint128).max || refillRate > type(uint128).max) revert InvalidOutflowLimit();
+        uint256 capacityShares = Math.mulDiv(burstBps, SHARE_UNIT, BPS_DENOMINATOR);
+        uint256 rateShares = Math.mulDiv(refillBpsPerWindow, SHARE_UNIT, BPS_DENOMINATOR) / BUCKET_REFILL_WINDOW;
         return OutflowRateLimiter.Settings({
             isEnabled: true,
             // forge-lint: disable-next-line(unsafe-typecast)
-            capacity: uint128(capacity),
+            capacity: uint128(capacityShares),
             // forge-lint: disable-next-line(unsafe-typecast)
-            rate: uint128(refillRate)
+            rate: uint128(rateShares)
         });
     }
 
@@ -867,43 +949,86 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         commissionManager.receiveTokenCommission(TOKEN, credited);
     }
 
-    /// @dev Consume immutable per-chain rolling allowance. The reference
-    ///      liquidity is `current + already spent`, which stays constant while
+    /// @dev Consume immutable per-chain rolling allowance. `reference` is
+    ///      `pre-debit liquidity + already spent`, which stays constant while
     ///      releases consume liquidity inside the same window. This prevents a
     ///      sequence of individually-small withdrawals from geometrically
     ///      draining the bucket.
-    function _consumeChainSafetyOutflow(uint256 chainId, uint256 currentLiquidity, uint256 amount) private {
-        RollingOutflowLimiter.Window storage window = _chainSafetyWindows[chainId];
-        uint256 spent = window.current();
-        uint256 limit = _safetyLimit(currentLiquidity, spent, MAX_CHAIN_OUTFLOW_BPS);
+    function _consumeChainSafetyOutflow(uint256 chainId, uint256 spent, uint256 refLiquidity, uint256 amount) private {
+        uint256 limit = _safetyLimit(refLiquidity, MAX_CHAIN_OUTFLOW_BPS);
         if (spent + amount > limit) revert ChainSafetyLimitExceeded(chainId, amount, spent, limit);
 
-        uint256 updatedSpent = window.consume(amount);
+        uint256 updatedSpent = _chainSafetyWindows[chainId].consume(amount);
         emit ChainSafetyOutflowConsumed(chainId, amount, updatedSpent, limit);
     }
 
     /// @dev Consume immutable aggregate rolling allowance for physical token
     ///      outflow. Rebalances do not call this function.
-    function _consumeGlobalSafetyOutflow(uint256 currentLiquidity, uint256 amount) private {
-        uint256 spent = _globalSafetyWindow.current();
-        uint256 limit = _safetyLimit(currentLiquidity, spent, MAX_GLOBAL_OUTFLOW_BPS);
+    function _consumeGlobalSafetyOutflow(uint256 spent, uint256 refLiquidity, uint256 amount) private {
+        uint256 limit = _safetyLimit(refLiquidity, MAX_GLOBAL_OUTFLOW_BPS);
         if (spent + amount > limit) revert GlobalSafetyLimitExceeded(amount, spent, limit);
 
         uint256 updatedSpent = _globalSafetyWindow.consume(amount);
         emit GlobalSafetyOutflowConsumed(amount, updatedSpent, limit);
     }
 
-    function _remainingSafetyAllowance(uint256 currentLiquidity, uint256 spent, uint256 maxBps)
+    /// @dev Validate a bucket policy. Deliberately liquidity-independent so a
+    ///      policy can be installed at deployment, before the first deposit —
+    ///      a percentage needs no reference to be well-formed.
+    ///
+    ///      The combined burst plus full-window refill budget cannot exceed
+    ///      `maxBps`. This makes both a full-TVL instant bucket and an
+    ///      over-permissive burst/refill pair unrepresentable, independently of
+    ///      current liquidity. The immutable rolling limiter remains the
+    ///      non-configurable backstop and no bucket policy can relax it.
+    function _validateOutflowBps(uint256 burstBps, uint256 refillBpsPerWindow, uint256 maxBps) private pure {
+        if (
+            burstBps == 0 || refillBpsPerWindow == 0 || burstBps > maxBps || refillBpsPerWindow > maxBps
+                || burstBps + refillBpsPerWindow > maxBps
+        ) {
+            revert InvalidOutflowPolicy(burstBps, refillBpsPerWindow, maxBps);
+        }
+    }
+
+    /// @dev Convert a token amount to bucket shares of `reference`. Rounds up so
+    ///      a release can never be cheaper in shares than its true fraction of
+    ///      the reference, and so dust cannot pass for free.
+    function _toShares(uint256 amount, uint256 refLiquidity) private pure returns (uint256) {
+        // Unreachable via `fundsOut`/`rebalanceLiquidity`: both revert with
+        // `InsufficientChainLiquidity` before this point when the reference is
+        // zero. Asserted rather than assumed — division safety must not depend
+        // on an upstream caller's ordering.
+        if (refLiquidity == 0) revert ZeroOutflowReference();
+        return Math.mulDiv(amount, SHARE_UNIT, refLiquidity, Math.Rounding.Ceil);
+    }
+
+    /// @dev Convert bucket shares back to token units for the public views.
+    function _fromShares(uint256 shares, uint256 refLiquidity) private pure returns (uint256) {
+        return Math.mulDiv(shares, refLiquidity, SHARE_UNIT);
+    }
+
+    /// @dev Reference liquidity for a source chain: accounted liquidity plus
+    ///      usage still counted in the rolling window.
+    function _chainReference(uint256 chainId) private view returns (uint256) {
+        return lockedLiquidity[chainId] + _chainSafetyWindows[chainId].current();
+    }
+
+    /// @dev Reference liquidity for the aggregate scope.
+    function _globalReference() private view returns (uint256) {
+        return totalLockedLiquidity + _globalSafetyWindow.current();
+    }
+
+    function _remainingSafetyAllowance(uint256 refLiquidity, uint256 spent, uint256 maxBps)
         private
         pure
         returns (uint256)
     {
-        uint256 limit = _safetyLimit(currentLiquidity, spent, maxBps);
+        uint256 limit = _safetyLimit(refLiquidity, maxBps);
         return spent < limit ? limit - spent : 0;
     }
 
-    function _safetyLimit(uint256 currentLiquidity, uint256 spent, uint256 maxBps) private pure returns (uint256) {
-        return Math.mulDiv(currentLiquidity + spent, maxBps, BPS_DENOMINATOR);
+    function _safetyLimit(uint256 refLiquidity, uint256 maxBps) private pure returns (uint256) {
+        return Math.mulDiv(refLiquidity, maxBps, BPS_DENOMINATOR);
     }
 
     /// @dev Canonical `operationId` = domain-separated hash of the deposit

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -38,8 +38,9 @@ import {
  *      `ethUsdHeartbeat`) and non-positive answers revert the call.
  *
  *      **Roles:** `bridgeAddress` may call `receiveTokenCommission` and `receive()` to credit fees;
- *      `owner` configures rules and withdraws accumulated pools. `renounceOwnership` is disabled.
- *      Withdrawals use `nonReentrant` against reentrancy via ERC-20 hooks or native recipients.
+ *      `owner` configures rules and withdraws accumulated pools. Every withdrawal pays the immutable
+ *      `commissionRecipient`, regardless of the caller or call path. `renounceOwnership` is disabled.
+ *      Withdrawals use `nonReentrant` against reentrancy via ERC-20 hooks or the native recipient.
  */
 contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager {
     using SafeERC20 for IERC20;
@@ -48,6 +49,11 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
 
     /// @notice Address allowed to credit token and native commission.
     address public bridgeAddress;
+
+    /// @notice Immutable destination for every token and native commission
+    ///         withdrawal. Enforced here at the asset-custody layer so no owner
+    ///         or alternate proxy call path can redirect accrued commission.
+    address public immutable commissionRecipient;
 
     /// @notice Default `stablePercent` when no per-route rule exists (×100; 0 = no % fee until configured).
     uint256 public globalStablePercent = 0;
@@ -77,9 +83,8 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     ///         in seconds. Quotes revert `StalePrice` when the answer is older.
     uint256 public ethUsdHeartbeat;
 
-    /// @notice Chainlink L2 Sequencer Uptime feed (Arbitrum). `address(0)`
-    ///         (default) disables the check for non-L2 / test environments;
-    ///         an Arbitrum deployment MUST wire it via `setSequencerUptimeFeed`.
+    /// @notice Chainlink L2 Sequencer Uptime feed (Arbitrum). NATIVE quotes
+    ///         fail closed while this is `address(0)`.
     address public sequencerUptimeFeed;
 
     /// @notice Seconds after a sequencer restart during which NATIVE quotes are
@@ -87,9 +92,9 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     ///         recovery. Chainlink's recommended grace period is 3600s.
     uint256 public constant SEQUENCER_GRACE_PERIOD = 3600;
 
-    /// @notice Optional [min, max] sanity band on the ETH/USD answer (in feed
-    ///         decimals). `ethUsdMaxPrice == 0` (default) disables the band; when
-    ///         set, an answer outside it (e.g. an aggregator floored/capped to
+    /// @notice Mandatory [min, max] sanity band on the ETH/USD answer (in feed
+    ///         decimals). NATIVE quotes fail closed while the band is unset; an
+    ///         answer outside it (e.g. an aggregator floored/capped to
     ///         `minAnswer`/`maxAnswer` during an extreme move) reverts
     ///         `PriceOutOfBounds`.
     uint256 public ethUsdMinPrice;
@@ -106,12 +111,15 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     // ============ Constructor ============
 
     /**
-     * @notice Deploys the manager; `msg.sender` is owner; `_bridgeAddress` is the initial bridge.
+     * @notice Deploys the manager; `msg.sender` is owner.
      * @param _bridgeAddress Bridge that will send commissions (non-zero).
+     * @param _commissionRecipient Immutable destination for all withdrawals (non-zero).
      */
-    constructor(address _bridgeAddress) Ownable(msg.sender) {
+    constructor(address _bridgeAddress, address _commissionRecipient) Ownable(msg.sender) {
         if (_bridgeAddress == address(0)) revert InvalidBridgeAddress();
+        if (_commissionRecipient == address(0)) revert InvalidRecipient();
         bridgeAddress = _bridgeAddress;
+        commissionRecipient = _commissionRecipient;
     }
 
     /// @inheritdoc Ownable
@@ -152,9 +160,11 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
 
         // Calculate stable fee in token units
         uint256 stableFee = calculateStableFee(amount, config.stablePercent, config.multiplier);
+        _requireNonZeroConfiguredCommission(amount, stableFee, config);
 
         if (config.currency == CommissionCurrency.TOKEN) {
             // TOKEN commission: deduct from amount
+            if (stableFee >= amount) revert ZeroNetAmount(amount, stableFee);
             tokenCommission = stableFee;
             nativeCommission = 0;
             netAmount = amount - tokenCommission;
@@ -165,6 +175,9 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
                 nativeCommission = 0;
             } else {
                 nativeCommission = convertTokenFeeToNative(stableFee, _tokenDecimals(token));
+                if (nativeCommission == 0) {
+                    revert CommissionRoundsToZero(amount, config.stablePercent, config.multiplier);
+                }
             }
             netAmount = amount; // Full amount bridges
         }
@@ -198,8 +211,10 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
 
         // Calculate stable fee
         uint256 stableFee = calculateStableFee(amount, config.stablePercent, config.multiplier);
+        _requireNonZeroConfiguredCommission(amount, stableFee, config);
 
         if (config.currency == CommissionCurrency.TOKEN) {
+            if (stableFee >= amount) revert ZeroNetAmount(amount, stableFee);
             tokenCommission = stableFee;
             nativeCommission = 0;
             netAmount = amount - tokenCommission;
@@ -210,6 +225,9 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
                 nativeCommission = 0;
             } else {
                 nativeCommission = convertTokenFeeToNative(stableFee, _tokenDecimals(token));
+                if (nativeCommission == 0) {
+                    revert CommissionRoundsToZero(amount, config.stablePercent, config.multiplier);
+                }
             }
             netAmount = amount;
         }
@@ -244,18 +262,23 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         address feedAddr = ethUsdFeed;
         if (feedAddr == address(0)) revert EthUsdFeedNotSet();
 
-        // L2 sequencer liveness (Arbitrum). Skipped when unset so non-L2 / test
-        // environments are unaffected; an Arbitrum deployment wires it.
-        if (sequencerUptimeFeed != address(0)) _requireSequencerUp();
+        // never consume an ETH/USD answer unless both Arbitrum
+        // hardening layers are configured. Setters may be executed in separate
+        // governance proposals, but the quote path remains fail-closed
+        // throughout any partially configured state.
+        if (sequencerUptimeFeed == address(0) || ethUsdMinPrice == 0 || ethUsdMaxPrice == 0) {
+            revert ChainlinkHardeningNotConfigured();
+        }
+        _requireSequencerUp();
 
         AggregatorV3Interface feed = AggregatorV3Interface(feedAddr);
 
         (, int256 answer,, uint256 updatedAt,) = feed.latestRoundData();
         if (answer <= 0) revert InvalidPrice();
         if (block.timestamp - updatedAt > ethUsdHeartbeat) revert StalePrice();
-        // Optional circuit-breaker band (disabled when ethUsdMaxPrice == 0):
-        // rejects a floored/capped aggregator answer that `answer > 0` misses.
-        if (ethUsdMaxPrice != 0 && (uint256(answer) < ethUsdMinPrice || uint256(answer) > ethUsdMaxPrice)) {
+        // Mandatory circuit-breaker rejects a floored/capped aggregator answer
+        // that the basic `answer > 0` validity check cannot detect.
+        if (uint256(answer) < ethUsdMinPrice || uint256(answer) > ethUsdMaxPrice) {
             revert PriceOutOfBounds();
         }
 
@@ -263,14 +286,15 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         nativeFee = (tokenFee * scale) / uint256(answer);
     }
 
-    /// @dev Reverts unless the Arbitrum L2 sequencer is up and past the grace
-    ///      period. Only invoked when `sequencerUptimeFeed` is configured. The
-    ///      uptime feed is a standard `AggregatorV3Interface`: `answer == 0`
-    ///      means the sequencer is up, `answer == 1` means down; `startedAt` is
-    ///      when the current status round began (i.e. the last restart when it
-    ///      transitions back to up).
+    /// @dev Reverts unless the Arbitrum L2 sequencer round is initialized, its
+    ///      timestamp is sane, and the sequencer is up and past the grace
+    ///      period. The uptime feed is a standard `AggregatorV3Interface`:
+    ///      `answer == 0` means up, `answer == 1` means down; `startedAt` is when
+    ///      the current status round began (the last restart when it returned
+    ///      to up).
     function _requireSequencerUp() internal view {
         (, int256 answer, uint256 startedAt,,) = AggregatorV3Interface(sequencerUptimeFeed).latestRoundData();
+        if (startedAt == 0 || startedAt > block.timestamp) revert InvalidSequencerRound(startedAt);
         if (answer != 0) revert SequencerDown();
         if (block.timestamp - startedAt <= SEQUENCER_GRACE_PERIOD) revert GracePeriodNotOver();
     }
@@ -307,12 +331,12 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         if (stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (multiplier == 0) revert MultiplierZero();
         // Joint invariant: the fee fraction is `stablePercent / multiplier^2`.
-        // When `stablePercent > multiplier^2` the quoted fee exceeds the
-        // bridged amount, so `netAmount = amount - fee` underflows and bricks
-        // every subsequent funds flow on the affected route. Widen to uint256
-        // before squaring — `multiplier` is uint8 and the common `100 * 100`
-        // would itself overflow uint8.
-        if (stablePercent > uint256(multiplier) * uint256(multiplier)) {
+        // The configured fee must be strictly below 100%. Equality would make
+        // TOKEN commission consume the entire amount and create a zero-net
+        // settlement; greater values would underflow. Widen to uint256 before
+        // squaring — `multiplier` is uint8 and the common `100 * 100` would
+        // itself overflow uint8.
+        if (stablePercent >= uint256(multiplier) * uint256(multiplier)) {
             revert InvalidFeeShape(stablePercent, multiplier);
         }
         // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
@@ -350,17 +374,17 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     }
 
     /// @inheritdoc ICommissionManager
-    /// @dev `address(0)` disables the sequencer-uptime gate (non-L2 / test
-    ///      environments). On Arbitrum, federation MUST set the Chainlink
-    ///      Sequencer Uptime feed so NATIVE quotes reject prices during
-    ///      downtime and the post-restart grace period.
+    /// @dev Setting `address(0)` is allowed for staged governance changes or to
+    ///      tear down an unused oracle config, but it makes every non-zero
+    ///      NATIVE quote revert `ChainlinkHardeningNotConfigured`.
     function setSequencerUptimeFeed(address feed) external onlyOwner {
         sequencerUptimeFeed = feed;
         emit SequencerUptimeFeedUpdated(feed);
     }
 
     /// @inheritdoc ICommissionManager
-    /// @dev Pass `(0, 0)` to disable the band; otherwise require
+    /// @dev Pass `(0, 0)` to clear the band during staged governance changes or
+    ///      oracle teardown; NATIVE quotes then fail closed. Otherwise require
     ///      `0 < minPrice < maxPrice` (values in the feed's decimals, e.g.
     ///      `100e8` / `100_000e8` for an 8-decimal ETH/USD feed).
     function setEthUsdPriceBounds(uint256 minPrice, uint256 maxPrice) external onlyOwner {
@@ -394,12 +418,12 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         if (config.stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (config.multiplier == 0) revert MultiplierZero();
         // Joint invariant: the fee fraction is `stablePercent / multiplier^2`.
-        // When `stablePercent > multiplier^2` the quoted fee exceeds the
-        // bridged amount, so `netAmount = amount - fee` underflows and bricks
-        // every subsequent funds flow on the affected route. Widen to uint256
-        // before squaring — `multiplier` is uint8 and the common `100 * 100`
-        // would itself overflow uint8.
-        if (config.stablePercent > uint256(config.multiplier) * uint256(config.multiplier)) {
+        // The configured fee must be strictly below 100%. Equality would make
+        // TOKEN commission consume the entire amount and create a zero-net
+        // settlement; greater values would underflow. Widen to uint256 before
+        // squaring — `multiplier` is uint8 and the common `100 * 100` would
+        // itself overflow uint8.
+        if (config.stablePercent >= uint256(config.multiplier) * uint256(config.multiplier)) {
             revert InvalidFeeShape(config.stablePercent, config.multiplier);
         }
         // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
@@ -462,6 +486,20 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
             currency: globalCurrency,
             isSet: true
         });
+    }
+
+    /// @dev A deliberately disabled fee (`stablePercent == 0`) is valid. Once
+    ///      governance enables a fee, however, every operation governed by that
+    ///      rule must pay at least one smallest unit. This runtime check couples
+    ///      the effective per-route/global rule to the actual transfer amount,
+    ///      so later configuration changes cannot reopen commission-free dust.
+    function _requireNonZeroConfiguredCommission(uint256 amount, uint256 stableFee, CommissionConfig memory config)
+        private
+        pure
+    {
+        if (config.stablePercent != 0 && stableFee == 0) {
+            revert CommissionRoundsToZero(amount, config.stablePercent, config.multiplier);
+        }
     }
 
     /**
@@ -540,72 +578,68 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     // ============ Withdrawal Functions ============
 
     /**
-     * @notice Owner withdraws `amount` of accrued `token` commission to `to`.
+     * @notice Owner withdraws `amount` of accrued `token` commission.
      * @param token ERC-20 token (non-zero).
-     * @param to Recipient (non-zero).
      * @param amount Amount to send (≤ pool).
-     * @dev `nonReentrant`; updates pool before `safeTransfer`.
+     * @dev Always pays immutable `commissionRecipient`. `nonReentrant`; updates
+     *      pool before `safeTransfer`.
      */
-    function withdrawTokenCommission(address token, address to, uint256 amount) external onlyOwner nonReentrant {
+    function withdrawTokenCommission(address token, uint256 amount) external onlyOwner nonReentrant {
         if (token == address(0)) revert InvalidToken();
-        if (to == address(0)) revert InvalidRecipient();
         if (tokenCommissionPool[token] < amount) revert InsufficientBalance();
 
         tokenCommissionPool[token] -= amount;
-        IERC20(token).safeTransfer(to, amount);
+        IERC20(token).safeTransfer(commissionRecipient, amount);
 
-        emit TokenCommissionWithdrawn(token, to, amount);
+        emit TokenCommissionWithdrawn(token, commissionRecipient, amount);
     }
 
     /**
      * @notice Owner withdraws `amount` wei of native commission.
-     * @param to Recipient (non-zero).
      * @param amount Wei to send (≤ pool).
-     * @dev `nonReentrant`; updates pool before native transfer.
+     * @dev Always pays immutable `commissionRecipient`. `nonReentrant`; updates
+     *      pool before native transfer.
      */
-    function withdrawNativeCommission(address payable to, uint256 amount) external onlyOwner nonReentrant {
-        if (to == address(0)) revert InvalidRecipient();
+    function withdrawNativeCommission(uint256 amount) external onlyOwner nonReentrant {
         if (nativeCommissionPool < amount) revert InsufficientBalance();
 
         nativeCommissionPool -= amount;
-        (bool success,) = to.call{value: amount}("");
+        (bool success,) = payable(commissionRecipient).call{value: amount}("");
         if (!success) revert NativeTransferFailed();
 
-        emit NativeCommissionWithdrawn(to, amount);
+        emit NativeCommissionWithdrawn(commissionRecipient, amount);
     }
 
     /**
-     * @notice Owner withdraws the full accrued balance for `token` to `to`.
+     * @notice Owner withdraws the full accrued balance for `token`.
      * @param token ERC-20 token (non-zero).
-     * @param to Recipient (non-zero).
-     * @dev `nonReentrant`. Reverts `NoBalance` if pool is zero.
+     * @dev Always pays immutable `commissionRecipient`. `nonReentrant`.
+     *      Reverts `NoBalance` if pool is zero.
      */
-    function withdrawAllTokenCommission(address token, address to) external onlyOwner nonReentrant {
+    function withdrawAllTokenCommission(address token) external onlyOwner nonReentrant {
         if (token == address(0)) revert InvalidToken();
-        if (to == address(0)) revert InvalidRecipient();
         uint256 balance = tokenCommissionPool[token];
         if (balance == 0) revert NoBalance();
 
         tokenCommissionPool[token] = 0;
-        IERC20(token).safeTransfer(to, balance);
+        IERC20(token).safeTransfer(commissionRecipient, balance);
 
-        emit TokenCommissionWithdrawn(token, to, balance);
+        emit TokenCommissionWithdrawn(token, commissionRecipient, balance);
     }
 
     /**
-     * @notice Owner withdraws the full `nativeCommissionPool` to `to`.
-     * @param to Recipient (non-zero).
-     * @dev `nonReentrant`. Reverts `NoBalance` if pool is zero.
+     * @notice Owner withdraws the full `nativeCommissionPool`.
+     * @dev Always pays immutable `commissionRecipient`. `nonReentrant`.
+     *      Reverts `NoBalance` if pool is zero.
      */
-    function withdrawAllNativeCommission(address payable to) external onlyOwner nonReentrant {
-        if (to == address(0)) revert InvalidRecipient();
+    function withdrawAllNativeCommission() external onlyOwner nonReentrant {
         uint256 balance = nativeCommissionPool;
         if (balance == 0) revert NoBalance();
 
         nativeCommissionPool = 0;
-        (bool success,) = to.call{value: balance}("");
+        (bool success,) = payable(commissionRecipient).call{value: balance}("");
         if (!success) revert NativeTransferFailed();
 
-        emit NativeCommissionWithdrawn(to, balance);
+        emit NativeCommissionWithdrawn(commissionRecipient, balance);
     }
 }

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -5,6 +5,7 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IMultisigProxy} from "./interfaces/IMultisigProxy.sol";
 import {IBridge} from "./interfaces/IBridge.sol";
+import {ICommissionManager} from "./interfaces/ICommissionManager.sol";
 import {IRouteRegistry} from "./interfaces/IRouteRegistry.sol";
 
 /// @notice Minimal view of the LayerZero adapter's outbound entry point. The
@@ -58,8 +59,6 @@ contract MultisigProxy is IMultisigProxy {
 
     address[] private _federationSigners;
     uint256 public federationThreshold;
-
-    address public commissionRecipient;
 
     /// @notice Per-source-chain nonce for the typed TEE methods (`fundsOutCall`
     ///         / `lzFundsOutCall`). Each source chain has its own lane, so the
@@ -123,15 +122,14 @@ contract MultisigProxy is IMultisigProxy {
     uint256 public constant SELECTOR_LENGTH = 4;
 
     /// @notice CommissionManager withdrawal selectors that the generic
-    ///         `AdminExecuteCommissionManager` path is NOT allowed to call —
-    ///         they take a free recipient and would bypass the pinned
-    ///         `commissionRecipient`. Withdrawals must go through the
-    ///         dedicated WithdrawTokenCommissionCM / WithdrawNativeCommissionCM
-    ///         ops, which force the recipient to `commissionRecipient`.
-    bytes4 private constant _SEL_WITHDRAW_TOKEN = bytes4(keccak256("withdrawTokenCommission(address,address,uint256)"));
-    bytes4 private constant _SEL_WITHDRAW_NATIVE = bytes4(keccak256("withdrawNativeCommission(address,uint256)"));
-    bytes4 private constant _SEL_WITHDRAW_ALL_TOKEN = bytes4(keccak256("withdrawAllTokenCommission(address,address)"));
-    bytes4 private constant _SEL_WITHDRAW_ALL_NATIVE = bytes4(keccak256("withdrawAllNativeCommission(address)"));
+    ///         `AdminExecuteCommissionManager` path is NOT allowed to call.
+    ///         The asset layer always pays CM's immutable recipient, while this
+    ///         procedural guard keeps standard withdrawals on the dedicated,
+    ///         typed governance operations.
+    bytes4 private constant _SEL_WITHDRAW_TOKEN = ICommissionManager.withdrawTokenCommission.selector;
+    bytes4 private constant _SEL_WITHDRAW_NATIVE = ICommissionManager.withdrawNativeCommission.selector;
+    bytes4 private constant _SEL_WITHDRAW_ALL_TOKEN = ICommissionManager.withdrawAllTokenCommission.selector;
+    bytes4 private constant _SEL_WITHDRAW_ALL_NATIVE = ICommissionManager.withdrawAllNativeCommission.selector;
 
     uint256 private immutable _cachedChainId;
     bytes32 private immutable _cachedDomainSeparator;
@@ -161,8 +159,6 @@ contract MultisigProxy is IMultisigProxy {
     );
     bytes32 private constant _PROPOSE_UPDATE_BRIDGE_TYPEHASH =
         keccak256("ProposeUpdateBridge(address newBridge,uint256 nonce,uint256 deadline)");
-    bytes32 private constant _PROPOSE_SET_COMMISSION_RECIPIENT_TYPEHASH =
-        keccak256("ProposeSetCommissionRecipient(address newRecipient,uint256 nonce,uint256 deadline)");
     bytes32 private constant _PROPOSE_SET_TIMELOCK_DURATION_TYPEHASH =
         keccak256("ProposeSetTimelockDuration(uint256 newDuration,uint256 nonce,uint256 deadline)");
 
@@ -221,7 +217,6 @@ contract MultisigProxy is IMultisigProxy {
         uint256 initialEnclaveSourceChain_,
         address[] memory federationSigners_,
         uint256 federationThreshold_,
-        address commissionRecipient_,
         uint256 timelockDuration_,
         uint256 minTimelock_
     ) {
@@ -232,7 +227,6 @@ contract MultisigProxy is IMultisigProxy {
         _requireValidThreshold(enclaveThreshold_, enclaveSigners_.length);
         if (federationSigners_.length == 0) revert NoSigners();
         _requireValidThreshold(federationThreshold_, federationSigners_.length);
-        if (commissionRecipient_ == address(0)) revert ZeroCommissionRecipient();
         if (minTimelock_ == 0 || minTimelock_ >= MAX_PROPOSAL_LIFETIME) revert InvalidMinTimelock();
         if (timelockDuration_ < minTimelock_) revert TimelockTooShort();
         if (timelockDuration_ >= MAX_PROPOSAL_LIFETIME) revert TimelockTooLong();
@@ -250,7 +244,6 @@ contract MultisigProxy is IMultisigProxy {
         _enclaveSourceChains.push(initialEnclaveSourceChain_);
         _federationSigners = federationSigners_;
         federationThreshold = federationThreshold_;
-        commissionRecipient = commissionRecipient_;
         timelockDuration = timelockDuration_;
         MIN_TIMELOCK = minTimelock_;
 
@@ -640,29 +633,6 @@ contract MultisigProxy is IMultisigProxy {
     }
 
     /// @inheritdoc IMultisigProxy
-    function proposeSetCommissionRecipient(
-        address newRecipient,
-        uint256 nonce,
-        uint256 deadline,
-        uint256 fedBitmap,
-        bytes[] calldata fedSigs
-    ) external returns (bytes32) {
-        bytes32 structHash = keccak256(
-            abi.encode(_PROPOSE_SET_COMMISSION_RECIPIENT_TYPEHASH, newRecipient, nonce, deadline)
-        );
-
-        return _propose(
-            OperationType.SetCommissionRecipient,
-            abi.encode(newRecipient),
-            nonce,
-            deadline,
-            structHash,
-            fedBitmap,
-            fedSigs
-        );
-    }
-
-    /// @inheritdoc IMultisigProxy
     function proposeSetTimelockDuration(
         uint256 newDuration,
         uint256 nonce,
@@ -696,8 +666,8 @@ contract MultisigProxy is IMultisigProxy {
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
 
-        // Commission withdrawals must use the pinned-recipient ops; reject them
-        // on the generic path up front (fail-fast, no wasted proposal slot).
+        // Standard withdrawals use the dedicated typed operations; reject them
+        // on this generic path up front (recipient safety remains in CM).
         _requireNotCommissionWithdrawSelector(selector);
 
         bytes32 structHash =
@@ -990,6 +960,11 @@ contract MultisigProxy is IMultisigProxy {
     // =========================================================================
 
     /// @inheritdoc IMultisigProxy
+    function commissionRecipient() public view returns (address) {
+        return ICommissionManager(payable(commissionManager)).commissionRecipient();
+    }
+
+    /// @inheritdoc IMultisigProxy
     function verifyEnclaveSignature(
         uint256 sourceChainId,
         bytes32 digest,
@@ -1113,12 +1088,6 @@ contract MultisigProxy is IMultisigProxy {
             address oldBridge = bridge;
             bridge = newBridge;
             emit BridgeAddressUpdated(oldBridge, newBridge);
-        } else if (opType == OperationType.SetCommissionRecipient) {
-            address newRecipient = abi.decode(opData, (address));
-            if (newRecipient == address(0)) revert ZeroRecipient();
-            address old = commissionRecipient;
-            commissionRecipient = newRecipient;
-            emit CommissionRecipientUpdated(old, newRecipient);
         } else if (opType == OperationType.SetTimelockDuration) {
             uint256 newDuration = abi.decode(opData, (uint256));
             if (newDuration < MIN_TIMELOCK) revert TimelockTooShort();
@@ -1127,9 +1096,8 @@ contract MultisigProxy is IMultisigProxy {
             emit TimelockDurationUpdated(newDuration);
         } else if (opType == OperationType.AdminExecuteCommissionManager) {
             // opData = raw CommissionManager callData. Enforce (again, at the
-            // execution boundary) that this generic path cannot call a
-            // withdrawal selector and re-point commission away from the pinned
-            // `commissionRecipient`.
+            // execution boundary) that standard withdrawals use their typed
+            // governance operations.
             _requireNotCommissionWithdrawSelector(_firstSelector(opData));
             (bool ok, bytes memory ret) = commissionManager.call(opData);
             _propagateRevert(ok, ret);
@@ -1144,18 +1112,16 @@ contract MultisigProxy is IMultisigProxy {
             _propagateRevert(ok, ret);
         } else if (opType == OperationType.WithdrawTokenCommissionCM) {
             (address token, uint256 amount) = abi.decode(opData, (address, uint256));
-            address recipient = commissionRecipient;
-            (bool ok, bytes memory ret) = commissionManager.call(
-                abi.encodeWithSignature("withdrawTokenCommission(address,address,uint256)", token, recipient, amount)
-            );
+            address recipient = commissionRecipient();
+            (bool ok, bytes memory ret) =
+                commissionManager.call(abi.encodeCall(ICommissionManager.withdrawTokenCommission, (token, amount)));
             _propagateRevert(ok, ret);
             emit CommissionWithdrawn(token, amount, recipient);
         } else if (opType == OperationType.WithdrawNativeCommissionCM) {
             uint256 amount = abi.decode(opData, (uint256));
-            address recipient = commissionRecipient;
-            (bool ok, bytes memory ret) = commissionManager.call(
-                abi.encodeWithSignature("withdrawNativeCommission(address,uint256)", recipient, amount)
-            );
+            address recipient = commissionRecipient();
+            (bool ok, bytes memory ret) =
+                commissionManager.call(abi.encodeCall(ICommissionManager.withdrawNativeCommission, (amount)));
             _propagateRevert(ok, ret);
             emit NativeCommissionWithdrawn(amount, recipient);
         } else if (opType == OperationType.UpdateCommissionManager) {
@@ -1360,9 +1326,9 @@ contract MultisigProxy is IMultisigProxy {
         }
     }
 
-    /// @dev Reverts if `selector` is one of the CommissionManager withdrawal
-    ///      selectors, which the generic AdminExecuteCommissionManager path must
-    ///      not reach (they bypass the pinned `commissionRecipient`).
+    /// @dev Reverts for CommissionManager withdrawal selectors so the generic
+    ///      path cannot bypass the dedicated typed governance operations.
+    ///      Recipient safety itself is enforced inside CommissionManager.
     function _requireNotCommissionWithdrawSelector(bytes4 selector) private pure {
         if (
             selector == _SEL_WITHDRAW_TOKEN || selector == _SEL_WITHDRAW_NATIVE || selector == _SEL_WITHDRAW_ALL_TOKEN

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -25,6 +25,8 @@ interface IBridge {
     error InvalidBurnId(uint256 provided, uint256 expected);
     error BurnIdAlreadyConsumed(uint256 burnId);
     error NativeValueMismatch();
+    error NativeCommissionOutOfBounds(uint256 provided, uint256 minimum, uint256 maximum);
+    error NativeRefundFailed(address recipient, uint256 amount);
     error RebalanceSameChain(uint256 chainId);
     error ChainSafetyLimitExceeded(uint256 chainId, uint256 requested, uint256 spentInWindow, uint256 windowLimit);
     error GlobalSafetyLimitExceeded(uint256 requested, uint256 spentInWindow, uint256 windowLimit);
@@ -181,11 +183,15 @@ interface IBridge {
     /// @notice Direct deposit overload for EVM users on this chain. The
     ///         `sourceChainId` half of the commission route key is filled with
     ///         `block.chainid` — non-spoofable by the caller.
-    /// @dev Payable: if the active route uses NATIVE commission currency, `msg.value`
-    ///      must be at least the quoted native commission — any surplus (from
-    ///      favorable ETH/USD drift between quote and execution) is collected as
-    ///      commission, not refunded (R-I-03). If the route takes no native
-    ///      commission (TOKEN currency), `msg.value` must be 0.
+    /// @dev Payable: if the active route uses NATIVE commission currency,
+    ///      `msg.value` must be at least the freshly quoted native commission
+    ///      and at most `NATIVE_COMMISSION_TOLERANCE_BPS` above it. Attach the
+    ///      quote plus a small buffer so ETH/USD drift between quoting and
+    ///      execution cannot revert the deposit: exactly the fresh quote is
+    ///      charged and the surplus is refunded to the caller before the call
+    ///      returns. A caller that cannot receive native value must therefore
+    ///      send the exact quote. If the route takes no native commission
+    ///      (TOKEN currency), `msg.value` must be 0.
     /// @dev `settlementData` is an opaque per-route blob forwarded into the
     ///      route's `ISettlementModule.onFundsIn`. Routes whose module does not
     ///      consume any extra data (e.g. RGB) accept an empty bytes string.
@@ -208,6 +214,12 @@ interface IBridge {
     ///      overload is effectively closed. `sourceSender` is authenticated by
     ///      the source-chain entrypoint and adapter, not by an arbitrary
     ///      caller — it is bound into the derived `operationId`.
+    /// @dev Native commission here is the source-agreed value the adapter
+    ///      forwards, and its payer lives on the source chain. Because no refund
+    ///      can reach them, `msg.value` is accepted anywhere within
+    ///      `NATIVE_COMMISSION_TOLERANCE_BPS` either side of the fresh quote and
+    ///      is collected in full — unlike the direct overload, which charges the
+    ///      quote exactly and refunds the difference.
     /// @return operationId The canonical bridge-side operation id.
     function fundsIn(
         uint256 amount,

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -26,6 +26,8 @@ interface IBridge {
     error BurnIdAlreadyConsumed(uint256 burnId);
     error NativeValueMismatch();
     error RebalanceSameChain(uint256 chainId);
+    error ChainSafetyLimitExceeded(uint256 chainId, uint256 requested, uint256 spentInWindow, uint256 windowLimit);
+    error GlobalSafetyLimitExceeded(uint256 requested, uint256 spentInWindow, uint256 windowLimit);
 
     // =========================================================================
     // Events
@@ -65,6 +67,16 @@ interface IBridge {
     /// @param refillRate New refill rate (token units per second).
     /// @param available  Accrued allowance carried over after the update.
     event GlobalOutflowLimitUpdated(uint256 capacity, uint256 refillRate, uint256 available);
+
+    /// @notice Emitted after an outflow consumes immutable per-chain rolling
+    ///         safety allowance.
+    event ChainSafetyOutflowConsumed(
+        uint256 indexed chainId, uint256 amount, uint256 spentInWindow, uint256 windowLimit
+    );
+
+    /// @notice Emitted after a physical token outflow consumes immutable global
+    ///         rolling safety allowance.
+    event GlobalSafetyOutflowConsumed(uint256 amount, uint256 spentInWindow, uint256 windowLimit);
 
     /// @notice RGB-route deposit event. Emitted only when the route's settlement
     ///         module returns a non-zero external correlation id — in practice
@@ -341,6 +353,14 @@ interface IBridge {
     /// @notice Spendable global outflow allowance right now, including the
     ///         accrued refill. Returns 0 if the global bucket is unconfigured.
     function availableGlobalOutflow() external view returns (uint256);
+
+    /// @notice Remaining immutable per-chain safety allowance in the current
+    ///         rolling window. Independent of the configurable token bucket.
+    function availableChainSafetyOutflow(uint256 chainId) external view returns (uint256);
+
+    /// @notice Remaining immutable global safety allowance in the current
+    ///         rolling window. Independent of the configurable token bucket.
+    function availableGlobalSafetyOutflow() external view returns (uint256);
 
     /// @notice Current trusted adapter; `address(0)` means the adapter
     ///         overload is closed.

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -28,6 +28,8 @@ interface IBridge {
     error RebalanceSameChain(uint256 chainId);
     error ChainSafetyLimitExceeded(uint256 chainId, uint256 requested, uint256 spentInWindow, uint256 windowLimit);
     error GlobalSafetyLimitExceeded(uint256 requested, uint256 spentInWindow, uint256 windowLimit);
+    error InvalidOutflowPolicy(uint256 burstBps, uint256 refillBpsPerWindow, uint256 maxBps);
+    error ZeroOutflowReference();
 
     // =========================================================================
     // Events
@@ -56,17 +58,19 @@ interface IBridge {
     event MinFundsInAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
 
     /// @notice Emitted on `setOutflowLimit` (per-chain outflow token bucket).
-    /// @param chainId    Source chain the limit applies to.
-    /// @param capacity   New bucket capacity (max instant outflow).
-    /// @param refillRate New refill rate (token units per second).
-    /// @param available  Accrued allowance carried over after the update.
-    event OutflowLimitUpdated(uint256 indexed chainId, uint256 capacity, uint256 refillRate, uint256 available);
+    /// @param chainId             Source chain the limit applies to.
+    /// @param burstBps            Max instant outflow, in bps of reference liquidity.
+    /// @param refillBpsPerWindow  Allowance restored per refill window, in bps.
+    /// @param availableShares     Accrued allowance carried over, in shares.
+    event OutflowLimitUpdated(
+        uint256 indexed chainId, uint256 burstBps, uint256 refillBpsPerWindow, uint256 availableShares
+    );
 
     /// @notice Emitted on `setGlobalOutflowLimit` (aggregate outflow token bucket).
-    /// @param capacity   New bucket capacity (max instant aggregate outflow).
-    /// @param refillRate New refill rate (token units per second).
-    /// @param available  Accrued allowance carried over after the update.
-    event GlobalOutflowLimitUpdated(uint256 capacity, uint256 refillRate, uint256 available);
+    /// @param burstBps            Max instant aggregate outflow, in bps of reference TVL.
+    /// @param refillBpsPerWindow  Allowance restored per refill window, in bps.
+    /// @param availableShares     Accrued allowance carried over, in shares.
+    event GlobalOutflowLimitUpdated(uint256 burstBps, uint256 refillBpsPerWindow, uint256 availableShares);
 
     /// @notice Emitted after an outflow consumes immutable per-chain rolling
     ///         safety allowance.
@@ -331,27 +335,46 @@ interface IBridge {
     function minFundsInAmount() external view returns (uint256);
 
     /// @notice Configure (or reconfigure) the per-chain outflow token bucket for
-    ///         `chainId`. Owner-only (MultisigProxy timelock flow). Reverts
-    ///         `InvalidOutflowLimit` on zero `chainId` or zero `capacity`. A
-    ///         reconfiguration accrues the pending refill under the old settings
-    ///         and preserves the accrued `available` (clamped to the new
-    ///         capacity) — it never gifts a fresh full burst.
-    function setOutflowLimit(uint256 chainId, uint256 capacity, uint256 refillRate) external;
+    ///         `chainId`. Owner-only (MultisigProxy timelock flow).
+    ///
+    ///         Both parameters are basis points of the chain's reference
+    ///         liquidity, not absolute token units: `burstBps` is the maximum
+    ///         instant outflow and `refillBpsPerWindow` the allowance restored
+    ///         over one `BUCKET_REFILL_WINDOW`. The bucket therefore tracks
+    ///         liquidity automatically — the same policy means 5k at 100k TVL
+    ///         and 50k at 1M TVL, with no governance retuning.
+    ///
+    ///         Validation is liquidity-independent — both values must be
+    ///         non-zero and their sum must not exceed
+    ///         `MAX_CHAIN_OUTFLOW_BPS` — so a policy can be installed at
+    ///         deployment before any deposit exists. This combined bound makes
+    ///         a full-TVL bucket and an over-permissive burst/refill pair
+    ///         unrepresentable at every liquidity level.
+    ///         Reverts `InvalidOutflowLimit` on zero `chainId` and
+    ///         `InvalidOutflowPolicy` on an out-of-range policy.
+    ///
+    ///         A reconfiguration accrues the pending refill under the old policy
+    ///         and preserves the accrued allowance (clamped to the new burst) —
+    ///         it never gifts a fresh full burst.
+    function setOutflowLimit(uint256 chainId, uint256 burstBps, uint256 refillBpsPerWindow) external;
 
     /// @notice Configure (or reconfigure) the global (aggregate) outflow token
     ///         bucket that bounds total `fundsOut` across all source chains.
-    ///         Owner-only. Same accrue-and-preserve semantics as
-    ///         `setOutflowLimit`.
-    function setGlobalOutflowLimit(uint256 capacity, uint256 refillRate) external;
+    ///         Owner-only. Same bps semantics, combined burst-plus-refill bound
+    ///         (against `MAX_GLOBAL_OUTFLOW_BPS`) and accrue-and-preserve
+    ///         behaviour as `setOutflowLimit`.
+    function setGlobalOutflowLimit(uint256 burstBps, uint256 refillBpsPerWindow) external;
 
-    /// @notice Spendable per-chain outflow allowance right now, including the
-    ///         refill accrued since the last update (which the stored
-    ///         `chainBuckets` getter does not materialize). Returns 0 for an
+    /// @notice Spendable per-chain bucket allowance right now in token units,
+    ///         including the refill accrued since the last update (which the
+    ///         stored `chainBuckets` getter does not materialize, and which it
+    ///         reports in shares rather than tokens). Returns 0 for an
     ///         unconfigured chain.
     function availableOutflow(uint256 chainId) external view returns (uint256);
 
-    /// @notice Spendable global outflow allowance right now, including the
-    ///         accrued refill. Returns 0 if the global bucket is unconfigured.
+    /// @notice Spendable global bucket allowance right now in token units,
+    ///         including the accrued refill. Returns 0 if the global bucket is
+    ///         unconfigured.
     function availableGlobalOutflow() external view returns (uint256);
 
     /// @notice Remaining immutable per-chain safety allowance in the current
@@ -361,6 +384,25 @@ interface IBridge {
     /// @notice Remaining immutable global safety allowance in the current
     ///         rolling window. Independent of the configurable token bucket.
     function availableGlobalSafetyOutflow() external view returns (uint256);
+
+    /// @notice Reference liquidity every percentage in this contract is measured
+    ///         against for `chainId`: accounted liquidity plus usage still
+    ///         counted in the rolling window. Constant while releases drain
+    ///         liquidity inside one window — each release moves the same amount
+    ///         from one term to the other — and it steps down to plain
+    ///         `lockedLiquidity` once that usage expires. Both the configurable
+    ///         bucket and the immutable safety limit are denominated against it.
+    function chainOutflowReference(uint256 chainId) external view returns (uint256);
+
+    /// @notice Aggregate counterpart of `chainOutflowReference`.
+    function globalOutflowReference() external view returns (uint256);
+
+    /// @notice The amount `fundsOut` would actually permit for `chainId` right
+    ///         now, in token units: the minimum of isolated chain liquidity,
+    ///         both token buckets and both immutable safety allowances. Use this
+    ///         rather than the single-layer views when asking "how much can
+    ///         leave" — no individual layer answers that question.
+    function effectiveAvailableOutflow(uint256 chainId) external view returns (uint256);
 
     /// @notice Current trusted adapter; `address(0)` means the adapter
     ///         overload is closed.

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -47,6 +47,8 @@ interface ICommissionManager {
     error StablePercentTooHigh();
     error MultiplierZero();
     error InvalidFeeShape(uint256 stablePercent, uint8 multiplier);
+    error CommissionRoundsToZero(uint256 amount, uint256 stablePercent, uint8 multiplier);
+    error ZeroNetAmount(uint256 amount, uint256 commission);
     error NativeCommissionNotAllowedOnFundsOut();
     error TokenDecimalsUnavailable();
     error BalanceBelowRecordedPool();
@@ -67,6 +69,8 @@ interface ICommissionManager {
     error GracePeriodNotOver();
     error PriceOutOfBounds();
     error InvalidPriceBounds();
+    error ChainlinkHardeningNotConfigured();
+    error InvalidSequencerRound(uint256 startedAt);
 
     // ============ Events ============
 
@@ -87,10 +91,10 @@ interface ICommissionManager {
 
     event EthUsdFeedUpdated(address indexed feed, uint256 heartbeat);
 
-    /// @notice Emitted on `setSequencerUptimeFeed` (`address(0)` disables the check).
+    /// @notice Emitted on `setSequencerUptimeFeed`; zero makes NATIVE quotes fail closed.
     event SequencerUptimeFeedUpdated(address indexed feed);
 
-    /// @notice Emitted on `setEthUsdPriceBounds` (both zero disables the band).
+    /// @notice Emitted on `setEthUsdPriceBounds`; both zero make NATIVE quotes fail closed.
     event EthUsdPriceBoundsUpdated(uint256 minPrice, uint256 maxPrice);
 
     event TokenCommissionWithdrawn(address indexed token, address indexed to, uint256 amount);
@@ -99,6 +103,8 @@ interface ICommissionManager {
     // ============ State getters ============
 
     function bridgeAddress() external view returns (address);
+
+    function commissionRecipient() external view returns (address);
 
     function globalStablePercent() external view returns (uint256);
 
@@ -143,9 +149,11 @@ interface ICommissionManager {
 
     /// @notice Convert a USD-denominated token fee (stablecoin, 1 token ≈ $1) to
     ///         native wei using the configured ETH/USD Chainlink feed. Reverts
-    ///         `EthUsdFeedNotSet` when the feed is unconfigured, `InvalidPrice`
-    ///         on non-positive answers, and `StalePrice` when `updatedAt` is
-    ///         older than the configured heartbeat.
+    ///         `EthUsdFeedNotSet` when the price feed is unconfigured,
+    ///         `ChainlinkHardeningNotConfigured` unless the sequencer feed and
+    ///         price band are both configured, `InvalidPrice` on non-positive
+    ///         answers, and `StalePrice` when `updatedAt` is older than the
+    ///         configured heartbeat.
     function convertTokenFeeToNative(uint256 tokenFee, uint256 tokenDecimals) external view returns (uint256 nativeFee);
 
     // ============ Admin / config ============
@@ -166,12 +174,13 @@ interface ICommissionManager {
     function setEthUsdFeed(address feed, uint256 heartbeat) external;
 
     /// @notice Configure (or rotate) the Chainlink L2 Sequencer Uptime feed used
-    ///         to gate NATIVE quotes on Arbitrum. Pass `address(0)` to disable
-    ///         the check (non-L2 / test environments).
+    ///         to gate NATIVE quotes on Arbitrum. Passing `address(0)` clears
+    ///         the configuration and makes non-zero NATIVE quotes fail closed.
     function setSequencerUptimeFeed(address feed) external;
 
-    /// @notice Configure the optional [min, max] sanity band on the ETH/USD
-    ///         answer (feed decimals). Pass `(0, 0)` to disable; otherwise
+    /// @notice Configure the mandatory [min, max] sanity band on the ETH/USD
+    ///         answer (feed decimals). Passing `(0, 0)` clears the configuration
+    ///         and makes non-zero NATIVE quotes fail closed; otherwise
     ///         `0 < minPrice < maxPrice`.
     function setEthUsdPriceBounds(uint256 minPrice, uint256 maxPrice) external;
 
@@ -213,11 +222,19 @@ interface ICommissionManager {
 
     // ============ Withdrawals (owner) ============
 
-    function withdrawTokenCommission(address token, address to, uint256 amount) external;
+    /// @notice Withdraw accrued token commission to the immutable
+    ///         `commissionRecipient`.
+    function withdrawTokenCommission(address token, uint256 amount) external;
 
-    function withdrawNativeCommission(address payable to, uint256 amount) external;
+    /// @notice Withdraw accrued native commission to the immutable
+    ///         `commissionRecipient`.
+    function withdrawNativeCommission(uint256 amount) external;
 
-    function withdrawAllTokenCommission(address token, address to) external;
+    /// @notice Withdraw all accrued commission for `token` to the immutable
+    ///         `commissionRecipient`.
+    function withdrawAllTokenCommission(address token) external;
 
-    function withdrawAllNativeCommission(address payable to) external;
+    /// @notice Withdraw all accrued native commission to the immutable
+    ///         `commissionRecipient`.
+    function withdrawAllNativeCommission() external;
 }

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -25,9 +25,10 @@ import {IBridge} from "./IBridge.sol";
 ///      COMMISSION MANAGER
 ///      This proxy is the owner of the CommissionManager. Federation can reach CM via:
 ///        - typed `WithdrawTokenCommissionCM` / `WithdrawNativeCommissionCM`
-///          (destination is always the stored `commissionRecipient`).
+///          (CM always pays its immutable `commissionRecipient`).
 ///        - generic `AdminExecuteCommissionManager` for rare config changes
-///          (route rules, global defaults, mock rates, transferOwnership, …).
+///          (route rules, global defaults, mock rates, ownership migration, …).
+///          Withdrawal selectors are reserved for the typed operations.
 ///        - `UpdateCommissionManager` to migrate to a redeployed CM.
 ///
 ///      BITMAP ENCODING
@@ -44,7 +45,6 @@ interface IMultisigProxy {
     error ZeroCommissionManager();
     error NoSigners();
     error InvalidThreshold();
-    error ZeroCommissionRecipient();
     error TimelockTooLong();
     error TimelockTooShort();
     error InvalidMinTimelock();
@@ -71,7 +71,6 @@ interface IMultisigProxy {
     error TooManyEnclaveSourceChains(uint256 count, uint256 max);
     error CallFailed();
     error UnknownOperationType();
-    error ZeroRecipient();
     error ZeroTarget();
     error ForbiddenCommissionManagerSelector(bytes4 selector);
     error LZAdapterNotSet();
@@ -86,20 +85,19 @@ interface IMultisigProxy {
         UpdateEnclaveSigners, // 1  — replace the enclave signer set + threshold
         UpdateFederationSigners, // 2  — replace the federation signer set + threshold
         UpdateBridge, // 3  — repoint the owned Bridge address
-        SetCommissionRecipient, // 4  — set the pinned commission payout recipient
-        SetTimelockDuration, // 5  — change the governance timelock (>= MIN_TIMELOCK)
-        AdminExecuteCommissionManager, // 6  — generic call into CommissionManager
-        WithdrawTokenCommissionCM, // 7  — CM.withdrawTokenCommission -> commissionRecipient
-        WithdrawNativeCommissionCM, // 8  — CM.withdrawNativeCommission -> commissionRecipient
-        UpdateCommissionManager, // 9  — migrate to a new CommissionManager address
-        AdminExecuteAdapter, // 10 — generic call into LZAdapter (setTrustedEntrypoint, refundStuckFunds, …)
-        UpdateLZAdapter, // 11 — rotate the routing target for AdminExecuteAdapter
-        SetRoute, // 12 — RouteRegistry.setRoute(src, dst, enabled, verifier, module)
-        UpdateRouteRegistry, // 13 — Bridge.setRouteRegistry(newRouteRegistry)
-        PauseInflow, // 14 — Bridge.pauseInflow()  (planned inflow-only freeze, timelocked)
-        UnpauseInflow, // 15 — Bridge.unpauseInflow()
-        DisableLZAdapter, // 16 — clear the routing target (explicit disable, distinct from UpdateLZAdapter rotation)
-        AdminExecuteRouteRegistry // 17 — generic call into RouteRegistry (transferOwnership/acceptOwnership, setRoute, …)
+        SetTimelockDuration, // 4  — change the governance timelock (>= MIN_TIMELOCK)
+        AdminExecuteCommissionManager, // 5  — generic call into CommissionManager
+        WithdrawTokenCommissionCM, // 6  — CM.withdrawTokenCommission -> immutable recipient
+        WithdrawNativeCommissionCM, // 7  — CM.withdrawNativeCommission -> immutable recipient
+        UpdateCommissionManager, // 8  — migrate to a new CommissionManager address
+        AdminExecuteAdapter, // 9 — generic call into LZAdapter (setTrustedEntrypoint, refundStuckFunds, …)
+        UpdateLZAdapter, // 10 — rotate the routing target for AdminExecuteAdapter
+        SetRoute, // 11 — RouteRegistry.setRoute(src, dst, enabled, verifier, module)
+        UpdateRouteRegistry, // 12 — Bridge.setRouteRegistry(newRouteRegistry)
+        PauseInflow, // 13 — Bridge.pauseInflow()  (planned inflow-only freeze, timelocked)
+        UnpauseInflow, // 14 — Bridge.unpauseInflow()
+        DisableLZAdapter, // 15 — clear the routing target (explicit disable, distinct from UpdateLZAdapter rotation)
+        AdminExecuteRouteRegistry // 16 — generic call into RouteRegistry (transferOwnership/acceptOwnership, setRoute, …)
     }
 
     enum ProposalStatus {
@@ -176,7 +174,6 @@ interface IMultisigProxy {
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event LZAdapterDisabled(address indexed oldAdapter);
-    event CommissionRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
     event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
     event NativeCommissionWithdrawn(uint256 amount, address indexed recipient);
     event TimelockDurationUpdated(uint256 newDuration);
@@ -283,17 +280,6 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose changing the commission recipient (used as the destination for
-    ///         all typed `WithdrawTokenCommissionCM` / `WithdrawNativeCommissionCM` ops).
-    /// @dev opData = abi.encode(address newRecipient)
-    function proposeSetCommissionRecipient(
-        address newRecipient,
-        uint256 nonce,
-        uint256 deadline,
-        uint256 fedBitmap,
-        bytes[] calldata fedSigs
-    ) external returns (bytes32);
-
     /// @notice Propose changing the timelock duration.
     /// @dev opData = abi.encode(uint256 newDuration)
     function proposeSetTimelockDuration(
@@ -306,9 +292,10 @@ interface IMultisigProxy {
 
     // --- CommissionManager-targeted operations ---
 
-    /// @notice Propose an arbitrary call into the CommissionManager.
+    /// @notice Propose a permitted generic call into the CommissionManager.
     /// @dev Used for rare configuration: setCommissionRule, setGlobalDefaults,
     ///      setMockTokenToNativeRate, setBridgeAddress, transferOwnership, …
+    ///      Withdrawal selectors are reserved for the typed operations.
     /// @dev opData = raw ABI-encoded CommissionManager callData (selector + args).
     function proposeAdminExecuteCommissionManager(
         bytes calldata callData,
@@ -333,8 +320,8 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose an ERC-20 commission withdrawal from the CommissionManager
-    ///         to the stored `commissionRecipient`.
+    /// @notice Propose an ERC-20 commission withdrawal from the CommissionManager.
+    ///         The CM pays its immutable `commissionRecipient`.
     /// @dev opData = abi.encode(address token, uint256 amount)
     function proposeWithdrawTokenCommissionCM(
         address token,
@@ -345,8 +332,8 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose a native commission withdrawal from the CommissionManager
-    ///         to the stored `commissionRecipient`.
+    /// @notice Propose a native commission withdrawal from the CommissionManager.
+    ///         The CM pays its immutable `commissionRecipient`.
     /// @dev opData = abi.encode(uint256 amount)
     function proposeWithdrawNativeCommissionCM(
         uint256 amount,
@@ -490,6 +477,7 @@ interface IMultisigProxy {
     function enclaveThreshold(uint256 sourceChainId) external view returns (uint256);
     function getFederationSigners() external view returns (address[] memory);
     function federationThreshold() external view returns (uint256);
+    /// @notice Immutable recipient reported by the current CommissionManager.
     function commissionRecipient() external view returns (address);
     function DOMAIN_SEPARATOR() external view returns (bytes32);
     function proposalNonce() external view returns (uint256);

--- a/ethereum/src/libraries/OutflowRateLimiter.sol
+++ b/ethereum/src/libraries/OutflowRateLimiter.sol
@@ -2,9 +2,11 @@
 pragma solidity 0.8.35;
 
 /// @title OutflowRateLimiter
-/// @notice Small token-bucket helper used by Bridge withdrawals.
-/// @dev Amounts are stored as uint128 to keep bucket state compact; Bridge
-///      rejects larger admin inputs before constructing a limit config.
+/// @notice Small unit-agnostic token-bucket helper used by Bridge withdrawals.
+/// @dev Amounts are stored as uint128 to keep bucket state compact. Bridge uses
+///      normalized liquidity shares as the unit, so this library's raw state,
+///      events, and revert arguments are share-denominated in that integration.
+///      Bridge validates policy inputs before constructing a limit config.
 library OutflowRateLimiter {
     error LimitNotConfigured();
     error StoredAllowanceAboveCapacity(uint256 available, uint256 capacity);

--- a/ethereum/src/libraries/RollingOutflowLimiter.sol
+++ b/ethereum/src/libraries/RollingOutflowLimiter.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+/// @title RollingOutflowLimiter
+/// @notice Bounded-storage accounting for aggregate outflow over a rolling
+///         time window.
+/// @dev Usage is grouped into one-hour slots. Twenty-five slots are retained:
+///      an amount recorded at any point in hour H is removed no earlier than
+///      the beginning of hour H+25, so it remains counted for at least 24
+///      complete hours. This deliberately errs on the conservative side by up
+///      to one hour and avoids the boundary double-spend of fixed daily epochs.
+library RollingOutflowLimiter {
+    uint256 internal constant SLOT_DURATION = 1 hours;
+    uint256 internal constant SLOT_COUNT = 25;
+
+    struct Window {
+        uint256 spent;
+        uint256 lastEpoch;
+        bool initialized;
+        uint256[SLOT_COUNT] slots;
+    }
+
+    /// @notice Record `amount` in the current rolling window.
+    /// @return updatedSpent Total non-expired usage after recording `amount`.
+    function consume(Window storage window, uint256 amount) internal returns (uint256 updatedSpent) {
+        _roll(window);
+
+        uint256 index = _currentEpoch() % SLOT_COUNT;
+        window.slots[index] += amount;
+        updatedSpent = window.spent + amount;
+        window.spent = updatedSpent;
+    }
+
+    /// @notice Return the currently counted usage without modifying storage.
+    function current(Window storage window) internal view returns (uint256 currentSpent) {
+        if (!window.initialized) return 0;
+
+        uint256 epoch = _currentEpoch();
+        uint256 lastEpoch = window.lastEpoch;
+        currentSpent = window.spent;
+
+        // Timestamps cannot move backwards on-chain. If a test environment does,
+        // retain all usage rather than accidentally weakening the limit.
+        if (epoch <= lastEpoch) return currentSpent;
+
+        uint256 elapsed = epoch - lastEpoch;
+        if (elapsed >= SLOT_COUNT) return 0;
+
+        for (uint256 i = 1; i <= elapsed; i++) {
+            currentSpent -= window.slots[(lastEpoch + i) % SLOT_COUNT];
+        }
+    }
+
+    /// @dev Expire slots that are at least 25 epochs old and advance the ring.
+    function _roll(Window storage window) private {
+        uint256 epoch = _currentEpoch();
+
+        if (!window.initialized) {
+            window.initialized = true;
+            window.lastEpoch = epoch;
+            return;
+        }
+
+        uint256 lastEpoch = window.lastEpoch;
+        if (epoch <= lastEpoch) return;
+
+        uint256 elapsed = epoch - lastEpoch;
+        if (elapsed >= SLOT_COUNT) {
+            for (uint256 i = 0; i < SLOT_COUNT; i++) {
+                delete window.slots[i];
+            }
+            window.spent = 0;
+        } else {
+            uint256 spent = window.spent;
+            for (uint256 i = 1; i <= elapsed; i++) {
+                uint256 index = (lastEpoch + i) % SLOT_COUNT;
+                spent -= window.slots[index];
+                delete window.slots[index];
+            }
+            window.spent = spent;
+        }
+
+        window.lastEpoch = epoch;
+    }
+
+    function _currentEpoch() private view returns (uint256) {
+        return block.timestamp / SLOT_DURATION;
+    }
+}

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -27,6 +27,7 @@ import {MockSettlementModule} from "./mocks/MockSettlementModule.sol";
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract BridgeTest is Test {
     // Events re-declared locally for vm.expectEmit
@@ -69,6 +70,7 @@ contract BridgeTest is Test {
     RGBVerifier rgbVerifier;
     RgbSettlementModule rgbModule;
     MockAggregatorV3 ethUsdFeed;
+    MockAggregatorV3 sequencerUptimeFeed;
 
     address deployer = makeAddr("deployer");
     address user = makeAddr("user");
@@ -99,6 +101,10 @@ contract BridgeTest is Test {
     uint256 constant LATEST_CONFIRMATIONS = 1;
 
     function setUp() public {
+        // Leave enough history for the healthy sequencer round to be past the
+        // mandatory one-hour post-restart grace period.
+        vm.warp(2 hours);
+
         usdt0 = new MockERC20("Mock USDT0", "USDT0");
         btcRelay = new MockBtcRelay();
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, CONFIRMATIONS);
@@ -116,7 +122,7 @@ contract BridgeTest is Test {
         uint64 currentNonce = vm.getNonce(deployer);
         address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
 
-        cm = new CommissionManager(predictedBridge);
+        cm = new CommissionManager(predictedBridge, recipient);
         routeRegistry = new RouteRegistry(predictedBridge, deployer);
         bridge = new Bridge(
             address(usdt0),
@@ -133,9 +139,12 @@ contract BridgeTest is Test {
         routeRegistry.setRoute(SOURCE_CHAIN_ID, RGB_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
         routeRegistry.setRoute(RGB_CHAIN_ID, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
 
-        // Wire a Chainlink ETH/USD feed ($2000 / ETH, 8 decimals, fresh) so
-        // the NATIVE commission path quotes a positive value.
+        // Wire the complete mandatory R-I-14 oracle config: healthy sequencer,
+        // ETH/USD circuit-breaker bounds, then the fresh ETH/USD price feed.
         ethUsdFeed = new MockAggregatorV3(8, 2_000e8, block.timestamp);
+        sequencerUptimeFeed = new MockAggregatorV3(0, 0, block.timestamp - 1 hours - 1);
+        cm.setSequencerUptimeFeed(address(sequencerUptimeFeed));
+        cm.setEthUsdPriceBounds(100e8, 100_000e8);
         cm.setEthUsdFeed(address(ethUsdFeed), 1 hours);
 
         // Production-flow ownership transfer of Bridge → multisig. CM and
@@ -390,6 +399,29 @@ contract BridgeTest is Test {
         );
     }
 
+    /// @dev Accepted `msg.value` band on the DIRECT overload: the floor is the
+    ///      fresh quote itself, because the headroom above it is a refundable
+    ///      drift buffer rather than extra commission.
+    function _directNativeBounds(uint256 nativeCommission) internal view returns (uint256 minimum, uint256 maximum) {
+        uint256 denominator = bridge.BPS_DENOMINATOR();
+        uint256 tolerance = bridge.NATIVE_COMMISSION_TOLERANCE_BPS();
+        minimum = nativeCommission;
+        maximum = Math.mulDiv(nativeCommission, denominator + tolerance, denominator);
+    }
+
+    /// @dev Accepted `msg.value` band on the ADAPTER overload: symmetric, since
+    ///      the source-chain payer is unreachable and nothing can be refunded.
+    function _adapterNativeBounds(uint256 nativeCommission) internal view returns (uint256 minimum, uint256 maximum) {
+        uint256 denominator = bridge.BPS_DENOMINATOR();
+        uint256 tolerance = bridge.NATIVE_COMMISSION_TOLERANCE_BPS();
+        minimum = Math.mulDiv(nativeCommission, denominator - tolerance, denominator, Math.Rounding.Ceil);
+        maximum = Math.mulDiv(nativeCommission, denominator + tolerance, denominator);
+    }
+
+    function _nativeQuote(uint256 amount) internal view returns (uint256 quote) {
+        (, quote,) = cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), amount);
+    }
+
     /// @dev Ensure `requested` fits under the configured bucket burst (and
     ///      therefore also under the immutable 20% safety ceiling). Used by
     ///      legacy success-path tests whose subject is not the C-01 limiter.
@@ -631,23 +663,50 @@ contract BridgeTest is Test {
 
     function test_fundsIn_dustThatRoundsCommissionToZeroIsRejected() public {
         // 4% token commission. Below 25 units the fee floors to zero
-        // (24 * 400 / 100 / 100 == 0) — the exact dust case R-I-08 describes.
-        // A floor of 25 keeps such dust off the inbound path; at 25 the fee is
-        // a non-zero 1 unit.
+        // (24 * 400 / 100 / 100 == 0) — the exact dust case I-08 describes.
+        // The effective fee policy itself now rejects that dust, independently
+        // of the separately configurable global minimum.
         _setFundsInTokenRule(400);
-        vm.prank(multisig);
-        bridge.setMinFundsInAmount(25);
 
         assertEq(cm.calculateStableFee(24, 400, 100), 0, "sanity: 24 pays zero commission");
 
-        vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, uint256(24), uint256(25)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICommissionManager.CommissionRoundsToZero.selector, uint256(24), uint256(400), uint8(100)
+            )
+        );
         vm.prank(user);
         bridge.fundsIn(24, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        // At the floor the deposit is accepted and pays a non-zero commission.
+        // The smallest amount that produces one fee unit is accepted.
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(25, RGB_CHAIN_ID, DST_ADDR, _rgbData());
         assertEq(rgbModule.fundsInRecords(opId), 24, "net = 25 - 1 commission");
+    }
+
+    function test_R_I_08_fundsOutDustThatRoundsCommissionToZeroIsRejected() public {
+        uint256 dustAmount = 24;
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn(dustAmount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(dustAmount);
+        _setFundsOutTokenRule(400);
+
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlementWithAmounts(_ids(opId), _one(dustAmount));
+        uint256 burnId =
+            _deriveBurnId(recipient, dustAmount, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICommissionManager.CommissionRoundsToZero.selector, dustAmount, uint256(400), uint8(100)
+            )
+        );
+        vm.prank(multisig);
+        _fundsOutWithBurnId(
+            recipient, dustAmount, burnId, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+
+        assertFalse(bridge.consumedBurnIds(burnId), "reverted release does not consume burn id");
     }
 
     function test_fundsInFromAdapter_revertsBelowMinimum() public {
@@ -2215,7 +2274,7 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
-    // Commission — NativeValueMismatch
+    // Commission — I-03 bounded native quote drift
     // ========================================================================
 
     function test_fundsIn_revertsOnNativeValueMismatch_zeroRuleButValueSent() public {
@@ -2228,52 +2287,260 @@ contract BridgeTest is Test {
     function test_fundsIn_revertsOnNativeValueMismatch_nativeRuleButNoValue() public {
         _setFundsInNativeRule(100);
 
-        vm.expectRevert(IBridge.NativeValueMismatch.selector);
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _directNativeBounds(quote);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeCommissionOutOfBounds.selector, uint256(0), minimum, maximum)
+        );
         vm.prank(user);
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
-    // R-I-03 after-fix: a native overpayment (favorable ETH/USD drift between
-    // quote and execution) is now accepted; the FULL msg.value is collected as
-    // commission (not refunded, not stranded) and the deposit completes.
-    function test_fundsIn_nativeOverpayAcceptedAndCollected_afterFix() public {
+    // ========================================================================
+    // I-03 — native commission drift band
+    //
+    // Direct deposits: attach the quote plus optional headroom; exactly the
+    // fresh quote is charged and the remainder refunded, so the protocol never
+    // under-collects and the caller is never overcharged.
+    // Adapter deposits: the source-chain payer is unreachable, so the band is
+    // symmetric and whatever arrives inside it is collected in full.
+    // ========================================================================
+
+    function test_I_03_direct_exactQuoteChargedInFull() public {
         _setFundsInNativeRule(100);
+        uint256 quote = _nativeQuote(AMOUNT);
+        assertGt(quote, 0, "native fee quoted");
 
-        (, uint256 nativeCommission,) =
-            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
-        assertGt(nativeCommission, 0, "native fee quoted");
-
-        uint256 sent = nativeCommission + 0.01 ether; // overpay (price moved down)
-        vm.deal(user, sent);
-
-        uint256 cmNativeBefore = address(cm).balance;
-        uint256 nativePoolBefore = cm.nativeCommissionPool();
+        vm.deal(user, quote);
+        uint256 poolBefore = cm.nativeCommissionPool();
 
         vm.prank(user);
-        bytes32 opId = bridge.fundsIn{value: sent}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        bytes32 opId = bridge.fundsIn{value: quote}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        // Full msg.value collected as commission — surplus neither refunded nor
-        // left in the Bridge.
-        assertEq(address(cm).balance, cmNativeBefore + sent, "cm received full msg.value");
-        assertEq(cm.nativeCommissionPool(), nativePoolBefore + sent, "native pool credited full msg.value");
+        assertEq(cm.nativeCommissionPool(), poolBefore + quote, "pool credited exactly the quote");
+        assertEq(user.balance, 0, "nothing to refund");
         assertEq(address(bridge).balance, 0, "no native stranded in bridge");
-        // Deposit completed: RGB record created (NATIVE rule → token commission 0, net == gross).
-        assertEq(rgbModule.fundsInRecords(opId), AMOUNT, "deposit recorded from actual amount");
+        assertEq(rgbModule.fundsInRecords(opId), AMOUNT, "deposit completed");
     }
 
-    // R-I-03: underpaying the freshly-quoted native commission (price moved up)
-    // still reverts — the lower bound is enforced.
-    function test_fundsIn_nativeUnderpayReverts_afterFix() public {
+    /// @dev The invariant I-03 asks for: a caller who attaches more than the
+    ///      quote is charged only the quote and refunded the surplus.
+    function test_I_03_direct_surplusIsRefundedNotCollected() public {
+        _setFundsInNativeRule(100);
+        uint256 quote = _nativeQuote(AMOUNT);
+        uint256 attached = quote + (quote * 400) / 10_000; // +4%, inside the band
+
+        vm.deal(user, attached);
+        uint256 poolBefore = cm.nativeCommissionPool();
+
+        vm.prank(user);
+        bridge.fundsIn{value: attached}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(cm.nativeCommissionPool(), poolBefore + quote, "protocol collected ONLY the quote");
+        assertEq(user.balance, attached - quote, "caller refunded the whole surplus");
+        assertEq(address(bridge).balance, 0, "no native stranded in bridge");
+    }
+
+    function test_I_03_direct_upperBoundaryRefunded() public {
+        _setFundsInNativeRule(100);
+        uint256 quote = _nativeQuote(AMOUNT);
+        (, uint256 maximum) = _directNativeBounds(quote);
+
+        vm.deal(user, maximum);
+        vm.prank(user);
+        bridge.fundsIn{value: maximum}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(cm.nativeCommissionPool(), quote, "still only the quote is collected");
+        assertEq(user.balance, maximum - quote, "full headroom refunded");
+    }
+
+    function test_I_03_direct_revertsBelowQuote() public {
+        _setFundsInNativeRule(100);
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _directNativeBounds(quote);
+        uint256 provided = minimum - 1;
+
+        vm.deal(user, provided);
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeCommissionOutOfBounds.selector, provided, minimum, maximum)
+        );
+        vm.prank(user);
+        bridge.fundsIn{value: provided}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+    }
+
+    function test_I_03_direct_revertsAboveUpperBoundary() public {
+        _setFundsInNativeRule(100);
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _directNativeBounds(quote);
+        uint256 provided = maximum + 1;
+
+        vm.deal(user, provided);
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeCommissionOutOfBounds.selector, provided, minimum, maximum)
+        );
+        vm.prank(user);
+        bridge.fundsIn{value: provided}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+    }
+
+    /// @dev The scenario from the finding: quote, then the price moves against
+    ///      the caller before the tx mines. The attached buffer absorbs it and
+    ///      the deposit succeeds, charged at the FRESH (higher) quote.
+    function test_I_03_direct_adverseDriftAbsorbedByBuffer() public {
+        _setFundsInNativeRule(100);
+        uint256 quotedAtSubmit = _nativeQuote(AMOUNT);
+        uint256 attached = quotedAtSubmit + (quotedAtSubmit * 400) / 10_000; // +4% buffer
+
+        // ETH depreciates ~3%: the same fee costs more wei than first quoted,
+        // but less than the 4% buffer the caller attached.
+        ethUsdFeed.setAnswer(1_940e8);
+        uint256 freshQuote = _nativeQuote(AMOUNT);
+        assertGt(freshQuote, quotedAtSubmit, "drift moved against the caller");
+        assertLe(freshQuote, attached, "the buffer covers the drift, so no revert");
+
+        vm.deal(user, attached);
+        vm.prank(user);
+        bridge.fundsIn{value: attached}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(cm.nativeCommissionPool(), freshQuote, "charged the fresh quote, not the stale one");
+        assertEq(user.balance, attached - freshQuote, "remaining buffer refunded");
+    }
+
+    /// @dev Favorable drift simply returns more: the caller is charged the fresh
+    ///      (lower) quote, never the stale higher one.
+    function test_I_03_direct_favorableDriftRefundsMore() public {
+        _setFundsInNativeRule(100);
+        uint256 quotedAtSubmit = _nativeQuote(AMOUNT);
+
+        ethUsdFeed.setAnswer(2_090e8); // ETH appreciates: the fee costs less wei
+        uint256 freshQuote = _nativeQuote(AMOUNT);
+        assertLt(freshQuote, quotedAtSubmit, "drift moved in the caller's favour");
+
+        vm.deal(user, quotedAtSubmit);
+        vm.prank(user);
+        bridge.fundsIn{value: quotedAtSubmit}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(cm.nativeCommissionPool(), freshQuote, "charged the fresh, lower quote");
+        assertEq(user.balance, quotedAtSubmit - freshQuote, "difference refunded");
+    }
+
+    /// @dev The protocol cannot be systematically under-paid: every deposit
+    ///      credits exactly the quote in force at execution.
+    function test_I_03_direct_noSystematicUnderCollection() public {
+        _setFundsInNativeRule(100);
+        uint256 expected;
+
+        for (uint256 i; i < 3; i++) {
+            uint256 quote = _nativeQuote(AMOUNT);
+            (, uint256 maximum) = _directNativeBounds(quote);
+            vm.deal(user, maximum);
+            vm.prank(user);
+            bridge.fundsIn{value: maximum}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(RGB_OP_ID + 900 + i));
+            expected += quote;
+        }
+
+        assertEq(cm.nativeCommissionPool(), expected, "collected exactly the sum of the quotes");
+    }
+
+    /// @dev A caller that cannot accept native value must send the exact quote;
+    ///      attaching a buffer it cannot be refunded reverts cleanly.
+    function test_I_03_direct_nonPayableCallerMustSendExactQuote() public {
+        _setFundsInNativeRule(100);
+        NonPayableDepositor depositor = new NonPayableDepositor(bridge, usdt0);
+        usdt0.mint(address(depositor), AMOUNT * 2);
+        depositor.approveBridge(AMOUNT * 2);
+
+        uint256 quote = _nativeQuote(AMOUNT);
+
+        // Exact quote: nothing to refund, so the deposit goes through.
+        vm.deal(address(depositor), quote);
+        depositor.deposit(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(), quote);
+        assertEq(cm.nativeCommissionPool(), quote, "exact quote accepted from a non-payable caller");
+
+        // With a buffer the refund cannot land, and the deposit reverts.
+        uint256 attached = quote + (quote * 200) / 10_000;
+        vm.deal(address(depositor), attached);
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeRefundFailed.selector, address(depositor), attached - quote)
+        );
+        depositor.deposit(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(RGB_OP_ID + 951), attached);
+    }
+
+    function test_I_03_adapter_symmetricBandCollectedInFull() public {
         _setFundsInNativeRule(100);
 
-        (, uint256 nativeCommission,) =
-            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
-        assertGt(nativeCommission, 1, "native fee quoted");
+        address adapter = makeAddr("lz-adapter");
+        vm.prank(multisig);
+        bridge.setLZAdapter(adapter);
+        usdt0.mint(adapter, AMOUNT * 2);
+        vm.prank(adapter);
+        usdt0.approve(address(bridge), AMOUNT * 2);
 
-        vm.deal(user, nativeCommission);
-        vm.expectRevert(IBridge.NativeValueMismatch.selector);
-        vm.prank(user);
-        bridge.fundsIn{value: nativeCommission - 1}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _adapterNativeBounds(quote);
+        assertLt(minimum, quote, "adapter band extends BELOW the quote");
+
+        // Below the quote is accepted here — and collected in full, since the
+        // source-chain payer cannot be refunded.
+        vm.deal(adapter, minimum);
+        vm.prank(adapter);
+        bridge.fundsIn{value: minimum}(
+            AMOUNT, SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+        assertEq(cm.nativeCommissionPool(), minimum, "source-agreed value collected in full");
+        assertEq(adapter.balance, 0, "adapter is not refunded");
+
+        // Above the quote is likewise collected in full, not refunded.
+        vm.deal(adapter, maximum);
+        vm.prank(adapter);
+        bridge.fundsIn{value: maximum}(
+            AMOUNT, SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), RGB_CHAIN_ID, DST_ADDR, _rgbData(RGB_OP_ID + 961)
+        );
+        assertEq(cm.nativeCommissionPool(), minimum + maximum, "upper bound also collected in full");
+        assertEq(adapter.balance, 0, "adapter still not refunded");
+        assertEq(address(bridge).balance, 0, "no native stranded in bridge");
+    }
+
+    function test_I_03_adapter_revertsBelowLowerBoundary() public {
+        _setFundsInNativeRule(100);
+
+        address adapter = makeAddr("lz-adapter");
+        vm.prank(multisig);
+        bridge.setLZAdapter(adapter);
+
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _adapterNativeBounds(quote);
+        uint256 provided = minimum - 1;
+        vm.deal(adapter, provided);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeCommissionOutOfBounds.selector, provided, minimum, maximum)
+        );
+        vm.prank(adapter);
+        bridge.fundsIn{value: provided}(
+            AMOUNT, SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+    }
+
+    function test_I_03_adapter_revertsAboveUpperBoundary() public {
+        _setFundsInNativeRule(100);
+
+        address adapter = makeAddr("lz-adapter");
+        vm.prank(multisig);
+        bridge.setLZAdapter(adapter);
+
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _adapterNativeBounds(quote);
+        uint256 provided = maximum + 1;
+        vm.deal(adapter, provided);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeCommissionOutOfBounds.selector, provided, minimum, maximum)
+        );
+        vm.prank(adapter);
+        bridge.fundsIn{value: provided}(
+            AMOUNT, SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
     }
 
     // ========================================================================
@@ -3169,70 +3436,25 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId2), netAmount, "second record created");
     }
 
-    // A positive gross deposit with zero net leaves a zero record — the RGB
-    // duplicate guard is value-based, so a zero record does not occupy the id.
-    // Post R-W-08 each deposit derives a distinct id anyway; this proves the
-    // zero-net record semantics still hold under a derived id.
-    function test_fundsIn_zeroNetDepositLeavesZeroRecord_currentBehavior() public {
-        // stablePercent == multiplier^2 makes tokenCommission == amount.
-        vm.prank(deployer);
-        cm.setCommissionRule(
-            SOURCE_CHAIN_ID,
-            RGB_CHAIN_ID,
-            address(usdt0),
-            CommissionConfig({
-                stablePercent: 8_100,
-                multiplier: 90,
-                side: CommissionSide.FUNDS_IN,
-                currency: CommissionCurrency.TOKEN,
-                isSet: true
-            })
+    /// @dev I-08 regression: the auditor's 100% fee shape is rejected before
+    ///      it can become an active route rule and create zero-net records.
+    function test_R_I_08_hundredPercentRouteRuleCannotBeConfigured() public {
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 8_100,
+            multiplier: 90,
+            side: CommissionSide.FUNDS_IN,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, cfg.stablePercent, cfg.multiplier)
         );
+        vm.prank(deployer);
+        cm.setCommissionRule(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), cfg);
 
-        _assertZeroNetDepositLeavesZeroRecord(1);
-        _assertZeroNetDepositLeavesZeroRecord(AMOUNT / 2);
-        _assertZeroNetDepositLeavesZeroRecord(AMOUNT);
-    }
-
-    function _assertZeroNetDepositLeavesZeroRecord(uint256 amount) internal {
-        (uint256 tokenCommission,, uint256 netAmount) =
-            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), amount);
-
-        assertEq(tokenCommission, amount, "pre fee equals amount");
-        assertEq(netAmount, 0, "pre zero net");
-
-        uint256 userBefore = usdt0.balanceOf(user);
-        uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
-        uint256 cmBefore = usdt0.balanceOf(address(cm));
-        uint256 cmPoolBefore = cm.tokenCommissionPool(address(usdt0));
-        uint256 nativePoolBefore = cm.nativeCommissionPool();
-
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsIn(user, RGB_OP_ID, 0);
-        vm.prank(user);
-        bytes32 opId1 = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
-
-        assertEq(usdt0.balanceOf(user), userBefore - amount, "user spent first gross");
-        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, "bridge keeps no net");
-        assertEq(usdt0.balanceOf(address(cm)), cmBefore + amount, "cm got first gross");
-        assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore + amount, "cm pool first gross");
-        assertEq(cm.nativeCommissionPool(), nativePoolBefore, "native pool unchanged");
-        assertEq(rgbModule.fundsInRecords(opId1), 0, "zero-net leaves zero record");
-
-        // A second identical deposit derives a distinct id and also leaves a
-        // zero record — no collision, no revert.
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsIn(user, RGB_OP_ID, 0);
-        vm.prank(user);
-        bytes32 opId2 = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
-
-        assertTrue(opId2 != opId1, "second deposit distinct id");
-        assertEq(usdt0.balanceOf(user), userBefore - (2 * amount), "user spent duplicate gross");
-        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, "bridge still keeps no net");
-        assertEq(usdt0.balanceOf(address(cm)), cmBefore + (2 * amount), "cm got duplicate gross");
-        assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore + (2 * amount), "cm pool duplicate gross");
-        assertEq(cm.nativeCommissionPool(), nativePoolBefore, "duplicate native pool unchanged");
-        assertEq(rgbModule.fundsInRecords(opId2), 0, "second zero record");
+        CommissionConfig memory stored = cm.getCommissionRule(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0));
+        assertFalse(stored.isSet, "invalid rule was not stored");
     }
 
     // ========================================================================
@@ -3375,7 +3597,7 @@ contract BridgeTest is Test {
         uint64 currentNonce = vm.getNonce(deployer);
         address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
 
-        s.cm = new CommissionManager(predictedBridge);
+        s.cm = new CommissionManager(predictedBridge, recipient);
         RouteRegistry feeRouteRegistry = new RouteRegistry(predictedBridge, deployer);
         s.bridge = new Bridge(address(s.token), address(feeRouteRegistry), payable(address(s.cm)), address(0), 1);
 
@@ -3386,6 +3608,8 @@ contract BridgeTest is Test {
         feeRouteRegistry.setRoute(SOURCE_CHAIN_ID, RGB_CHAIN_ID, true, address(rgbVerifier), address(s.module));
         feeRouteRegistry.setRoute(RGB_CHAIN_ID, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(s.module));
 
+        s.cm.setSequencerUptimeFeed(address(sequencerUptimeFeed));
+        s.cm.setEthUsdPriceBounds(100e8, 100_000e8);
         s.cm.setEthUsdFeed(address(ethUsdFeed), 1 hours);
 
         s.bridge.transferOwnership(multisig);
@@ -3570,11 +3794,11 @@ contract BridgeTest is Test {
         assertEq(s.bridge.lockedLiquidity(RGB_CHAIN_ID), received * 9, "90% bucket reserve remains locked");
     }
 
-    // --- Received < tokenCommission reverts InsufficientReceived ---
+    // --- Received <= tokenCommission reverts InsufficientReceived ---
     //
     // Fee = 9000 bps (90%) → received = 10% of AMOUNT = 10e18. The fee-shape
     // guard caps the commission fraction at `stablePercent / multiplier^2`
-    // (stablePercent ≤ 9000, stablePercent ≤ multiplier^2). Choosing
+    // (stablePercent ≤ 9000, stablePercent < multiplier^2). Choosing
     // multiplier = 95, stablePercent = 9000 yields a fraction 9000/9025 ≈ 99.7%,
     // so the commission quote on the NOMINAL AMOUNT (~99.7e18) far exceeds the
     // actual received (10e18) — configurable within the guard, so no boundary
@@ -3593,4 +3817,51 @@ contract BridgeTest is Test {
         vm.prank(user);
         s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
+
+    /// @dev I-08: a nominally valid (<100%) commission can still consume the
+    ///      full ACTUAL receipt when the token charges a transfer fee. Equality
+    ///      must revert rather than recording a zero-net settlement.
+    function test_R_I_08_fundsInFeeTokenRevertsWhenActualNetWouldBeZero() public {
+        FeeStack memory s = _deployFeeStack(5000); // Bridge receives 50%
+        _setFeeStackFundsInTokenRule(s, 5000, 100); // nominal commission is 50%
+
+        uint256 received = AMOUNT - s.token.feeOn(AMOUNT);
+        uint256 tokenCommission = s.cm.calculateStableFee(AMOUNT, 5000, 100);
+        assertEq(received, tokenCommission, "sanity: actual receipt equals nominal commission");
+
+        vm.expectRevert(abi.encodeWithSelector(IBridge.InsufficientReceived.selector, received, tokenCommission));
+        vm.prank(user);
+        s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(s.bridge.lockedLiquidity(RGB_CHAIN_ID), 0, "zero-net liquidity was not recorded");
+        assertEq(s.cm.tokenCommissionPool(address(s.token)), 0, "commission transfer rolled back");
+    }
+}
+
+/// @dev Caller that deliberately cannot receive native value, used to cover the
+///      `NativeRefundFailed` path on the direct `fundsIn` overload.
+contract NonPayableDepositor {
+    Bridge private immutable _bridge;
+    MockERC20 private immutable _token;
+
+    constructor(Bridge bridge_, MockERC20 token_) {
+        _bridge = bridge_;
+        _token = token_;
+    }
+
+    function approveBridge(uint256 amount) external {
+        _token.approve(address(_bridge), amount);
+    }
+
+    function deposit(
+        uint256 amount,
+        uint256 destinationChainId,
+        string calldata destinationAddress,
+        bytes calldata settlementData,
+        uint256 nativeValue
+    ) external returns (bytes32) {
+        return _bridge.fundsIn{value: nativeValue}(amount, destinationChainId, destinationAddress, settlementData);
+    }
+
+    // no receive / fallback: any refund attempt fails
 }

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -138,12 +138,6 @@ contract BridgeTest is Test {
         ethUsdFeed = new MockAggregatorV3(8, 2_000e8, block.timestamp);
         cm.setEthUsdFeed(address(ethUsdFeed), 1 hours);
 
-        // Outflow rate limits: configure generous buckets so the
-        // release path is enabled (fundsOut fails closed on an unconfigured
-        // bucket). Buckets start full, so releases pass immediately.
-        bridge.setOutflowLimit(RGB_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
-        bridge.setGlobalOutflowLimit(1_000_000 ether, uint256(1_000_000 ether) / 1 days);
-
         // Production-flow ownership transfer of Bridge → multisig. CM and
         // RouteRegistry stay owned by deployer for this suite so individual
         // tests can configure commission rules and routes inline. The
@@ -394,6 +388,46 @@ contract BridgeTest is Test {
                 isSet: true
             })
         );
+    }
+
+    /// @dev Ensure `requested` fits under the configured bucket burst (and
+    ///      therefore also under the immutable 20% safety ceiling). Used by
+    ///      legacy success-path tests whose subject is not the C-01 limiter.
+    function _ensureRgbSafetyCapacity(uint256 requested) internal {
+        uint256 requiredLiquidity = requested * bridge.BPS_DENOMINATOR() / MAX_BURST_BPS;
+        uint256 currentLiquidity = bridge.lockedLiquidity(RGB_CHAIN_ID);
+        if (currentLiquidity < requiredLiquidity) {
+            uint256 topUp = requiredLiquidity - currentLiquidity;
+            usdt0.mint(user, topUp);
+            vm.prank(user);
+            bridge.fundsIn(topUp, RGB_CHAIN_ID, DST_ADDR, _rgbData(RGB_OP_ID + 1_000_000));
+        }
+
+        _configureMaxSafeBuckets();
+    }
+
+    /// @dev Balanced policy that consumes the full 20% configurable budget:
+    ///      10% instant burst plus 10% refill per window. Test liquidity is
+    ///      sized so this bucket stays out of the way unless it is the subject.
+    uint256 constant MAX_BURST_BPS = 1_000;
+    uint256 constant MAX_REFILL_BPS = 1_000;
+
+    function _configureMaxSafeBuckets() internal {
+        vm.startPrank(multisig);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, MAX_BURST_BPS, MAX_REFILL_BPS);
+        bridge.setGlobalOutflowLimit(MAX_BURST_BPS, MAX_REFILL_BPS);
+        vm.stopPrank();
+    }
+
+    /// @dev Convert an absolute token amount into bps of a chain's reference
+    ///      liquidity, so bucket tests can keep expressing intent in amounts.
+    function _bpsOfChain(uint256 chainId, uint256 amount) internal view returns (uint256) {
+        return amount * bridge.BPS_DENOMINATOR() / bridge.lockedLiquidity(chainId);
+    }
+
+    /// @dev Same conversion against aggregate liquidity, for the global bucket.
+    function _bpsOfGlobal(uint256 amount) internal view returns (uint256) {
+        return amount * bridge.BPS_DENOMINATOR() / bridge.totalLockedLiquidity();
     }
 
     // ========================================================================
@@ -725,6 +759,7 @@ contract BridgeTest is Test {
     function test_fundsOut_acceptsSourceAddressAtMaxLength() public {
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(AMOUNT);
 
         uint256 max = bridge.MAX_ADDRESS_LENGTH();
 
@@ -800,6 +835,7 @@ contract BridgeTest is Test {
         // happy path still succeeds.
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(AMOUNT);
 
         assertLt(_proof().length, bridge.MAX_PROOF_LENGTH(), "sanity: real proof under cap");
 
@@ -956,6 +992,7 @@ contract BridgeTest is Test {
     function test_fundsOut_transfersAndEmits() public {
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(AMOUNT);
 
         bytes memory proof = _proof();
         bytes memory settlementData = _settlement(_ids(opId));
@@ -969,12 +1006,13 @@ contract BridgeTest is Test {
         _fundsOut(recipient, AMOUNT, burnId, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData);
 
         assertEq(usdt0.balanceOf(recipient), AMOUNT);
-        assertEq(usdt0.balanceOf(address(bridge)), 0);
+        assertEq(usdt0.balanceOf(address(bridge)), AMOUNT * 9, "90% configured bucket reserve remains");
     }
 
     function test_fundsOut_keepsRecordAfterRelease() public {
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(AMOUNT);
 
         vm.prank(multisig);
         _fundsOut(
@@ -993,6 +1031,7 @@ contract BridgeTest is Test {
         bytes32 opId1 = bridge.fundsIn(amount1, RGB_CHAIN_ID, DST_ADDR, _rgbData(1));
         vm.prank(user);
         bytes32 opId2 = bridge.fundsIn(amount2, RGB_CHAIN_ID, DST_ADDR, _rgbData(2));
+        _ensureRgbSafetyCapacity(amount1 + amount2);
 
         bytes32[] memory ids = new bytes32[](2);
         ids[0] = opId1;
@@ -1026,6 +1065,7 @@ contract BridgeTest is Test {
     function test_fundsOut_revertsOnUnverifiedBlock() public {
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(AMOUNT);
 
         // Well-formed two-pair proof, but the source block is unknown to the relay.
         bytes memory badProof = abi.encode(uint256(999_999), keccak256("unknown-block"), LATEST_HEIGHT, LATEST_COMMIT);
@@ -1046,6 +1086,7 @@ contract BridgeTest is Test {
     function test_fundsOut_revertsOnUnknownFundsInId() public {
         vm.prank(user);
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(AMOUNT);
 
         bytes32 unknown = bytes32(uint256(999));
         bytes32[] memory ids = _ids(unknown);
@@ -1061,6 +1102,7 @@ contract BridgeTest is Test {
         // the mismatch must revert (surfaced through the Bridge).
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(50e18, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(50e18);
 
         bytes32[] memory ids = _ids(opId);
         uint256[] memory amounts = _one(60e18); // != recorded 50e18
@@ -1086,6 +1128,7 @@ contract BridgeTest is Test {
         bytes32 opId1 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(1));
         vm.prank(user);
         bytes32 opId2 = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(2));
+        _ensureRgbSafetyCapacity(AMOUNT);
 
         bytes32[] memory ids1 = _ids(opId1);
         bytes memory proof = _proof();
@@ -1172,35 +1215,41 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId2), AMOUNT, "second record unchanged");
     }
 
-    function test_fundsOut_revertsOnDoubleSpendsConsumedFundsIn() public {
+    function test_fundsOut_reusedPermanentRecordCannotExceedRollingLimit() public {
+        vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(AMOUNT);
 
         vm.prank(multisig);
         _fundsOut(
             recipient, AMOUNT, BURN_ID, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, _proof(), _settlement(_ids(opId))
         );
 
-        // Top up the bridge directly (simulates a fresh pool) and try a second
-        // release against the same — now consumed — fundsIn record.
-        usdt0.mint(address(bridge), AMOUNT);
-
-        // Isolated liquidity (R-C-01 level 1): the first release drained the RGB
-        // bucket to zero, and a direct mint does not credit it (only fundsIn
-        // does). The settlement module no longer consumes records (the mint
-        // proof is permanent and would still pass), so the liquidity guard is
-        // now the sole backstop against re-releasing a spent deposit.
+        // The settlement module no longer consumes records (the mint proof is
+        // permanent and may back another distinct burn intent), so let the
+        // configurable bucket refill while the first spend remains inside the
+        // rolling window.
         bytes32 altLatestCommit = keccak256("test-btc-alt-latest-commitment");
         btcRelay.setBlock(LATEST_HEIGHT + 1, altLatestCommit, LATEST_CONFIRMATIONS);
         bytes memory altProof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT + 1, altLatestCommit);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IBridge.InsufficientChainLiquidity.selector, RGB_CHAIN_ID, AMOUNT, uint256(0))
-        );
+        vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
         vm.prank(multisig);
         _fundsOut(
             recipient, AMOUNT, BURN_ID + 1, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, altProof, _settlement(_ids(opId))
         );
+
+        // Two 10% bucket bursts have now consumed the immutable 20% allowance.
+        // A third distinct intent cannot reuse the permanent proof to move more.
+        vm.warp(block.timestamp + 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IBridge.ChainSafetyLimitExceeded.selector, RGB_CHAIN_ID, uint256(1), AMOUNT * 2, AMOUNT * 2
+            )
+        );
+        vm.prank(multisig);
+        _fundsOut(recipient, 1, BURN_ID + 1, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, altProof, _settlement(_ids(opId)));
     }
 
     // ========================================================================
@@ -1234,6 +1283,8 @@ contract BridgeTest is Test {
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
         uint256 release = 40e18;
+        _ensureRgbSafetyCapacity(release);
+        uint256 liquidityBefore = bridge.lockedLiquidity(RGB_CHAIN_ID);
         vm.prank(multisig);
         _fundsOut(
             recipient,
@@ -1245,7 +1296,7 @@ contract BridgeTest is Test {
             _proof(),
             _settlement(_ids(opId)) // settlement amount = recorded AMOUNT
         );
-        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), AMOUNT - release, "bucket debited by gross release");
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), liquidityBefore - release, "bucket debited by gross release");
     }
 
     function test_isolatedLiquidity_chainCannotConsumeAnotherChainsLiquidity() public {
@@ -1253,14 +1304,11 @@ contract BridgeTest is Test {
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        // A different source chain with an enabled route and a (full) outflow
-        // bucket, so the rate limiter is NOT what blocks — only isolated
-        // liquidity is. Its lockedLiquidity is zero.
+        // A different source chain has no isolated liquidity. This guard runs
+        // before its bucket, so the missing liquidity is the precise blocker.
         uint256 otherChain = 777;
         vm.prank(deployer);
         routeRegistry.setRoute(otherChain, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
-        vm.prank(multisig);
-        bridge.setOutflowLimit(otherChain, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
 
         // Bridge holds AMOUNT (from the RGB deposit), but it is locked for RGB,
         // not for `otherChain`. The release must fail on isolated liquidity.
@@ -1286,12 +1334,13 @@ contract BridgeTest is Test {
         assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), AMOUNT, "debit rolled back on revert");
     }
 
-    /// @dev Fuzz the deposit/release round trip: a release of exactly the locked
-    ///      net amount succeeds and zeroes the bucket; one unit more reverts.
-    function testFuzz_isolatedLiquidity_roundTrip(uint256 amount) public {
+    /// @dev Fuzz the interaction between isolated liquidity and the immutable
+    ///      C-01 ceiling: overdraw still fails on isolated liquidity, while a
+    ///      full-bucket release fails and a release inside both limits succeeds.
+    function testFuzz_isolatedLiquidity_andSafetyLimit(uint256 amount) public {
         // Bound to the user's funded balance and above the dust floor; no
         // commission in setUp so net == gross.
-        amount = bound(amount, bridge.minFundsInAmount(), AMOUNT * 10);
+        amount = bound(amount, 1 ether, AMOUNT * 10);
 
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
@@ -1318,7 +1367,19 @@ contract BridgeTest is Test {
             _settlementWithAmounts(_ids(opId), _one(amount))
         );
 
-        // Exactly the locked amount succeeds and zeroes the bucket.
+        // Releasing the whole chain balance is 100% of the reference, i.e. one
+        // full SHARE_UNIT, against the configured 10% burst capacity.
+        _configureMaxSafeBuckets();
+        uint256 shareUnit = bridge.SHARE_UNIT();
+        uint256 bucketLimit = amount * MAX_BURST_BPS / bridge.BPS_DENOMINATOR();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OutflowRateLimiter.TokenRequestAboveCapacity.selector,
+                MAX_BURST_BPS * shareUnit / bridge.BPS_DENOMINATOR(),
+                shareUnit,
+                address(usdt0)
+            )
+        );
         vm.prank(multisig);
         _fundsOut(
             recipient,
@@ -1330,19 +1391,31 @@ contract BridgeTest is Test {
             _proof(),
             _settlementWithAmounts(_ids(opId), _one(amount))
         );
-        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), 0, "fully debited");
+
+        vm.prank(multisig);
+        _fundsOut(
+            recipient,
+            bucketLimit,
+            BURN_ID,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            _proof(),
+            _settlementWithAmounts(_ids(opId), _one(amount))
+        );
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), amount - bucketLimit, "configured 10% burst debited");
     }
 
     // ========================================================================
     // Outflow rate limit — OutflowRateLimiter token bucket
     //
     // fundsOut consumes the per-chain bucket (token-scoped errors) then the
-    // global bucket (aggregate-scoped errors). setUp configures both RGB and
-    // global to 1_000_000 ether and primes them full; tests reconfigure RGB down
-    // (clamp makes available == new capacity) to exercise tight limits. SEED_TX
-    // seeds ample isolated liquidity + a settlement record (proof-of-mint), so
-    // the token bucket is the only limiter. Rate-limit reverts are matched by
-    // selector (the library's minWait is an implementation detail).
+    // global bucket (aggregate-scoped errors). `_seedRGB` configures both with a
+    // balanced policy whose burst + refill equals the maximum 20% configurable
+    // budget; tests can then reconfigure RGB down to exercise tighter limits.
+    // SEED_TX seeds ample isolated liquidity + a settlement
+    // record (proof-of-mint). Rate-limit reverts are matched by selector (the
+    // library's minWait is an implementation detail).
     // ========================================================================
 
     uint256 constant SEED_TX = 5_000;
@@ -1358,17 +1431,24 @@ contract BridgeTest is Test {
     bytes32 _seedOpId;
 
     function _seedRGB(uint256 amount) internal {
-        _seedAmt = amount; // no fundsIn commission in this suite → net == gross
+        uint256 seededLiquidity = amount * bridge.BPS_DENOMINATOR() / MAX_BURST_BPS;
+        _seedAmt = seededLiquidity; // no fundsIn commission in this suite → net == gross
+        usdt0.mint(user, seededLiquidity);
         vm.prank(user);
-        _seedOpId = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _seedOpId = bridge.fundsIn(seededLiquidity, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _configureMaxSafeBuckets();
     }
 
     function _releaseRGB(uint256 amount, uint256 burnId) internal {
+        _releaseRGBTo(recipient, amount, burnId);
+    }
+
+    function _releaseRGBTo(address payoutRecipient, uint256 amount, uint256 burnId) internal {
         bytes32[] memory ids = new bytes32[](1);
         ids[0] = _seedOpId;
         vm.prank(multisig);
         _fundsOut(
-            recipient,
+            payoutRecipient,
             amount,
             burnId,
             RGB_CHAIN_ID,
@@ -1379,15 +1459,23 @@ contract BridgeTest is Test {
         );
     }
 
-    function _setRGBBucket(uint256 cap, uint256 rate) internal {
+    /// @dev Configure the RGB bucket from absolute token amounts, converted to
+    ///      bps of the chain's current reference liquidity: `burstAmount` is the
+    ///      instant allowance, `refillAmountPerWindow` the amount restored over
+    ///      one `BUCKET_REFILL_WINDOW`.
+    function _setRGBBucket(uint256 burstAmount, uint256 refillAmountPerWindow) internal {
+        // Resolve the bps values first: each `_bpsOfChain` makes an external view
+        // call, which would consume a pending `vm.prank`.
+        uint256 burstBps = _bpsOfChain(RGB_CHAIN_ID, burstAmount);
+        uint256 refillBps = _bpsOfChain(RGB_CHAIN_ID, refillAmountPerWindow);
         vm.prank(multisig);
-        bridge.setOutflowLimit(RGB_CHAIN_ID, cap, rate);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, burstBps, refillBps);
     }
 
     function test_outflow_fullBucketAllowsCapacityRejectsOverByOne() public {
         _seedRGB(1000 ether);
         uint256 cap = 100 ether;
-        _setRGBBucket(cap, cap / 1 days); // reconfig down → available == cap
+        _setRGBBucket(cap, cap); // reconfig down → available == cap
 
         _releaseRGB(cap, BURN_ID);
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 0, "capacity fully spent");
@@ -1400,7 +1488,7 @@ contract BridgeTest is Test {
     function test_outflow_releaseAboveCapacityReverts() public {
         _seedRGB(1000 ether);
         uint256 cap = 100 ether;
-        _setRGBBucket(cap, cap / 1 days);
+        _setRGBBucket(cap, cap);
 
         // Full bucket, but the request exceeds capacity entirely → a different,
         // more-specific error than the rate-limit one.
@@ -1411,28 +1499,31 @@ contract BridgeTest is Test {
     function test_outflow_refillAccruesOverTime() public {
         _seedRGB(1000 ether);
         uint256 cap = 100 ether;
-        uint256 rate = cap / 1 days;
-        _setRGBBucket(cap, rate);
+        _setRGBBucket(cap, cap);
 
         _releaseRGB(cap, BURN_ID);
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 0, "drained");
 
+        // `cap` is restored over one full BUCKET_REFILL_WINDOW, so half a window
+        // accrues half of it (to within the per-second share truncation).
         vm.warp(block.timestamp + 12 hours);
-        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), rate * 12 hours, "partial linear refill");
+        uint256 refilled = bridge.availableOutflow(RGB_CHAIN_ID);
+        assertApproxEqRel(refilled, cap / 2, 1e12, "partial linear refill"); // 1e-6 relative
 
-        _releaseRGB(rate * 12 hours, BURN_ID + 1); // the refilled allowance is spendable
+        _releaseRGB(refilled - 1, BURN_ID + 1); // the refilled allowance is spendable
     }
 
     function test_outflow_noDoubleCapBurstOverShortGap() public {
         _seedRGB(1000 ether);
         uint256 cap = 100 ether;
-        uint256 rate = cap / 1 days;
-        _setRGBBucket(cap, rate);
+        _setRGBBucket(cap, cap);
 
         _releaseRGB(cap, BURN_ID);
         vm.warp(block.timestamp + 1); // one second later
 
-        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), rate, "only refillRate accrued, not a fresh cap");
+        uint256 accrued = bridge.availableOutflow(RGB_CHAIN_ID);
+        assertApproxEqRel(accrued, cap / (24 hours), 1e12, "only one second of refill accrued");
+        assertLt(accrued, cap, "not a fresh cap");
         bytes32 altLatestCommit = keccak256("test-btc-short-gap-latest-commitment");
         btcRelay.setBlock(LATEST_HEIGHT + 1, altLatestCommit, LATEST_CONFIRMATIONS);
         bytes memory altProof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT + 1, altLatestCommit);
@@ -1456,12 +1547,20 @@ contract BridgeTest is Test {
     function test_outflow_perChainIsolation() public {
         uint256 other = 888;
         vm.prank(deployer);
+        routeRegistry.setRoute(SOURCE_CHAIN_ID, other, true, address(rgbVerifier), address(rgbModule));
+        vm.prank(deployer);
         routeRegistry.setRoute(other, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
+
+        usdt0.mint(user, 500 ether);
+        vm.prank(user);
+        bridge.fundsIn(500 ether, other, DST_ADDR, _rgbData(RGB_OP_ID + 888));
+
+        uint256 otherBps = _bpsOfChain(other, 50 ether);
         vm.prank(multisig);
-        bridge.setOutflowLimit(other, 50 ether, uint256(50 ether) / 1 days);
+        bridge.setOutflowLimit(other, otherBps, otherBps);
 
         _seedRGB(1000 ether);
-        _setRGBBucket(100 ether, uint256(100 ether) / 1 days);
+        _setRGBBucket(100 ether, 100 ether);
         _releaseRGB(100 ether, BURN_ID); // drain RGB bucket to 0
 
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 0, "RGB drained");
@@ -1469,11 +1568,12 @@ contract BridgeTest is Test {
     }
 
     function test_outflow_globalBucketBoundsAggregate() public {
-        // Per-chain RGB stays large (1M from setUp); tighten only the global bucket.
-        vm.prank(multisig);
-        bridge.setGlobalOutflowLimit(100 ether, uint256(100 ether) / 1 days);
-
         _seedRGB(1000 ether);
+        // Keep the per-chain bucket large; tighten only the global bucket.
+        uint256 globalBps = _bpsOfGlobal(100 ether);
+        vm.prank(multisig);
+        bridge.setGlobalOutflowLimit(globalBps, globalBps);
+
         _releaseRGB(100 ether, BURN_ID); // consumes the whole global allowance
         assertEq(bridge.availableGlobalOutflow(), 0, "global drained");
 
@@ -1484,18 +1584,19 @@ contract BridgeTest is Test {
 
     function test_outflow_reconfigPreservesAvailableNoGift() public {
         _seedRGB(1000 ether);
-        _setRGBBucket(100 ether, uint256(100 ether) / 1 days);
+        _setRGBBucket(100 ether, 100 ether);
         _releaseRGB(60 ether, BURN_ID); // available 40 ether
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 40 ether, "pre");
 
         // Raising capacity must NOT gift a fresh full bucket.
-        _setRGBBucket(200 ether, uint256(200 ether) / 1 days);
+        _setRGBBucket(200 ether, 200 ether);
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 40 ether, "available preserved, not gifted");
     }
 
     function test_outflow_reconfigClampsOnDecrease() public {
-        _setRGBBucket(100 ether, uint256(100 ether) / 1 days); // available 100 ether
-        _setRGBBucket(30 ether, uint256(30 ether) / 1 days); // clamp down
+        _seedRGB(1_000 ether);
+        _setRGBBucket(100 ether, 100 ether); // available 100 ether
+        _setRGBBucket(30 ether, 30 ether); // clamp down
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 30 ether, "clamped to new capacity");
     }
 
@@ -1528,7 +1629,7 @@ contract BridgeTest is Test {
 
     function test_outflow_downstreamRevertRestoresBuckets() public {
         _seedRGB(1000 ether);
-        _setRGBBucket(100 ether, uint256(100 ether) / 1 days);
+        _setRGBBucket(100 ether, 100 ether);
 
         uint256 globalBefore = bridge.availableGlobalOutflow();
         bytes memory badProof = abi.encode(uint256(999_999), keccak256("unknown"));
@@ -1552,85 +1653,423 @@ contract BridgeTest is Test {
         assertEq(bridge.availableGlobalOutflow(), globalBefore, "global restored");
     }
 
+    // ========================================================================
+    // C-01 — immutable TVL-relative rolling safety limit
+    // ========================================================================
+
+    function test_C01_usageCannotExpireBefore24Hours_andNewLimitUsesLowerTVL() public {
+        // Align to a ring slot boundary so expiry happens exactly at H+25.
+        vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
+        uint256 bucketBurst = 100 ether;
+        _seedRGB(bucketBurst); // deposits 1000 ether; bucket 10%, hard limit 20%
+
+        assertEq(bridge.totalLockedLiquidity(), 1_000 ether);
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 200 ether);
+        assertEq(bridge.availableGlobalSafetyOutflow(), 200 ether);
+
+        _releaseRGBTo(makeAddr("c01-window-first"), bucketBurst, BURN_ID);
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 100 ether);
+        assertEq(bridge.availableGlobalSafetyOutflow(), 100 ether);
+
+        // Hour-slot rounding is deliberately conservative: usage is still
+        // counted at exactly 24 hours, preventing a boundary double-spend.
+        vm.warp(block.timestamp + bridge.OUTFLOW_SAFETY_WINDOW());
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 100 ether);
+        assertEq(bridge.availableGlobalSafetyOutflow(), 100 ether);
+
+        // One extra second fully restores the slightly conservative, integer-
+        // rounded bucket refill while the first rolling-window spend remains.
+        vm.warp(block.timestamp + 1);
+        _releaseRGBTo(makeAddr("c01-window-second"), bucketBurst, BURN_ID + 1);
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 0);
+        assertEq(bridge.availableGlobalSafetyOutflow(), 0);
+
+        // At H+25 the first spend expires but the second remains. Reference is
+        // remaining liquidity (800) plus still-counted spend (100) = 900, so the
+        // new 20% limit is 180 with 100 already consumed: 80 remains.
+        vm.warp(block.timestamp + 1 hours - 1);
+        uint256 nextWindowLimit = 80 ether;
+        assertEq(bridge.chainOutflowReference(RGB_CHAIN_ID), 900 ether, "reference follows rolling lower TVL");
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), nextWindowLimit);
+        assertEq(bridge.availableGlobalSafetyOutflow(), nextWindowLimit);
+
+        // Liveness: after the second spend also expires, the bucket has refilled
+        // and a new 10%-of-current-liquidity tranche can leave.
+        vm.warp(block.timestamp + bridge.OUTFLOW_SAFETY_WINDOW());
+        assertEq(bridge.chainOutflowReference(RGB_CHAIN_ID), 800 ether);
+        assertEq(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), nextWindowLimit);
+        _releaseRGBTo(makeAddr("c01-window-third"), nextWindowLimit, BURN_ID + 2);
+        assertEq(bridge.totalLockedLiquidity(), 720 ether);
+    }
+
+    function test_C01_directTokenDonationCannotInflateGlobalSafetyAllowance() public {
+        _seedRGB(100 ether); // accounted TVL 1000 ether; global hard limit 200
+        uint256 beforeAllowance = bridge.availableGlobalSafetyOutflow();
+
+        usdt0.mint(address(bridge), 10_000 ether);
+
+        assertEq(bridge.totalLockedLiquidity(), 1_000 ether, "donation excluded from accounted TVL");
+        assertEq(
+            bridge.availableGlobalSafetyOutflow(),
+            beforeAllowance,
+            "unaccounted token donation cannot increase the security allowance"
+        );
+    }
+
+    /// @dev However the attacker splits the drain, the total leaving inside one
+    ///      rolling window never exceeds 20% of the window's reference. The two
+    ///      parts are not required to sum to exactly the cap: converting each
+    ///      release into shares rounds up, so splitting can cost a sub-share more
+    ///      than one combined release. That is the conservative direction, and
+    ///      the aggregate bound is what this asserts.
+    function testFuzz_C01_arbitrarySplitCannotExceedRollingLimit(uint96 firstPartSeed) public {
+        vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
+        _seedRGB(100 ether); // chain liquidity 1000; bucket burst 100; hard limit 200
+        uint256 poolBefore = usdt0.balanceOf(address(bridge));
+        uint256 hardLimit = bridge.availableChainSafetyOutflow(RGB_CHAIN_ID); // 20% of reference
+        uint256 initialBucketAllowance = bridge.effectiveAvailableOutflow(RGB_CHAIN_ID);
+
+        uint256 firstPart = bound(uint256(firstPartSeed), 1, initialBucketAllowance);
+
+        // Vary recipients so every split has a distinct canonical burn intent,
+        // even when two fuzzed amounts happen to be equal.
+        _releaseRGBTo(makeAddr("c01-first"), firstPart, BURN_ID);
+
+        // The reference does not move inside the window, so the remaining
+        // immutable allowance is exactly the complement of the first part.
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), hardLimit - firstPart, "complement remains");
+        assertEq(bridge.availableGlobalSafetyOutflow(), hardLimit - firstPart, "global complement remains");
+
+        // Refill the configurable bucket while the first spend is still inside
+        // the conservative rolling window, then take everything still permitted.
+        vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
+        uint256 secondPart = bridge.effectiveAvailableOutflow(RGB_CHAIN_ID);
+        if (secondPart != 0) _releaseRGBTo(makeAddr("c01-second"), secondPart, BURN_ID + 1);
+
+        // The C-01 invariant: however the drain is split, the pool never loses
+        // more than 20% of the window's reference, and nothing further may leave.
+        assertLe(firstPart + secondPart, hardLimit, "rolling cap never exceeded");
+        assertEq(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), 0, "allowance exhausted");
+        assertGe(usdt0.balanceOf(address(bridge)), poolBefore - hardLimit, "at least 80% of the pool remains");
+
+        // Which layer refuses the next unit depends on where the sub-share
+        // rounding lands, so that is asserted deterministically instead in
+        // `test_C01_usageCannotExpireBefore24Hours_andNewLimitUsesLowerTVL` (bucket)
+        // and `MultisigProxy.t.sol::test_C01_split...` (immutable limiter).
+    }
+
+    /// @dev The global rolling window aggregates physical outflow from every
+    ///      source chain. Two chains may each consume their own allowance, but
+    ///      splitting a drain across chains cannot bypass the global accounting.
+    function test_C01_globalRollingUsageAggregatesAcrossSourceChains() public {
+        vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
+
+        uint256 otherChain = 888;
+        vm.startPrank(deployer);
+        routeRegistry.setRoute(SOURCE_CHAIN_ID, otherChain, true, address(rgbVerifier), address(rgbModule));
+        routeRegistry.setRoute(otherChain, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
+        vm.stopPrank();
+
+        usdt0.mint(user, 1_000 ether);
+        vm.prank(user);
+        bytes32 otherOpId = bridge.fundsIn(1_000 ether, otherChain, DST_ADDR, _rgbData(RGB_OP_ID + otherChain));
+
+        _seedRGB(100 ether); // 1000 RGB + 1000 other; 10% bucket bursts
+        vm.prank(multisig);
+        bridge.setOutflowLimit(otherChain, MAX_BURST_BPS, MAX_REFILL_BPS);
+
+        assertEq(bridge.availableGlobalOutflow(), 200 ether, "global bucket is 10% of aggregate TVL");
+        assertEq(bridge.availableGlobalSafetyOutflow(), 400 ether, "global hard cap is 20% of aggregate TVL");
+
+        bytes32[] memory otherIds = _ids(otherOpId);
+        bytes memory otherSettlement = _settlementWithAmounts(otherIds, _one(1_000 ether));
+
+        _releaseRGBTo(makeAddr("aggregate-rgb-1"), 100 ether, BURN_ID);
+        vm.prank(multisig);
+        _fundsOut(
+            makeAddr("aggregate-other-1"),
+            100 ether,
+            BURN_ID + 1,
+            otherChain,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            _proof(),
+            otherSettlement
+        );
+
+        assertEq(bridge.availableGlobalOutflow(), 0, "both chains consume one global bucket");
+        assertEq(bridge.availableGlobalSafetyOutflow(), 200 ether, "aggregate hard allowance tracks both chains");
+
+        // Buckets refill after 24h, but the aligned rolling window retains both
+        // first releases until H+25. A second 100 from each chain exhausts the
+        // immutable aggregate and per-chain allowances without exceeding them.
+        vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
+        _releaseRGBTo(makeAddr("aggregate-rgb-2"), 100 ether, BURN_ID + 2);
+        vm.prank(multisig);
+        _fundsOut(
+            makeAddr("aggregate-other-2"),
+            100 ether,
+            BURN_ID + 3,
+            otherChain,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            _proof(),
+            otherSettlement
+        );
+
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 0, "RGB rolling allowance exhausted");
+        assertEq(bridge.availableChainSafetyOutflow(otherChain), 0, "other rolling allowance exhausted");
+        assertEq(bridge.availableGlobalSafetyOutflow(), 0, "aggregate rolling allowance exhausted");
+        assertEq(bridge.totalLockedLiquidity(), 1_600 ether, "at most 20% of aggregate reference left the bridge");
+
+        vm.warp(block.timestamp + 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IBridge.ChainSafetyLimitExceeded.selector,
+                RGB_CHAIN_ID,
+                uint256(1),
+                uint256(200 ether),
+                uint256(200 ether)
+            )
+        );
+        _releaseRGBTo(makeAddr("aggregate-rgb-blocked"), 1, BURN_ID + 4);
+    }
+
     function test_setOutflowLimit_revertsOnZeroChainId() public {
         vm.prank(multisig);
         vm.expectRevert(IBridge.InvalidOutflowLimit.selector);
-        bridge.setOutflowLimit(0, 100 ether, uint256(100 ether) / 1 days);
+        bridge.setOutflowLimit(0, 500, 1_500);
     }
 
-    function test_setOutflowLimit_revertsOnInvalidRate() public {
-        // Library validation requires 0 < rate < capacity.
-        vm.startPrank(multisig);
+    function test_setOutflowLimit_revertsOnZeroBurst() public {
+        vm.prank(multisig);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                OutflowRateLimiter.InvalidLimitConfig.selector,
-                OutflowRateLimiter.Settings({isEnabled: true, capacity: uint128(100 ether), rate: uint128(100 ether)})
-            )
+            abi.encodeWithSelector(IBridge.InvalidOutflowPolicy.selector, uint256(0), uint256(1_500), uint256(2_000))
         );
-        bridge.setOutflowLimit(RGB_CHAIN_ID, 100 ether, 100 ether); // rate == capacity
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 0, 1_500);
+    }
+
+    function test_setOutflowLimit_revertsOnZeroRefill() public {
+        vm.prank(multisig);
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.InvalidOutflowPolicy.selector, uint256(500), uint256(0), uint256(2_000))
+        );
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 500, 0);
+    }
+
+    /// @dev C-01 remaining issue: the federation must not be able to configure a
+    ///      bucket that covers TVL. `burstBps` is bounded by the immutable
+    ///      `MAX_CHAIN_OUTFLOW_BPS`, so no policy authorises more than 20% of
+    ///      reference liquidity in one release — at any liquidity level.
+    function test_C01_setOutflowLimit_rejectsBurstAboveImmutableCeiling() public {
+        uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
+
+        vm.prank(multisig);
+        vm.expectRevert(abi.encodeWithSelector(IBridge.InvalidOutflowPolicy.selector, maxBps + 1, uint256(1), maxBps));
+        bridge.setOutflowLimit(RGB_CHAIN_ID, maxBps + 1, 1);
+    }
+
+    function test_C01_setOutflowLimit_rejectsRefillAboveImmutableCeiling() public {
+        uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
+
+        vm.prank(multisig);
+        vm.expectRevert(abi.encodeWithSelector(IBridge.InvalidOutflowPolicy.selector, uint256(500), maxBps + 1, maxBps));
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 500, maxBps + 1);
+    }
+
+    /// @dev A policy whose combined burst and refill equals the immutable
+    ///      ceiling is accepted.
+    function test_C01_setOutflowLimit_acceptsCombinedCeiling() public {
+        uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
+        uint256 burstBps = 750;
+        uint256 refillBps = maxBps - burstBps;
+
+        vm.prank(multisig);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, burstBps, refillBps);
+
+        (,,, uint128 capacity,) = bridge.chainBuckets(RGB_CHAIN_ID);
+        assertEq(capacity, burstBps * bridge.SHARE_UNIT() / bridge.BPS_DENOMINATOR(), "burst stored as shares");
+    }
+
+    function test_C01_setOutflowLimit_rejectsCombinedPolicyAboveCeiling() public {
+        uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
+        uint256 burstBps = 1_001;
+        uint256 refillBps = 1_000;
+
+        vm.prank(multisig);
+        vm.expectRevert(abi.encodeWithSelector(IBridge.InvalidOutflowPolicy.selector, burstBps, refillBps, maxBps));
+        bridge.setOutflowLimit(RGB_CHAIN_ID, burstBps, refillBps);
+    }
+
+    function test_C01_setOutflowLimit_rejectsFullTvlPolicy() public {
+        uint256 denominator = bridge.BPS_DENOMINATOR();
+        uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
+
+        vm.prank(multisig);
+        vm.expectRevert(abi.encodeWithSelector(IBridge.InvalidOutflowPolicy.selector, denominator, denominator, maxBps));
+        bridge.setOutflowLimit(RGB_CHAIN_ID, denominator, denominator);
+    }
+
+    function test_C01_setGlobalOutflowLimit_rejectsFullTvlPolicy() public {
+        uint256 denominator = bridge.BPS_DENOMINATOR();
+        uint256 maxBps = bridge.MAX_GLOBAL_OUTFLOW_BPS();
+
+        vm.prank(multisig);
+        vm.expectRevert(abi.encodeWithSelector(IBridge.InvalidOutflowPolicy.selector, denominator, uint256(1), maxBps));
+        bridge.setGlobalOutflowLimit(denominator, 1);
+    }
+
+    function test_C01_setGlobalOutflowLimit_rejectsCombinedPolicyAboveCeiling() public {
+        uint256 maxBps = bridge.MAX_GLOBAL_OUTFLOW_BPS();
+        uint256 burstBps = 1_200;
+        uint256 refillBps = 801;
+
+        vm.prank(multisig);
+        vm.expectRevert(abi.encodeWithSelector(IBridge.InvalidOutflowPolicy.selector, burstBps, refillBps, maxBps));
+        bridge.setGlobalOutflowLimit(burstBps, refillBps);
+    }
+
+    /// @dev Deployment ergonomics: policy validation is liquidity-independent, so
+    ///      both buckets can be configured before the first deposit exists. This
+    ///      is what lets a deployment install every parameter in one pass instead
+    ///      of "deploy → seed liquidity → come back and configure buckets".
+    function test_C01_outflowPolicyConfigurableAtZeroLiquidity() public {
+        // `setUp` deploys the Bridge and configures routes but makes no deposit.
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), 0, "no chain liquidity yet");
+        assertEq(bridge.totalLockedLiquidity(), 0, "no global liquidity yet");
+
+        vm.startPrank(multisig);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 500, 1_500);
+        bridge.setGlobalOutflowLimit(800, 1_200);
         vm.stopPrank();
+
+        // Configured, but nothing is spendable until liquidity backs it — the
+        // percentage has no absolute meaning at zero reference.
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 0, "no allowance without liquidity");
+        assertEq(bridge.availableGlobalOutflow(), 0, "no global allowance without liquidity");
+        assertEq(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), 0, "nothing can leave");
+    }
+
+    /// @dev The same policy scales with liquidity and needs no governance touch:
+    ///      5% burst is 5 ether at 100 ether TVL and 50 ether at 1000 ether TVL.
+    function test_C01_outflowPolicyScalesWithLiquidity() public {
+        vm.startPrank(multisig);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 500, 1_500);
+        bridge.setGlobalOutflowLimit(500, 1_500);
+        vm.stopPrank();
+
+        usdt0.mint(user, 1_100 ether);
+        vm.prank(user);
+        bridge.fundsIn(100 ether, RGB_CHAIN_ID, DST_ADDR, _rgbData(RGB_OP_ID + 4_001));
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 5 ether, "5% of 100 ether");
+
+        vm.prank(user);
+        bridge.fundsIn(900 ether, RGB_CHAIN_ID, DST_ADDR, _rgbData(RGB_OP_ID + 4_002));
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 50 ether, "5% of 1000 ether, no reconfiguration");
     }
 
     function test_setOutflowLimit_onlyOwner() public {
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
-        bridge.setOutflowLimit(RGB_CHAIN_ID, 100 ether, 1);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 500, 1_500);
 
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
-        bridge.setGlobalOutflowLimit(100 ether, 1);
+        bridge.setGlobalOutflowLimit(500, 1_500);
     }
 
     function test_setOutflowLimit_emitsEvent() public {
-        uint256 cap = 100 ether;
-        uint256 rate = cap / 1 days;
-        // RGB already configured in setUp (full at 1M); reconfig down clamps
-        // available to the new capacity.
+        _seedRGB(100 ether); // chain liquidity 1000 ether
+        uint256 burstBps = 500; // 5% → 50 ether
+        uint256 refillBps = 1_500;
+        uint256 expectedShares = burstBps * bridge.SHARE_UNIT() / bridge.BPS_DENOMINATOR();
+
+        // RGB already uses a 10% balanced policy; reconfiguring to 5% clamps
+        // the accrued allowance to the new burst.
         vm.expectEmit(true, false, false, true, address(bridge));
-        emit OutflowLimitUpdated(RGB_CHAIN_ID, cap, rate, cap);
+        emit OutflowLimitUpdated(RGB_CHAIN_ID, burstBps, refillBps, expectedShares);
         vm.prank(multisig);
-        bridge.setOutflowLimit(RGB_CHAIN_ID, cap, rate);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, burstBps, refillBps);
     }
 
     /// @dev Fuzz the refill formula end-to-end through the live preview: reconfig
-    ///      RGB to a fuzzed (capacity, rate), drain a fuzzed amount, warp a fuzzed
-    ///      time, and assert availableOutflow matches an independent recomputation
-    ///      of the library's min(capacity, tokens + elapsed*rate).
+    ///      RGB to a fuzzed bps policy, drain a fuzzed fraction, warp a fuzzed
+    ///      time, and assert availableOutflow matches an independent
+    ///      recomputation of the library's min(capacity, tokens + elapsed*rate).
+    ///      The recomputation runs in share space, where the arithmetic is exact,
+    ///      and is converted to tokens exactly once — mirroring the view.
     function testFuzz_outflow_previewMatchesRefillFormula(
-        uint256 capacity,
-        uint256 rate,
-        uint256 drain,
+        uint256 burstBps,
+        uint256 refillBps,
+        uint256 drainBps,
         uint256 elapsed
     ) public {
-        capacity = bound(capacity, 2, 1_000_000 ether); // <= setUp's 1M so reconfig-down clamps to full
-        rate = bound(rate, 1, capacity - 1); // library requires 0 < rate < capacity
-        drain = bound(drain, 1, capacity < 1000 ether ? capacity : 1000 ether);
+        uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
+        burstBps = bound(burstBps, 1, MAX_BURST_BPS);
+        refillBps = bound(refillBps, 1, maxBps - burstBps);
+        drainBps = bound(drainBps, 1, burstBps);
         elapsed = bound(elapsed, 0, 4_000 days);
 
-        _seedRGB(drain);
-        _setRGBBucket(capacity, rate); // available == capacity (clamp down from 1M)
-        _releaseRGB(drain, BURN_ID); // available == capacity - drain
+        _seedRGB(1_000 ether);
+
+        vm.prank(multisig);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, burstBps, refillBps);
+
+        uint256 drain = bridge.chainOutflowReference(RGB_CHAIN_ID) * drainBps / bridge.BPS_DENOMINATOR();
+        vm.assume(drain > 0);
+        _releaseRGB(drain, BURN_ID);
 
         vm.warp(block.timestamp + elapsed);
 
-        uint256 tokensAfter = capacity - drain;
-        uint256 expected = tokensAfter + elapsed * rate;
-        if (expected > capacity) expected = capacity;
-        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), expected, "preview matches library refill");
-        assertLe(bridge.availableOutflow(RGB_CHAIN_ID), capacity, "never exceeds capacity");
+        // Read the reference AFTER the warp: it is invariant while the release is
+        // still counted in the window, then steps down to plain `lockedLiquidity`
+        // once the window expires. The view converts against the live value.
+        uint256 refLiquidity = bridge.chainOutflowReference(RGB_CHAIN_ID);
+
+        (uint128 tokens,,, uint128 capacity, uint128 rate) = bridge.chainBuckets(RGB_CHAIN_ID);
+        uint256 expectedShares = uint256(tokens) + elapsed * uint256(rate);
+        if (expectedShares > capacity) expectedShares = capacity;
+
+        uint256 shareUnit = bridge.SHARE_UNIT();
+        assertEq(
+            bridge.availableOutflow(RGB_CHAIN_ID),
+            expectedShares * refLiquidity / shareUnit,
+            "preview matches library refill"
+        );
+        assertLe(
+            bridge.availableOutflow(RGB_CHAIN_ID),
+            uint256(capacity) * refLiquidity / shareUnit,
+            "never exceeds capacity"
+        );
     }
 
-    /// @dev A release within the live allowance debits exactly that amount.
-    function testFuzz_outflow_releaseDebitsAvailable(uint256 capacity, uint256 amount) public {
-        capacity = bound(capacity, 1 ether, 1_000_000 ether); // >= 1e18 so capacity/1day >= 1 (valid rate)
-        amount = bound(amount, 1, capacity < 1000 ether ? capacity : 1000 ether);
+    /// @dev A release within the live allowance debits exactly that amount, up to
+    ///      the one-share ceiling applied when converting the amount into shares.
+    function testFuzz_outflow_releaseDebitsAvailable(uint256 burstBps, uint256 amountBps) public {
+        uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
+        burstBps = bound(burstBps, 1, MAX_BURST_BPS);
+        amountBps = bound(amountBps, 1, burstBps);
 
-        _seedRGB(1000 ether);
-        _setRGBBucket(capacity, capacity / 1 days);
+        _seedRGB(1_000 ether);
+        // No warp in this test, so the reference stays constant across the release.
+        uint256 refLiquidity = bridge.chainOutflowReference(RGB_CHAIN_ID);
 
-        uint256 available = bridge.availableOutflow(RGB_CHAIN_ID); // == capacity
+        vm.prank(multisig);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, burstBps, maxBps - burstBps);
+
+        uint256 amount = refLiquidity * amountBps / bridge.BPS_DENOMINATOR();
+        vm.assume(amount > 0);
+
+        uint256 available = bridge.availableOutflow(RGB_CHAIN_ID);
         _releaseRGB(amount, BURN_ID);
-        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), available - amount, "debited exactly");
+
+        // One share is worth `refLiquidity / SHARE_UNIT` tokens; the ceiling can
+        // debit at most that much more than the nominal amount.
+        uint256 oneShare = refLiquidity / bridge.SHARE_UNIT() + 1;
+        assertApproxEqAbs(
+            bridge.availableOutflow(RGB_CHAIN_ID), available - amount, oneShare, "debited to within one share"
+        );
+        assertLe(bridge.availableOutflow(RGB_CHAIN_ID), available - amount, "never debits less than the amount");
     }
 
     // ========================================================================
@@ -1746,6 +2185,7 @@ contract BridgeTest is Test {
     function test_fundsOut_tokenCommission_routesToCM() public {
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(AMOUNT);
 
         uint256 percent = 500; // 5%
         _setFundsOutTokenRule(percent);
@@ -2041,6 +2481,7 @@ contract BridgeTest is Test {
 
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(releaseAmount);
         _setFundsOutTokenRule(percent);
 
         (uint256 tokenCommission, uint256 nativeCommission, uint256 netAmount) =
@@ -2059,7 +2500,7 @@ contract BridgeTest is Test {
         uint256 nativePoolBefore = cm.nativeCommissionPool();
         uint256 recordBefore = rgbModule.fundsInRecords(opId);
 
-        assertEq(bridgeBefore, AMOUNT, "pre bridge pool");
+        assertEq(bridgeBefore, releaseAmount * 10, "pre bridge pool satisfies configured 10% burst");
         assertEq(recipientBefore, 0, "pre recipient token");
         assertEq(cmBefore, 0, "pre cm token");
         assertEq(cmPoolBefore, 0, "pre cm pool");
@@ -2194,6 +2635,7 @@ contract BridgeTest is Test {
     function test_fundsOut_verifierRevertRollsBackBurnIdAndRecords() public {
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(AMOUNT);
 
         // Well-formed two-pair proof, but the source block is unknown to the relay.
         bytes memory badProof = abi.encode(uint256(999_999), keccak256("unknown-block"), LATEST_HEIGHT, LATEST_COMMIT);
@@ -2209,7 +2651,7 @@ contract BridgeTest is Test {
             _deriveBurnId(recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, badProof, settlementData);
 
         assertFalse(bridge.consumedBurnIds(burnId), "pre burn id");
-        assertEq(bridgeBefore, AMOUNT, "pre bridge pool");
+        assertEq(bridgeBefore, AMOUNT * 10, "pre bridge pool includes bucket reserve");
         assertEq(recipientBefore, 0, "pre recipient token");
         assertEq(cmBefore, 0, "pre cm token");
         assertEq(cmPoolBefore, 0, "pre cm pool");
@@ -2241,6 +2683,7 @@ contract BridgeTest is Test {
         bytes32 opId1 = bridge.fundsIn(amount1, RGB_CHAIN_ID, DST_ADDR, _rgbData(1));
         vm.prank(user);
         bytes32 opId2 = bridge.fundsIn(amount2, RGB_CHAIN_ID, DST_ADDR, _rgbData(2));
+        _ensureRgbSafetyCapacity(releaseAmount);
 
         // Reference opId1 with a deliberately wrong amount so the settlement
         // module reverts (AmountMismatch) after the Bridge has already marked
@@ -2261,7 +2704,7 @@ contract BridgeTest is Test {
             _deriveBurnId(recipient, releaseAmount, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData);
 
         assertFalse(bridge.consumedBurnIds(burnId), "pre burn id");
-        assertEq(bridgeBefore, amount1 + amount2, "pre bridge pool");
+        assertEq(bridgeBefore, releaseAmount * 10, "pre bridge pool includes bucket reserve");
         assertEq(recipientBefore, 0, "pre recipient token");
         assertEq(cmBefore, 0, "pre cm token");
         assertEq(cmPoolBefore, 0, "pre cm pool");
@@ -2311,12 +2754,13 @@ contract BridgeTest is Test {
 
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(releaseAmount);
 
         uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
         uint256 recipientBefore = usdt0.balanceOf(alternateRecipient);
         uint256 recordBefore = rgbModule.fundsInRecords(opId);
 
-        assertEq(bridgeBefore, AMOUNT, "pre bridge pool");
+        assertEq(bridgeBefore, releaseAmount * 10, "pre bridge pool satisfies configured 10% burst");
         assertEq(recipientBefore, 0, "pre recipient token");
         assertEq(recordBefore, AMOUNT, "pre record");
         bytes memory proof = _proof();
@@ -2888,6 +3332,7 @@ contract BridgeTest is Test {
     function test_fundsOut_referencesDerivedOperationId() public {
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(AMOUNT);
 
         vm.prank(multisig);
         _fundsOut(
@@ -2942,9 +3387,6 @@ contract BridgeTest is Test {
         feeRouteRegistry.setRoute(RGB_CHAIN_ID, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(s.module));
 
         s.cm.setEthUsdFeed(address(ethUsdFeed), 1 hours);
-
-        s.bridge.setOutflowLimit(RGB_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
-        s.bridge.setGlobalOutflowLimit(1_000_000 ether, uint256(1_000_000 ether) / 1 days);
 
         s.bridge.transferOwnership(multisig);
         vm.stopPrank();
@@ -3087,6 +3529,20 @@ contract BridgeTest is Test {
         bytes32 opId = s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
         assertEq(s.module.fundsInRecords(opId), received, "record == actual received");
 
+        // Nine additional equal deposits provide the configured 90% bucket
+        // reserve; the test still releases exactly the first record's amount.
+        for (uint256 i = 1; i < 10; i++) {
+            vm.prank(user);
+            s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(RGB_OP_ID + i));
+        }
+
+        // Ten equal deposits back the release, so `received` is ~10% of chain
+        // liquidity and the balanced policy's burst covers it.
+        vm.startPrank(multisig);
+        s.bridge.setOutflowLimit(RGB_CHAIN_ID, MAX_BURST_BPS, MAX_REFILL_BPS);
+        s.bridge.setGlobalOutflowLimit(MAX_BURST_BPS, MAX_REFILL_BPS);
+        vm.stopPrank();
+
         // Release EXACTLY the recorded amount. Before the fix the record would
         // have been the nominal AMOUNT (> bridge balance `received`) and the
         // release would revert AmountExceedBridgePool.
@@ -3111,7 +3567,7 @@ contract BridgeTest is Test {
         uint256 delta = s.token.balanceOf(recipient) - recipientBefore;
         assertGt(delta, 0, "recipient balance increased");
         assertEq(delta, received - s.token.feeOn(received), "recipient nets received minus outbound fee");
-        assertEq(s.bridge.lockedLiquidity(RGB_CHAIN_ID), 0, "lockedLiquidity fully released");
+        assertEq(s.bridge.lockedLiquidity(RGB_CHAIN_ID), received * 9, "90% bucket reserve remains locked");
     }
 
     // --- Received < tokenCommission reverts InsufficientReceived ---

--- a/ethereum/test/BridgeRebalance.t.sol
+++ b/ethereum/test/BridgeRebalance.t.sol
@@ -71,6 +71,11 @@ contract BridgeRebalanceTest is Test {
     string constant RGB_SRC_ADDR = "rgb:burner/utxo1burn";
     string constant ARCH_SRC_ADDR = "arch:burner";
     uint256 constant AMOUNT = 100e18;
+
+    /// @dev Balanced policy that consumes the full configurable budget:
+    ///      10% instant burst plus 10% refill per window.
+    uint256 constant MAX_BURST_BPS = 1_000;
+    uint256 constant MAX_REFILL_BPS = 1_000;
     uint256 constant RGB_OP_ID = 0xABCDEF;
 
     // BtcRelay test data: deep source block (the RGB burn) + fresh latest block.
@@ -122,28 +127,32 @@ contract BridgeRebalanceTest is Test {
         // Pool → MintBurn (scenario A): operational, no external burn → NullVerifier.
         routeRegistry.setRoute(RGB_CHAIN_ID, RGB_MINTBURN_CHAIN_ID, true, address(nullVerifier), address(rgbModule));
 
-        // Outflow buckets for every non-EVM chain + global (fail-closed limiter).
-        bridge.setOutflowLimit(RGB_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
-        bridge.setOutflowLimit(ARCH_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
-        bridge.setOutflowLimit(RGB_MINTBURN_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
-        bridge.setGlobalOutflowLimit(1_000_000 ether, uint256(1_000_000 ether) / 1 days);
-
         bridge.transferOwnership(multisig);
         vm.stopPrank();
 
         vm.prank(multisig);
         bridge.acceptOwnership();
 
+        // Outflow policies are percentages of reference liquidity, so they are
+        // installed here — before any deposit exists — exactly as a deployment
+        // would. Nothing about the configuration depends on current TVL.
+        vm.startPrank(multisig);
+        bridge.setOutflowLimit(RGB_CHAIN_ID, MAX_BURST_BPS, MAX_REFILL_BPS);
+        bridge.setOutflowLimit(ARCH_CHAIN_ID, MAX_BURST_BPS, MAX_REFILL_BPS);
+        bridge.setOutflowLimit(RGB_MINTBURN_CHAIN_ID, MAX_BURST_BPS, MAX_REFILL_BPS);
+        bridge.setGlobalOutflowLimit(MAX_BURST_BPS, MAX_REFILL_BPS);
+        vm.stopPrank();
+
         // Fund both buckets with real deposits so rebalances have liquidity.
-        usdt0.mint(user, AMOUNT * 10);
+        usdt0.mint(user, AMOUNT * 30);
         vm.prank(user);
         usdt0.approve(address(bridge), type(uint256).max);
         vm.prank(user);
-        rgbSeedOpId = bridge.fundsIn(AMOUNT * 2, RGB_CHAIN_ID, RGB_DST_ADDR, abi.encode(RGB_OP_ID));
+        rgbSeedOpId = bridge.fundsIn(AMOUNT * 10, RGB_CHAIN_ID, RGB_DST_ADDR, abi.encode(RGB_OP_ID));
         vm.prank(user);
-        bridge.fundsIn(AMOUNT * 2, ARCH_CHAIN_ID, ARCH_DST_ADDR, "");
+        bridge.fundsIn(AMOUNT * 10, ARCH_CHAIN_ID, ARCH_DST_ADDR, "");
         vm.prank(user);
-        mintBurnSeedOpId = bridge.fundsIn(AMOUNT * 2, RGB_MINTBURN_CHAIN_ID, RGB_DST_ADDR, abi.encode(RGB_OP_ID + 100));
+        mintBurnSeedOpId = bridge.fundsIn(AMOUNT * 10, RGB_MINTBURN_CHAIN_ID, RGB_DST_ADDR, abi.encode(RGB_OP_ID + 100));
     }
 
     // ========================================================================
@@ -453,11 +462,16 @@ contract BridgeRebalanceTest is Test {
 
     function test_rebalance_preservesTotalLockedLiquidity() public {
         uint256 totalBefore = bridge.lockedLiquidity(RGB_CHAIN_ID) + bridge.lockedLiquidity(ARCH_CHAIN_ID)
-            + bridge.lockedLiquidity(SOURCE_CHAIN_ID);
+            + bridge.lockedLiquidity(SOURCE_CHAIN_ID) + bridge.lockedLiquidity(RGB_MINTBURN_CHAIN_ID);
+        uint256 accountedTotalBefore = bridge.totalLockedLiquidity();
+
         _rebalance(_archToRgbParams(AMOUNT, RGB_OP_ID + 1));
+
         uint256 totalAfter = bridge.lockedLiquidity(RGB_CHAIN_ID) + bridge.lockedLiquidity(ARCH_CHAIN_ID)
-            + bridge.lockedLiquidity(SOURCE_CHAIN_ID);
+            + bridge.lockedLiquidity(SOURCE_CHAIN_ID) + bridge.lockedLiquidity(RGB_MINTBURN_CHAIN_ID);
         assertEq(totalAfter, totalBefore, "sum(lockedLiquidity) preserved exactly");
+        assertEq(bridge.totalLockedLiquidity(), accountedTotalBefore, "accounted global TVL preserved exactly");
+        assertEq(bridge.totalLockedLiquidity(), totalAfter, "global TVL matches isolated liquidity sum");
     }
 
     function test_rebalance_spendsChainBucketNotGlobal() public {
@@ -482,6 +496,7 @@ contract BridgeRebalanceTest is Test {
         bytes32 secondOpId = _deriveRebalanceOpId(second);
         assertTrue(first.burnId != second.burnId, "distinct burnId per destination OpId");
         assertTrue(firstOpId != secondOpId, "distinct operationId per destination OpId");
+        vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
         _rebalance(second);
 
         assertEq(rgbModule.fundsInRecords(firstOpId), AMOUNT);
@@ -525,6 +540,7 @@ contract BridgeRebalanceTest is Test {
         // operationId folds in burnId, so debit-side differences propagate.
 
         // Second RGB deposit → a distinct record to reference for the 2nd burn.
+        usdt0.mint(user, AMOUNT);
         vm.prank(user);
         bytes32 secondSeedOpId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, RGB_DST_ADDR, abi.encode(RGB_OP_ID + 50));
 
@@ -541,6 +557,7 @@ contract BridgeRebalanceTest is Test {
         // Capture the emitted operationIds and assert they are distinct.
         vm.recordLogs();
         _rebalance(first);
+        vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
         _rebalance(second);
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bytes32 rebalanceTopic = keccak256("BridgeRebalance(bytes32,uint256,uint256,uint256,uint256,string,string)");
@@ -566,8 +583,9 @@ contract BridgeRebalanceTest is Test {
         // liquidity migration" — rebalance IS a liquidity migration.
         vm.prank(multisig);
         bridge.pauseInflow();
+        uint256 destinationBefore = bridge.lockedLiquidity(RGB_CHAIN_ID);
         _rebalance(_archToRgbParams(AMOUNT, RGB_OP_ID + 1));
-        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), AMOUNT * 3);
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), destinationBefore + AMOUNT);
     }
 
     // ========================================================================
@@ -658,15 +676,21 @@ contract BridgeRebalanceTest is Test {
     }
 
     function test_rebalance_revert_chainBucketThrottled() public {
-        // Reconfigure the ARCH bucket to less than AMOUNT: the rebalance must
-        // hit the same per-chain outflow throttle a release would.
+        // ARCH holds AMOUNT * 10, so a 500 bps burst is AMOUNT / 2 — less than
+        // the AMOUNT being migrated. The rebalance must hit the same per-chain
+        // outflow throttle a release would.
         vm.prank(multisig);
-        bridge.setOutflowLimit(ARCH_CHAIN_ID, AMOUNT / 2, 1);
+        bridge.setOutflowLimit(ARCH_CHAIN_ID, 500, 1);
+
+        uint256 shareUnit = bridge.SHARE_UNIT();
+        uint256 capacityShares = 500 * shareUnit / bridge.BPS_DENOMINATOR();
+        uint256 requestedShares = AMOUNT * shareUnit / bridge.lockedLiquidity(ARCH_CHAIN_ID);
+
         IBridge.RebalanceParams memory p = _archToRgbParams(AMOUNT, RGB_OP_ID + 1);
         vm.prank(multisig);
         vm.expectRevert(
             abi.encodeWithSelector(
-                OutflowRateLimiter.TokenRequestAboveCapacity.selector, AMOUNT / 2, AMOUNT, address(usdt0)
+                OutflowRateLimiter.TokenRequestAboveCapacity.selector, capacityShares, requestedShares, address(usdt0)
             )
         );
         bridge.rebalanceLiquidity(p);

--- a/ethereum/test/BridgeRebalance.t.sol
+++ b/ethereum/test/BridgeRebalance.t.sol
@@ -101,7 +101,7 @@ contract BridgeRebalanceTest is Test {
         uint64 currentNonce = vm.getNonce(deployer);
         address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
 
-        cm = new CommissionManager(predictedBridge);
+        cm = new CommissionManager(predictedBridge, deployer);
         routeRegistry = new RouteRegistry(predictedBridge, deployer);
         bridge = new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 1);
 

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -17,6 +17,7 @@ contract CommissionManagerTest is Test {
     CommissionManager internal cm;
     MockERC20 internal token;
     MockAggregatorV3 internal ethUsdFeed;
+    MockAggregatorV3 internal sequencerFeed;
 
     address internal constant BRIDGE = address(0xB01);
     address internal owner = makeAddr("owner");
@@ -35,6 +36,8 @@ contract CommissionManagerTest is Test {
     uint8 internal constant FEED_DECIMALS = 8;
     int256 internal constant DEFAULT_ETH_USD = 2_000e8; // $2000 / ETH
     uint256 internal constant HEARTBEAT = 1 hours;
+    uint256 internal constant MIN_ETH_USD = 100e8;
+    uint256 internal constant MAX_ETH_USD = 100_000e8;
 
     event BridgeAddressUpdated(address indexed newBridge);
     event GlobalDefaultsUpdated(
@@ -52,29 +55,39 @@ contract CommissionManagerTest is Test {
         vm.warp(HEARTBEAT * 10);
 
         vm.prank(owner);
-        cm = new CommissionManager(BRIDGE);
+        cm = new CommissionManager(BRIDGE, recipient);
         token = new MockERC20("Test", "TST");
         vm.prank(owner);
         cm.setGlobalDefaults(0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
 
-        // Deploy a default ETH/USD feed and wire it in. Tests that need to
-        // exercise the "feed unset" branch redeploy CM without calling
-        // `setEthUsdFeed` (see test_convertTokenFeeToNative_revertsIfFeedUnset).
+        // Install a complete healthy Arbitrum oracle config. R-I-14 makes the
+        // sequencer feed and price band mandatory whenever a non-zero NATIVE
+        // quote consumes ETH/USD.
         ethUsdFeed = new MockAggregatorV3(FEED_DECIMALS, DEFAULT_ETH_USD, block.timestamp);
-        vm.prank(owner);
+        sequencerFeed = new MockAggregatorV3(0, 0, block.timestamp - cm.SEQUENCER_GRACE_PERIOD() - 1);
+        vm.startPrank(owner);
+        cm.setSequencerUptimeFeed(address(sequencerFeed));
+        cm.setEthUsdPriceBounds(MIN_ETH_USD, MAX_ETH_USD);
         cm.setEthUsdFeed(address(ethUsdFeed), HEARTBEAT);
+        vm.stopPrank();
     }
 
     // --- Constructor ---
 
     function test_constructor_setsBridgeAndOwner() public view {
         assertEq(cm.bridgeAddress(), BRIDGE);
+        assertEq(cm.commissionRecipient(), recipient);
         assertEq(cm.owner(), owner);
     }
 
     function test_constructor_revertsOnZeroBridge() public {
         vm.expectRevert(ICommissionManager.InvalidBridgeAddress.selector);
-        new CommissionManager(address(0));
+        new CommissionManager(address(0), recipient);
+    }
+
+    function test_constructor_revertsOnZeroCommissionRecipient() public {
+        vm.expectRevert(ICommissionManager.InvalidRecipient.selector);
+        new CommissionManager(BRIDGE, address(0));
     }
 
     function test_renounceOwnership_blocked() public {
@@ -108,7 +121,7 @@ contract CommissionManagerTest is Test {
     function test_convertTokenFeeToNative_revertsIfFeedUnset() public {
         // Fresh CM with no feed configured.
         vm.prank(owner);
-        CommissionManager freshCm = new CommissionManager(BRIDGE);
+        CommissionManager freshCm = new CommissionManager(BRIDGE, recipient);
         vm.expectRevert(ICommissionManager.EthUsdFeedNotSet.selector);
         freshCm.convertTokenFeeToNative(1e18, 18);
     }
@@ -143,17 +156,14 @@ contract CommissionManagerTest is Test {
         cm.convertTokenFeeToNative(1, 19);
     }
 
-    // With the min/max band UNSET (the default), a fresh positive answer is
-    // accepted no matter how extreme — which is exactly why an Arbitrum
-    // deployment configures `setEthUsdPriceBounds`. Band-enabled rejection is
-    // covered by test_convertTokenFeeToNative_revertsWhenPriceBelowMin/AboveMax.
-    function test_convertTokenFeeToNative_allowsOutlierWhenBandUnset() public {
+    function test_convertTokenFeeToNative_revertsBeforeReadingOutlierWhenBandUnset() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(0, 0);
         ethUsdFeed.setAnswer(1); // $1e-8 — an extreme outlier
         ethUsdFeed.setUpdatedAt(block.timestamp);
 
-        uint256 nativeFee = cm.convertTokenFeeToNative(1e18, 18);
-
-        assertEq(nativeFee, 1e26, "fresh outlier accepted while band is unset");
+        vm.expectRevert(ICommissionManager.ChainlinkHardeningNotConfigured.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
     }
 
     function test_buildRouteKey_matchesEncodeHash() public view {
@@ -469,10 +479,9 @@ contract CommissionManagerTest is Test {
     //
     // The stable-fee formula is `amount * stablePercent / multiplier / multiplier`,
     // i.e. a fee fraction of `stablePercent / multiplier^2`. If `stablePercent`
-    // exceeds `multiplier^2` the quoted fee exceeds the bridged amount and the
-    // later `netAmount = amount - fee` underflows (Panic 0x11), bricking the
-    // route until the federation reconfigures. The setters must therefore reject
-    // any `(stablePercent, multiplier)` pair where `stablePercent > multiplier^2`.
+    // reaches `multiplier^2` the fee consumes the whole bridged amount; above it,
+    // `netAmount = amount - fee` underflows. The setters must therefore require
+    // `stablePercent < multiplier^2`, guaranteeing a positive nominal net.
     function test_setGlobalDefaults_revertsWhenStablePercentExceedsMultiplierSquared() public {
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(9000), uint8(1)));
@@ -487,15 +496,11 @@ contract CommissionManagerTest is Test {
         cm.setGlobalDefaults(101, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
-    /// @dev Exact boundary `stablePercent == multiplier^2` is accepted: it is a 100%
-    ///      fee (`netAmount = 0`) which is degenerate but does not underflow, so the
-    ///      invariant rejects only the strictly-greater case.
-    function test_setGlobalDefaults_acceptsFeeShapeAtExactBoundary() public {
+    /// @dev I-08: the exact boundary is a 100% fee and must be rejected too.
+    function test_setGlobalDefaults_revertsFeeShapeAtExactBoundary() public {
         vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(100), uint8(10)));
         cm.setGlobalDefaults(100, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
-        (uint256 sp, uint8 m,,) = cm.getGlobalDefaults();
-        assertEq(sp, 100);
-        assertEq(m, 10);
     }
 
     /// @dev Regression for the uint8 widening in the fix. With the default
@@ -526,8 +531,8 @@ contract CommissionManagerTest is Test {
         cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), cfg);
     }
 
-    /// @dev Exact boundary `stablePercent == multiplier^2` accepted on the route setter.
-    function test_setCommissionRule_acceptsFeeShapeAtExactBoundary() public {
+    /// @dev I-08: per-route rules also reject the exact 100% boundary.
+    function test_setCommissionRule_revertsFeeShapeAtExactBoundary() public {
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 100,
             multiplier: 10,
@@ -536,10 +541,8 @@ contract CommissionManagerTest is Test {
             isSet: true
         });
         vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(100), uint8(10)));
         cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), cfg);
-        CommissionConfig memory stored = cm.getCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token));
-        assertEq(stored.stablePercent, 100);
-        assertEq(stored.multiplier, 10);
     }
 
     /// @dev uint8-widening regression on the per-route setter: `(9000, 100)` is valid.
@@ -558,19 +561,54 @@ contract CommissionManagerTest is Test {
         assertEq(stored.multiplier, 100);
     }
 
-    /// @dev End state of the invariant: a config accepted at the exact boundary
-    ///      yields `fee == amount` and `netAmount == 0` without underflowing. This
-    ///      is what the setter guard guarantees for every storable rule — the
-    ///      `amount - fee` subtraction in the calculators can never go negative.
-    function test_calculateFundsInCommission_acceptedBoundaryDoesNotUnderflow() public {
+    /// @dev Direct regression for the auditor's `8100 / 90^2 == 100%` PoC.
+    function test_R_I_08_rejectsAuditHundredPercentConfiguration() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(100, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
-        uint256 amount = 50_000;
-        (uint256 tok, uint256 nat, uint256 net) =
-            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), amount);
-        assertEq(tok, amount); // 100% fee at the boundary
-        assertEq(nat, 0);
-        assertEq(net, 0); // no underflow
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(8100), uint8(90)));
+        cm.setGlobalDefaults(8100, 90, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    /// @dev A non-zero inbound fee policy cannot silently round to zero.
+    function test_R_I_08_fundsInActiveFeeRejectsCommissionFreeDust() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICommissionManager.CommissionRoundsToZero.selector, uint256(24), uint256(400), uint8(100)
+            )
+        );
+        cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 24);
+    }
+
+    /// @dev The same runtime invariant applies to outbound fee rules.
+    function test_R_I_08_fundsOutActiveFeeRejectsCommissionFreeDust() public {
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 400,
+            multiplier: 100,
+            side: CommissionSide.FUNDS_OUT,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+        vm.prank(owner);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), cfg);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICommissionManager.CommissionRoundsToZero.selector, uint256(24), uint256(400), uint8(100)
+            )
+        );
+        cm.calculateFundsOutCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 24);
+    }
+
+    /// @dev A deliberately disabled fee remains valid; only active policies
+    ///      promise a non-zero commission.
+    function test_R_I_08_zeroFeePolicyStillAllowsSmallAmount() public view {
+        (uint256 tokenFee, uint256 nativeFee, uint256 netAmount) =
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 1);
+        assertEq(tokenFee, 0);
+        assertEq(nativeFee, 0);
+        assertEq(netAmount, 1);
     }
 
     // --- Bridge address ---
@@ -657,7 +695,7 @@ contract CommissionManagerTest is Test {
         cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(owner);
-        cm.withdrawTokenCommission(address(token), recipient, amt);
+        cm.withdrawTokenCommission(address(token), amt);
 
         assertEq(cm.tokenCommissionPool(address(token)), 0);
         assertEq(token.balanceOf(recipient), amt);
@@ -670,7 +708,7 @@ contract CommissionManagerTest is Test {
         cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(owner);
-        cm.withdrawAllTokenCommission(address(token), recipient);
+        cm.withdrawAllTokenCommission(address(token));
 
         assertEq(cm.tokenCommissionPool(address(token)), 0);
         assertEq(token.balanceOf(recipient), amt);
@@ -679,7 +717,31 @@ contract CommissionManagerTest is Test {
     function test_withdrawTokenCommission_revertsInsufficient() public {
         vm.prank(owner);
         vm.expectRevert(ICommissionManager.InsufficientBalance.selector);
-        cm.withdrawTokenCommission(address(token), recipient, 1);
+        cm.withdrawTokenCommission(address(token), 1);
+    }
+
+    function test_legacyFreeRecipientWithdrawalSelectorsUnavailable() public {
+        uint256 amount = 10 ether;
+        token.mint(address(cm), amount);
+        vm.prank(BRIDGE);
+        cm.receiveTokenCommission(address(token), amount);
+
+        bytes[] memory legacyCalls = new bytes[](4);
+        legacyCalls[0] =
+            abi.encodeWithSignature("withdrawTokenCommission(address,address,uint256)", address(token), user, amount);
+        legacyCalls[1] = abi.encodeWithSignature("withdrawNativeCommission(address,uint256)", user, amount);
+        legacyCalls[2] = abi.encodeWithSignature("withdrawAllTokenCommission(address,address)", address(token), user);
+        legacyCalls[3] = abi.encodeWithSignature("withdrawAllNativeCommission(address)", user);
+
+        for (uint256 i = 0; i < legacyCalls.length; i++) {
+            vm.prank(owner);
+            (bool ok,) = address(cm).call(legacyCalls[i]);
+            assertFalse(ok, "legacy free-recipient selector must not exist");
+        }
+
+        assertEq(cm.tokenCommissionPool(address(token)), amount, "failed legacy calls preserve pool");
+        assertEq(token.balanceOf(user), 0, "arbitrary recipient receives nothing");
+        assertEq(token.balanceOf(recipient), 0, "no valid withdrawal executed");
     }
 
     // --- Native commission ---
@@ -711,7 +773,7 @@ contract CommissionManagerTest is Test {
 
         uint256 before = recipient.balance;
         vm.prank(owner);
-        cm.withdrawNativeCommission(payable(recipient), 2 ether);
+        cm.withdrawNativeCommission(2 ether);
         assertEq(cm.nativeCommissionPool(), 0);
         assertEq(recipient.balance, before + 2 ether);
     }
@@ -724,7 +786,7 @@ contract CommissionManagerTest is Test {
 
         uint256 before = recipient.balance;
         vm.prank(owner);
-        cm.withdrawAllNativeCommission(payable(recipient));
+        cm.withdrawAllNativeCommission();
         assertEq(cm.nativeCommissionPool(), 0);
         assertEq(recipient.balance, before + 3 ether);
     }
@@ -732,7 +794,7 @@ contract CommissionManagerTest is Test {
     function test_withdrawNativeCommission_revertsInsufficient() public {
         vm.prank(owner);
         vm.expectRevert(ICommissionManager.InsufficientBalance.selector);
-        cm.withdrawNativeCommission(payable(recipient), 1 wei);
+        cm.withdrawNativeCommission(1 wei);
     }
 
     // --- Formula regression coverage ---
@@ -752,9 +814,12 @@ contract CommissionManagerTest is Test {
         // formula instead of mirroring the implementation expression.
         for (uint256 i = 0; i < tokenFees.length; i++) {
             MockAggregatorV3 feed = new MockAggregatorV3(feedDecimals[i], prices[i], block.timestamp);
+            uint256 decimalScale = 10 ** uint256(feedDecimals[i]);
 
-            vm.prank(owner);
+            vm.startPrank(owner);
+            cm.setEthUsdPriceBounds(100 * decimalScale, 100_000 * decimalScale);
             cm.setEthUsdFeed(address(feed), HEARTBEAT);
+            vm.stopPrank();
 
             assertEq(
                 cm.convertTokenFeeToNative(tokenFees[i], tokenDecimals[i]), expectedNativeFees[i], "native fee formula"
@@ -782,9 +847,12 @@ contract CommissionManagerTest is Test {
 
     // --- sequencer uptime ---
 
-    function test_convertTokenFeeToNative_noSequencerCheckWhenUnset() public view {
-        // No sequencer feed wired (setUp does not set one) → quote works.
-        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    function test_convertTokenFeeToNative_revertsWhenSequencerFeedUnset() public {
+        vm.prank(owner);
+        cm.setSequencerUptimeFeed(address(0));
+
+        vm.expectRevert(ICommissionManager.ChainlinkHardeningNotConfigured.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
     }
 
     function test_convertTokenFeeToNative_revertsWhenSequencerDown() public {
@@ -808,6 +876,19 @@ contract CommissionManagerTest is Test {
         cm.convertTokenFeeToNative(1e18, 18);
     }
 
+    function test_convertTokenFeeToNative_revertsOnUninitializedSequencerRound() public {
+        _setSequencer(0, 0);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidSequencerRound.selector, uint256(0)));
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_revertsOnFutureSequencerRound() public {
+        uint256 futureStartedAt = block.timestamp + 1;
+        _setSequencer(0, futureStartedAt);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidSequencerRound.selector, futureStartedAt));
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
     function test_convertTokenFeeToNative_passesWhenSequencerUpPastGrace() public {
         _setSequencer(0, block.timestamp - cm.SEQUENCER_GRACE_PERIOD() - 1);
         assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14); // same as happy path
@@ -815,9 +896,12 @@ contract CommissionManagerTest is Test {
 
     // --- min/max price band ---
 
-    function test_convertTokenFeeToNative_noBandWhenUnset() public view {
-        // No band configured in setUp → any positive fresh answer is accepted.
-        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    function test_convertTokenFeeToNative_revertsWhenBandUnset() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(0, 0);
+
+        vm.expectRevert(ICommissionManager.ChainlinkHardeningNotConfigured.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
     }
 
     function test_convertTokenFeeToNative_revertsWhenPriceBelowMin() public {
@@ -869,6 +953,9 @@ contract CommissionManagerTest is Test {
         vm.prank(owner);
         cm.setSequencerUptimeFeed(address(0));
         assertEq(cm.sequencerUptimeFeed(), address(0));
+
+        vm.expectRevert(ICommissionManager.ChainlinkHardeningNotConfigured.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
     }
 
     function test_setSequencerUptimeFeed_onlyOwner() public {
@@ -893,6 +980,9 @@ contract CommissionManagerTest is Test {
         cm.setEthUsdPriceBounds(0, 0);
         assertEq(cm.ethUsdMinPrice(), 0);
         assertEq(cm.ethUsdMaxPrice(), 0);
+
+        vm.expectRevert(ICommissionManager.ChainlinkHardeningNotConfigured.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
     }
 
     function test_setEthUsdPriceBounds_revertsOnZeroMinWithNonZeroMax() public {

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -186,7 +186,7 @@ contract IntegrationTest is Test {
         uint64 currentNonce = vm.getNonce(deployer);
         address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
 
-        cm = new CommissionManager(predictedBridge);
+        cm = new CommissionManager(predictedBridge, commissionReceiver);
         routeRegistry = new RouteRegistry(predictedBridge, deployer);
         bridge = new Bridge(
             address(token),
@@ -214,9 +214,7 @@ contract IntegrationTest is Test {
         fed[1] = fedA2;
         fed[2] = fedA3;
 
-        proxy = new MultisigProxy(
-            address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        proxy = new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, TIMELOCK, MIN_TIMELOCK);
 
         cm.transferOwnership(address(proxy));
         bridge.transferOwnership(address(proxy));
@@ -427,9 +425,16 @@ contract IntegrationTest is Test {
 
     function test_endToEnd_nativeCommission_inboundAndWithdraw() public {
         // Configure a NATIVE FUNDS_IN route (2% on token amount, paid in wei).
-        // Wire up a Chainlink ETH/USD feed ($2000 / ETH, 8 decimals, fresh)
-        // via federation governance — the same path production will use.
+        // Wire the complete mandatory R-I-14 config through federation
+        // governance — dependencies first, ETH/USD feed last.
+        MockAggregatorV3 sequencerFeed = new MockAggregatorV3(0, 0, block.timestamp);
         ethUsdFeed = new MockAggregatorV3(8, 2_000e8, block.timestamp);
+        _proposeAndExecuteCmAdminCall(
+            abi.encodeWithSelector(ICommissionManager.setSequencerUptimeFeed.selector, address(sequencerFeed))
+        );
+        _proposeAndExecuteCmAdminCall(
+            abi.encodeWithSelector(ICommissionManager.setEthUsdPriceBounds.selector, uint256(100e8), uint256(100_000e8))
+        );
         _proposeAndExecuteCmAdminCall(
             abi.encodeWithSelector(ICommissionManager.setEthUsdFeed.selector, address(ethUsdFeed), uint256(1 days))
         );

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -218,12 +218,6 @@ contract IntegrationTest is Test {
             address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
 
-        // Outflow rate limits: configure generous buckets while
-        // the deployer still owns the Bridge, so the release path is enabled
-        // before ownership moves to the proxy.
-        bridge.setOutflowLimit(RGB_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
-        bridge.setGlobalOutflowLimit(1_000_000 ether, uint256(1_000_000 ether) / 1 days);
-
         cm.transferOwnership(address(proxy));
         bridge.transferOwnership(address(proxy));
         vm.stopPrank();
@@ -310,16 +304,27 @@ contract IntegrationTest is Test {
         // -------------------------------------------------------------------------
         uint256 userBefore = token.balanceOf(user);
 
+        // Ten equal deposits make the release below exactly 10% of isolated
+        // and global TVL — the configured bucket burst.
         vm.prank(user);
-        // RGB route: settlementData carries the non-zero RGB OpId. The record is
-        // keyed by the bridge-derived operationId returned here.
         bytes32 opId = bridge.fundsIn(USER_DEPOSIT, RGB_CHAIN_ID, "rgb:asset1qp0y3mq/utxo1abc", abi.encode(RGB_OP_ID));
+        for (uint256 i = 1; i < 10; i++) {
+            vm.prank(user);
+            bridge.fundsIn(USER_DEPOSIT, RGB_CHAIN_ID, "rgb:asset1qp0y3mq/utxo1abc", abi.encode(RGB_OP_ID + i));
+        }
 
-        uint256 tokenCommissionIn = tInQuote;
+        uint256 tokenCommissionIn = tInQuote * 10;
         uint256 netBridgedIn = netIn;
 
-        assertEq(token.balanceOf(user), userBefore - USER_DEPOSIT, "user debited gross");
-        assertEq(token.balanceOf(address(bridge)), netBridgedIn, "bridge keeps net");
+        // Balanced maximum-total policy: 10% burst plus 10% refill per window.
+        // Ten deposits back a release of one, so the full burst is spendable.
+        vm.startPrank(address(proxy));
+        bridge.setOutflowLimit(RGB_CHAIN_ID, 1_000, 1_000);
+        bridge.setGlobalOutflowLimit(1_000, 1_000);
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(user), userBefore - USER_DEPOSIT * 10, "user debited ten gross deposits");
+        assertEq(token.balanceOf(address(bridge)), netBridgedIn * 10, "bridge keeps ten net deposits");
         assertEq(token.balanceOf(address(cm)), tokenCommissionIn, "cm got commission");
         assertEq(cm.tokenCommissionPool(address(token)), tokenCommissionIn, "cm pool mirrors balance");
         assertEq(rgbModule.fundsInRecords(opId), netBridgedIn, "record stores net");
@@ -367,7 +372,7 @@ contract IntegrationTest is Test {
 
         proxy.fundsOutCall(params, outNonce, outDeadline, 3, teeSigs);
 
-        assertEq(token.balanceOf(address(bridge)), 0, "bridge drained");
+        assertEq(token.balanceOf(address(bridge)), netBridgedIn * 9, "one tenth released; safety reserve remains");
         assertEq(token.balanceOf(recipient), netOut, "recipient got net");
         assertEq(token.balanceOf(address(cm)), tokenCommissionIn + tokenCommissionOut, "cm accrued both fees");
         assertEq(cm.tokenCommissionPool(address(token)), tokenCommissionIn + tokenCommissionOut, "cm pool mirrors");
@@ -400,16 +405,20 @@ contract IntegrationTest is Test {
         proxy.executeProposal(proposalId, opData);
 
         // -------------------------------------------------------------------------
-        // 5. Final invariants: bridge empty, CM empty, recipient holds netOut,
-        //    commissionReceiver holds the full aggregated commission.
+        // 5. Final invariants: the nine-deposit safety reserve remains in the
+        //    bridge, CM is empty, and all commissions reached their receiver.
         // -------------------------------------------------------------------------
-        assertEq(token.balanceOf(address(bridge)), 0, "bridge still empty");
+        assertEq(token.balanceOf(address(bridge)), netBridgedIn * 9, "nine-deposit safety reserve remains");
         assertEq(token.balanceOf(address(cm)), 0, "cm drained");
         assertEq(cm.tokenCommissionPool(address(token)), 0, "cm pool drained");
         assertEq(token.balanceOf(recipient), netOut, "recipient unchanged");
         assertEq(token.balanceOf(commissionReceiver), totalCommission, "commissionReceiver paid");
-        // Token conservation: user-deducted == everything distributed.
-        assertEq(token.balanceOf(recipient) + token.balanceOf(commissionReceiver), USER_DEPOSIT, "token conservation");
+        // Token conservation: ten gross deposits remain fully accounted for.
+        assertEq(
+            token.balanceOf(address(bridge)) + token.balanceOf(recipient) + token.balanceOf(commissionReceiver),
+            USER_DEPOSIT * 10,
+            "token conservation"
+        );
     }
 
     // =========================================================================

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -15,6 +15,7 @@ import {RouteRegistry} from "../src/RouteRegistry.sol";
 import {IRouteRegistry} from "../src/interfaces/IRouteRegistry.sol";
 import {RGBVerifier} from "../src/verifiers/RGBVerifier.sol";
 import {RgbSettlementModule} from "../src/settlement/RgbSettlementModule.sol";
+import {OutflowRateLimiter} from "../src/libraries/OutflowRateLimiter.sol";
 import {RouteConfig} from "../src/interfaces/RouteTypes.sol";
 import {
     CommissionConfig,
@@ -170,6 +171,11 @@ contract MultisigProxyTest is Test {
     string constant DST_ADDR = "rgb:asset/utxo1abc";
     string constant SRC_ADDR = "rgb:sender/utxo1src";
     uint256 constant AMOUNT = 100e18;
+
+    /// @dev Balanced policy that consumes the full configurable budget:
+    ///      10% instant burst plus 10% refill per window.
+    uint256 constant MAX_BURST_BPS = 1_000;
+    uint256 constant MAX_REFILL_BPS = 1_000;
     uint256 constant TX_ID = 42;
     uint256 constant RGB_OP_ID = 0xABCDEF;
     uint256 constant BURN_ID = 9_001;
@@ -249,12 +255,6 @@ contract MultisigProxyTest is Test {
             address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
         );
 
-        // Outflow rate limits: configure generous buckets while
-        // the deployer still owns the Bridge, so the release path is enabled
-        // before ownership moves to the proxy.
-        bridge.setOutflowLimit(RGB_CHAIN_ID, 1_000_000 ether, uint256(1_000_000 ether) / 1 days);
-        bridge.setGlobalOutflowLimit(1_000_000 ether, uint256(1_000_000 ether) / 1 days);
-
         // Production-flow ownership transfer.
         bridge.transferOwnership(address(proxy));
         cm.transferOwnership(address(proxy));
@@ -273,11 +273,22 @@ contract MultisigProxyTest is Test {
         domainSep = proxy.DOMAIN_SEPARATOR();
 
         // Fund user, lock tokens into the bridge so fundsOut has a pool.
-        token.mint(user, AMOUNT * 10);
+        // Keep a separate user balance for tests that make follow-up deposits
+        // or fund the CommissionManager after the 10x seed deposit.
+        token.mint(user, AMOUNT * 20);
         vm.prank(user);
         token.approve(address(bridge), type(uint256).max);
+        // Policies are percentages of reference liquidity, so they are installed
+        // before the deposit — the order a deployment uses. `burstBps +
+        // refillBpsPerWindow` is capped at 20%. This balanced policy spends the
+        // full configurable budget: 10% available up front, 10% refill/window.
+        vm.startPrank(address(proxy));
+        bridge.setOutflowLimit(RGB_CHAIN_ID, MAX_BURST_BPS, MAX_REFILL_BPS);
+        bridge.setGlobalOutflowLimit(MAX_BURST_BPS, MAX_REFILL_BPS);
+        vm.stopPrank();
+
         vm.prank(user);
-        seedOpId = bridge.fundsIn(AMOUNT * 5, RGB_CHAIN_ID, DST_ADDR, abi.encode(RGB_OP_ID));
+        seedOpId = bridge.fundsIn(AMOUNT * 10, RGB_CHAIN_ID, DST_ADDR, abi.encode(RGB_OP_ID));
     }
 
     // ========================================================================
@@ -2291,12 +2302,12 @@ contract MultisigProxyTest is Test {
         uint256 nativePoolBefore = cm.nativeCommissionPool();
         uint256 recordBefore = rgbModule.fundsInRecords(seedOpId);
 
-        assertEq(bridgeBefore, AMOUNT * 5, "pre bridge pool");
+        assertEq(bridgeBefore, AMOUNT * 10, "pre bridge pool");
         assertEq(recipientBefore, 0, "pre recipient token");
         assertEq(cmBefore, 0, "pre cm token");
         assertEq(cmPoolBefore, 0, "pre cm pool");
         assertEq(nativePoolBefore, 0, "pre native pool");
-        assertEq(recordBefore, AMOUNT * 5, "pre record");
+        assertEq(recordBefore, AMOUNT * 10, "pre record");
         assertFalse(bridge.consumedBurnIds(params.burnId), "pre burn id");
 
         vm.expectEmit(true, true, false, true);
@@ -2370,12 +2381,12 @@ contract MultisigProxyTest is Test {
         uint256 adapterEthBefore = address(adapter).balance;
         uint256 oftEthBefore = mockOft.balance;
 
-        assertEq(bridgeBefore, AMOUNT * 5, "pre bridge pool");
+        assertEq(bridgeBefore, AMOUNT * 10, "pre bridge pool");
         assertEq(adapterBefore, 0, "pre adapter token");
         assertEq(oftBefore, 0, "pre oft token");
         assertEq(cmBefore, 0, "pre cm token");
         assertEq(cmPoolBefore, 0, "pre cm pool");
-        assertEq(recordBefore, AMOUNT * 5, "pre record");
+        assertEq(recordBefore, AMOUNT * 10, "pre record");
         assertEq(adapterEthBefore, 0, "pre adapter native");
         assertEq(oftEthBefore, 0, "pre oft native");
         assertFalse(bridge.consumedBurnIds(params.burnId), "pre burn id");
@@ -2458,13 +2469,13 @@ contract MultisigProxyTest is Test {
         uint256 adapterEthBefore = address(adapter).balance;
         uint256 oftEthBefore = mockOft.balance;
 
-        assertEq(bridgeBefore, AMOUNT * 5, "pre bridge pool");
+        assertEq(bridgeBefore, AMOUNT * 10, "pre bridge pool");
         assertEq(adapterBefore, 0, "pre adapter token");
         assertEq(oftBefore, 0, "pre oft token");
         assertEq(cmBefore, 0, "pre cm token");
         assertEq(cmPoolBefore, 0, "pre cm pool");
         assertEq(nativePoolBefore, 0, "pre native pool");
-        assertEq(recordBefore, AMOUNT * 5, "pre record");
+        assertEq(recordBefore, AMOUNT * 10, "pre record");
         assertFalse(bridge.consumedBurnIds(params.burnId), "pre burn id");
 
         // An underfunded native fee reverts in sendOut, after Bridge.fundsOut
@@ -2544,13 +2555,13 @@ contract MultisigProxyTest is Test {
         uint256 adapterEthBefore = address(adapter).balance;
         uint256 oftEthBefore = mockOft.balance;
 
-        assertEq(bridgeBefore, AMOUNT * 5, "pre bridge pool");
+        assertEq(bridgeBefore, AMOUNT * 10, "pre bridge pool");
         assertEq(adapterBefore, 0, "pre adapter token");
         assertEq(oftBefore, 0, "pre oft token");
         assertEq(cmBefore, 0, "pre cm token");
         assertEq(cmPoolBefore, 0, "pre cm pool");
         assertEq(nativePoolBefore, 0, "pre native pool");
-        assertEq(recordBefore, AMOUNT * 5, "pre record");
+        assertEq(recordBefore, AMOUNT * 10, "pre record");
         assertEq(adapter.sendOutCalls(), 0, "pre adapter calls");
         assertFalse(bridge.consumedBurnIds(params.burnId), "pre burn id");
 
@@ -2625,13 +2636,13 @@ contract MultisigProxyTest is Test {
         uint256 adapterEthBefore = address(adapter).balance;
         uint256 oftEthBefore = mockOft.balance;
 
-        assertEq(bridgeBefore, AMOUNT * 5, "pre bridge pool");
+        assertEq(bridgeBefore, AMOUNT * 10, "pre bridge pool");
         assertEq(adapterBefore, 0, "pre adapter token");
         assertEq(oftBefore, 0, "pre oft token");
         assertEq(cmBefore, 0, "pre cm token");
         assertEq(cmPoolBefore, 0, "pre cm pool");
         assertEq(nativePoolBefore, 0, "pre native pool");
-        assertEq(recordBefore, AMOUNT * 5, "pre record");
+        assertEq(recordBefore, AMOUNT * 10, "pre record");
         assertEq(adapter.sendOutCalls(), 0, "pre adapter calls");
         assertFalse(bridge.consumedBurnIds(params.burnId), "pre burn id");
 
@@ -2717,12 +2728,12 @@ contract MultisigProxyTest is Test {
         uint256 adapterEthBefore = address(adapter).balance;
         uint256 oftEthBefore = mockOft.balance;
 
-        assertEq(bridgeBefore, AMOUNT * 6, "pre bridge pool");
+        assertEq(bridgeBefore, AMOUNT * 11, "pre bridge pool");
         assertEq(adapterBefore, 0, "pre adapter token");
         assertEq(oftBefore, 0, "pre oft token");
         assertEq(cmBefore, 0, "pre cm token");
         assertEq(cmPoolBefore, 0, "pre cm pool");
-        assertEq(originalRecordBefore, AMOUNT * 5, "pre original record");
+        assertEq(originalRecordBefore, AMOUNT * 10, "pre original record");
         assertEq(duplicateRecordBefore, AMOUNT, "pre duplicate record");
         assertEq(adapter.sendOutCalls(), 0, "pre adapter calls");
         assertFalse(bridge.consumedBurnIds(params.burnId), "pre burn id");
@@ -2849,45 +2860,167 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
-    // Current behavior reproduction
+    // C-01 immutable TVL-relative safety limit
     // ========================================================================
 
-    function test_enclaveSignedFundsOutCanDrainPool_currentBehavior() public {
+    /// @dev buckets are set to a maximum-total policy, the pool is fully funded, and
+    ///      a valid 2-of-3 enclave quorum signs a release of the entire pool.
+    ///      It reverts. Note what the assertions now show that the audited build
+    ///      could not: `availableOutflow` reports 10% of TVL, not ≥ TVL, so the
+    ///      PoC's own `assertGe(availableOutflow, tvl)` premise no longer holds
+    ///      either.
+    function test_enclaveSignedFullPoolDrainRevertsWithMaxAllowedBuckets() public {
         address drainRecipient = makeAddr("drainRecipient");
 
-        // The TEE path checks signatures, but it does not impose an on-chain
-        // amount cap on the signed Bridge fundsOut.
         uint256 bridgeBefore = token.balanceOf(address(bridge));
-        uint256 recipientBefore = token.balanceOf(drainRecipient);
         uint256 recordBefore = rgbModule.fundsInRecords(seedOpId);
+        uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
 
-        assertEq(bridgeBefore, AMOUNT * 5, "pre bridge pool");
-        assertEq(recipientBefore, 0, "pre recipient token");
+        assertEq(bridgeBefore, AMOUNT * 10, "pre bridge pool");
         assertEq(recordBefore, bridgeBefore, "pre record backs full pool");
-        // Current behavior: if an on-chain amount cap or rate limit is added
-        // later, this test should be inverted to expect a revert.
+        assertLt(bridge.availableOutflow(RGB_CHAIN_ID), bridgeBefore, "chain bucket cannot cover TVL");
+        assertLt(bridge.availableGlobalOutflow(), bridgeBefore, "global bucket cannot cover TVL");
+        assertEq(
+            bridge.effectiveAvailableOutflow(RGB_CHAIN_ID),
+            bridgeBefore * MAX_BURST_BPS / bridge.BPS_DENOMINATOR(),
+            "at most the configured burst can leave, well under TVL"
+        );
+
         IBridge.FundsOutParams memory params = _fundsOutParams(drainRecipient, bridgeBefore, BURN_ID);
-        assertFalse(bridge.consumedBurnIds(params.burnId), "pre burn id");
         uint256 nonce = proxy.teeNonce(RGB_CHAIN_ID);
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _encSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit BridgeFundsOut(
-            drainRecipient, bridgeBefore, bridgeBefore, 0, params.burnId, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR
+        // The whole pool is 10_000 bps of the reference; the bucket's burst is
+        // MAX_BURST_BPS. Requesting 100% therefore exceeds capacity outright.
+        uint256 shareUnit = bridge.SHARE_UNIT();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OutflowRateLimiter.TokenRequestAboveCapacity.selector,
+                MAX_BURST_BPS * shareUnit / bridge.BPS_DENOMINATOR(),
+                shareUnit, // the full pool is exactly one SHARE_UNIT of reference
+                address(token)
+            )
         );
-        vm.expectEmit(true, true, false, true, address(proxy));
-        emit FundsOutExecuted(RGB_CHAIN_ID, nonce, bitmap);
-
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
 
-        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce + 1, "nonce incremented");
-        assertTrue(bridge.consumedBurnIds(params.burnId), "burn id consumed");
-        assertEq(token.balanceOf(address(bridge)), 0, "bridge pool drained");
-        assertEq(token.balanceOf(drainRecipient), recipientBefore + bridgeBefore, "recipient got full pool");
-        assertEq(rgbModule.fundsInRecords(seedOpId), recordBefore, "record unchanged (proof-of-mint permanent)");
+        assertEq(proxy.teeNonce(RGB_CHAIN_ID), nonce, "reverted release does not consume nonce");
+        assertFalse(bridge.consumedBurnIds(params.burnId), "reverted release does not consume burn id");
+        assertEq(token.balanceOf(address(bridge)), bridgeBefore, "entire pool remains");
+        assertEq(token.balanceOf(drainRecipient), 0, "recipient receives nothing");
+        assertEq(
+            bridge.availableChainSafetyOutflow(RGB_CHAIN_ID),
+            bridgeBefore * maxBps / bridge.BPS_DENOMINATOR(),
+            "immutable allowance unchanged"
+        );
+    }
+
+    /// @dev Fragmented drain: the attacker splits the release across refill
+    ///      windows. At the 24-hour boundary the bucket has refilled, while the
+    ///      first spend is still retained by the conservative rolling window.
+    ///      The second release may consume the immutable remainder, but a third
+    ///      valid 2-of-3 signed transaction cannot exceed the rolling 20% cap.
+    function test_C01_splitTransactionsCannotExceedAggregateRollingLimit() public {
+        // Align to an hour boundary so the ring's 24-25h retention is exact
+        // relative to the releases below rather than to an arbitrary offset.
+        vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
+
+        uint256 tvl = token.balanceOf(address(bridge));
+        uint256 hardLimit = tvl * bridge.MAX_CHAIN_OUTFLOW_BPS() / bridge.BPS_DENOMINATOR();
+
+        _signedRelease(makeAddr("split-recipient-1"), hardLimit / 2, BURN_ID);
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), hardLimit / 2, "half the allowance left");
+        assertEq(bridge.availableGlobalSafetyOutflow(), hardLimit / 2);
+
+        // At 24h + 1s the conservatively rounded share bucket is fully refilled,
+        // while the rolling limiter deliberately still counts the first release.
+        vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
+        _signedRelease(makeAddr("split-recipient-2"), hardLimit / 2, BURN_ID + 1);
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 0, "immutable chain allowance exhausted");
+        assertEq(bridge.availableGlobalSafetyOutflow(), 0, "immutable global allowance exhausted");
+
+        // One second of bucket refill makes the immutable limiter the failing
+        // layer, and `effectiveAvailableOutflow` reports the truth: nothing.
+        vm.warp(block.timestamp + 1);
+        assertGt(bridge.availableOutflow(RGB_CHAIN_ID), 0, "bucket has accrued allowance");
+        assertEq(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), 0, "but nothing may leave");
+
+        (IBridge.FundsOutParams memory third, uint256 nonce, uint256 deadline, uint256 bitmap, bytes[] memory sigs) =
+            _prepareRelease(makeAddr("split-recipient-3"), 1, BURN_ID + 2);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IBridge.ChainSafetyLimitExceeded.selector, RGB_CHAIN_ID, uint256(1), hardLimit, hardLimit
+            )
+        );
+        proxy.fundsOutCall(third, nonce, deadline, bitmap, sigs);
+
+        assertEq(token.balanceOf(address(bridge)), tvl - hardLimit, "at most 20% left during the window");
+
+        // Liveness: once the oldest usage expires the next tranche is releasable.
+        // The ring retains for 24-25h, so 25h past the aligned start clears it.
+        vm.warp(block.timestamp + 25 hours);
+        assertGt(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 0, "allowance returns in the next window");
+        assertGt(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), 0, "releases resume");
+    }
+
+    /// @dev Everything a signed release needs, resolved up front. Kept separate
+    ///      from submission so `vm.expectRevert` can sit immediately before the
+    ///      single `fundsOutCall` — the preparation itself makes external calls
+    ///      and would otherwise absorb the expectation.
+    function _prepareRelease(address to, uint256 amount, uint256 burnId)
+        internal
+        view
+        returns (
+            IBridge.FundsOutParams memory params,
+            uint256 nonce,
+            uint256 deadline,
+            uint256 bitmap,
+            bytes[] memory sigs
+        )
+    {
+        params = _fundsOutParams(to, amount, burnId);
+        nonce = proxy.teeNonce(RGB_CHAIN_ID);
+        deadline = block.timestamp + 1 hours;
+        bytes32 digest = MultisigHelper.digestTeeFundsOut(domainSep, params, nonce, deadline);
+        uint256[] memory pks;
+        (pks, bitmap) = _encSigSet2of3();
+        sigs = MultisigHelper.signAll(vm, digest, pks);
+    }
+
+    /// @dev Sign and submit a `fundsOut` through the enclave 2-of-3 quorum.
+    function _signedRelease(address to, uint256 amount, uint256 burnId) internal {
+        (IBridge.FundsOutParams memory params, uint256 nonce, uint256 deadline, uint256 bitmap, bytes[] memory sigs) =
+            _prepareRelease(to, amount, burnId);
+        proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
+    }
+
+    /// @dev C-01 remaining issue, configuration side: a full-TVL bucket is not
+    ///      merely rejected against current liquidity, it is unrepresentable.
+    ///      The policy is a percentage, and `burstBps + refillBpsPerWindow` is
+    ///      bounded by the immutable `MAX_CHAIN_OUTFLOW_BPS`, so there is no
+    ///      liquidity level at which this proposal would ever succeed.
+    function test_C01_federationCannotConfigureChainBucketForFullTvl() public {
+        uint256 fullTvlBps = bridge.BPS_DENOMINATOR(); // 10_000 bps == 100% of TVL
+        uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
+        uint256 availableBefore = bridge.availableOutflow(RGB_CHAIN_ID);
+
+        bytes memory callData = abi.encodeCall(IBridge.setOutflowLimit, (RGB_CHAIN_ID, fullTvlBps, uint256(1)));
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 digest =
+            MultisigHelper.digestProposeAdminExecute(domainSep, bytes4(callData), callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes32 proposalId =
+            proxy.proposeAdminExecute(callData, nonce, deadline, bitmap, MultisigHelper.signAll(vm, digest, pks));
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        vm.expectRevert(abi.encodeWithSelector(IBridge.InvalidOutflowPolicy.selector, fullTvlBps, uint256(1), maxBps));
+        proxy.executeProposal(proposalId, callData);
+
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), availableBefore, "safe bucket configuration unchanged");
     }
 
     function test_governanceCanRotateEnclaveToUnattestedEOA_currentBehavior() public {

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -27,6 +27,22 @@ import {
 import {MockERC20} from "./mocks/MockERC20.sol";
 import {MockBtcRelay} from "./mocks/MockBtcRelay.sol";
 import {MultisigHelper} from "./mocks/MultisigHelper.sol";
+import {EmergencyPause} from "../script/interact/EmergencyPause.s.sol";
+import {EmergencyUnpause} from "../script/interact/EmergencyUnpause.s.sol";
+
+/// @dev Exposes the exact nonce/digest preparation used by the production
+///      scripts so R-I-09 tests cannot pass against a duplicated implementation.
+contract EmergencyPauseHarness is EmergencyPause {
+    function prepare(MultisigProxy proxy, uint256 deadline) external view returns (uint256 nonce, bytes32 digest) {
+        return _prepareEmergencyPause(proxy, deadline);
+    }
+}
+
+contract EmergencyUnpauseHarness is EmergencyUnpause {
+    function prepare(MultisigProxy proxy, uint256 deadline) external view returns (uint256 nonce, bytes32 digest) {
+        return _prepareEmergencyUnpause(proxy, deadline);
+    }
+}
 
 contract MockOutboundLZAdapter {
     MockERC20 public immutable token;
@@ -223,7 +239,7 @@ contract MultisigProxyTest is Test {
         uint64 currentNonce = vm.getNonce(deployer);
         address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
 
-        cm = new CommissionManager(predictedBridge);
+        cm = new CommissionManager(predictedBridge, commissionReceiver);
         routeRegistry = new RouteRegistry(predictedBridge, deployer);
         bridge = new Bridge(
             address(token),
@@ -251,9 +267,7 @@ contract MultisigProxyTest is Test {
         fed[1] = fedA2;
         fed[2] = fedA3;
 
-        proxy = new MultisigProxy(
-            address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        proxy = new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, TIMELOCK, MIN_TIMELOCK);
 
         // Production-flow ownership transfer.
         bridge.transferOwnership(address(proxy));
@@ -490,9 +504,7 @@ contract MultisigProxyTest is Test {
         address[] memory fed = new address[](1);
         fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroBridge.selector);
-        new MultisigProxy(
-            address(0), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        new MultisigProxy(address(0), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommissionManager() public {
@@ -501,9 +513,7 @@ contract MultisigProxyTest is Test {
         address[] memory fed = new address[](1);
         fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionManager.selector);
-        new MultisigProxy(
-            address(bridge), address(0), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(0), enc, 1, RGB_CHAIN_ID, fed, 1, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnNoEnclaveSigners() public {
@@ -511,9 +521,7 @@ contract MultisigProxyTest is Test {
         address[] memory fed = new address[](1);
         fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.NoSigners.selector);
-        new MultisigProxy(
-            address(bridge), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnBadEnclaveThreshold() public {
@@ -523,40 +531,13 @@ contract MultisigProxyTest is Test {
         address[] memory fed = new address[](1);
         fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(
-            address(bridge), address(cm), enc, 3, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
-    }
-
-    function test_constructor_revertsOnZeroCommission() public {
-        vm.expectRevert(IMultisigProxy.ZeroCommissionRecipient.selector);
-        new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _validEnc(),
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            address(0),
-            TIMELOCK,
-            MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(cm), enc, 3, RGB_CHAIN_ID, fed, 1, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnTimelockTooLong() public {
         vm.expectRevert(IMultisigProxy.TimelockTooLong.selector);
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _validEnc(),
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            30 days,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, 30 days, MIN_TIMELOCK
         );
     }
 
@@ -566,43 +547,19 @@ contract MultisigProxyTest is Test {
     function test_constructor_revertsOnTimelockBelowMinTimelock() public {
         // timelock (1h) is below the requested floor (2h) -> TimelockTooShort
         vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
-        new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _validEnc(),
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            1 hours,
-            2 hours
-        );
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, 1 hours, 2 hours);
     }
 
     /// @dev A zero floor is rejected — it would defeat the purpose of the fix.
     function test_constructor_revertsOnZeroMinTimelock() public {
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(
-            address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, 0
-        );
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, 0);
     }
 
     /// @dev A floor at/above the upper bound leaves no valid range — rejected.
     function test_constructor_revertsOnMinTimelockTooLong() public {
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _validEnc(),
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            30 days
-        );
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, 30 days);
     }
 
     function test_minTimelock_returnsConfiguredFloor() public view {
@@ -616,18 +573,7 @@ contract MultisigProxyTest is Test {
         enc[0] = encA1;
         enc[1] = encA1;
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        new MultisigProxy(
-            address(bridge),
-            address(cm),
-            enc,
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroAddressSigner() public {
@@ -638,18 +584,7 @@ contract MultisigProxyTest is Test {
         enc[0] = address(0);
         enc[1] = encA2;
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        new MultisigProxy(
-            address(bridge),
-            address(cm),
-            enc,
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK);
     }
 
     // ========================================================================
@@ -685,16 +620,7 @@ contract MultisigProxyTest is Test {
     function test_constructor_rejectsOneOfThree_enclave() public {
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(3),
-            1,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(3), 1, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK
         );
     }
 
@@ -702,16 +628,7 @@ contract MultisigProxyTest is Test {
         // n < 2 — single-key set, rejected even though 2*1 > 1.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(1),
-            1,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(1), 1, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK
         );
     }
 
@@ -719,16 +636,7 @@ contract MultisigProxyTest is Test {
         // 2-of-4: 2*2 == 4, not a strict majority.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(4),
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(4), 2, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK
         );
     }
 
@@ -736,31 +644,13 @@ contract MultisigProxyTest is Test {
         // Enclave valid, federation 1-of-3 — the floor applies to both sets.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _validEnc(),
-            2,
-            RGB_CHAIN_ID,
-            _signers(3),
-            1,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _signers(3), 1, TIMELOCK, MIN_TIMELOCK
         );
     }
 
     function test_constructor_acceptsTwoOfTwo() public {
         MultisigProxy p = new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(2),
-            2,
-            RGB_CHAIN_ID,
-            _signersB(2),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(2), 2, RGB_CHAIN_ID, _signersB(2), 2, TIMELOCK, MIN_TIMELOCK
         );
         assertEq(p.enclaveThreshold(RGB_CHAIN_ID), 2);
         assertEq(p.federationThreshold(), 2);
@@ -769,16 +659,7 @@ contract MultisigProxyTest is Test {
     function test_constructor_acceptsThreeOfFour() public {
         // Strict majority with a non-trivial set (2*3 > 4).
         MultisigProxy p = new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(4),
-            3,
-            RGB_CHAIN_ID,
-            _signersB(4),
-            3,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(4), 3, RGB_CHAIN_ID, _signersB(4), 3, TIMELOCK, MIN_TIMELOCK
         );
         assertEq(p.enclaveThreshold(RGB_CHAIN_ID), 3);
         assertEq(p.federationThreshold(), 3);
@@ -925,23 +806,12 @@ contract MultisigProxyTest is Test {
         fed[0] = encA1;
         fed[1] = fedA2;
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, encA1));
-        new MultisigProxy(
-            address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_acceptsDisjointSignerSets() public {
         MultisigProxy p = new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(2),
-            2,
-            RGB_CHAIN_ID,
-            _signersB(2),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(2), 2, RGB_CHAIN_ID, _signersB(2), 2, TIMELOCK, MIN_TIMELOCK
         );
         assertEq(p.getEnclaveSigners(RGB_CHAIN_ID).length, 2);
         assertEq(p.getFederationSigners().length, 2);
@@ -1006,16 +876,7 @@ contract MultisigProxyTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            enc,
-            encThreshold,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), enc, encThreshold, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK
         );
     }
 
@@ -1031,7 +892,6 @@ contract MultisigProxyTest is Test {
             RGB_CHAIN_ID,
             _signersB(max),
             threshold,
-            commissionReceiver,
             TIMELOCK,
             MIN_TIMELOCK
         );
@@ -1426,6 +1286,92 @@ contract MultisigProxyTest is Test {
 
         proxy.emergencyUnpause(nonce, deadline, bitmap, sigs);
         assertFalse(bridge.paused());
+    }
+
+    /// @dev R-I-09 known-answer regression for the production pause script.
+    ///      A regular proposal first advances only `proposalNonce`, reproducing
+    ///      the state in which the old script selected the wrong nonce lane.
+    function test_R_I_09_emergencyPauseScriptUsesEmergencyNonceAfterLanesDiverge() public {
+        uint256 regularNonce = proxy.proposalNonce();
+        uint256 regularDeadline = block.timestamp + 1 days;
+        address newBridge = makeAddr("ri09-pause-regular-proposal");
+        bytes32 regularDigest =
+            MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, regularNonce, regularDeadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        proxy.proposeUpdateBridge(
+            newBridge, regularNonce, regularDeadline, bitmap, MultisigHelper.signAll(vm, regularDigest, pks)
+        );
+
+        assertEq(proxy.proposalNonce(), 1, "regular lane advanced");
+        assertEq(proxy.emergencyNonce(), 0, "emergency lane untouched");
+
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // Negative control: the pre-fix script read proposalNonce(), producing
+        // a correctly signed emergency digest for the wrong nonce.
+        uint256 wrongNonce = proxy.proposalNonce();
+        bytes32 wrongDigest = MultisigHelper.digestEmergencyPause(domainSep, wrongNonce, deadline);
+        vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
+        proxy.emergencyPause(wrongNonce, deadline, bitmap, MultisigHelper.signAll(vm, wrongDigest, pks));
+
+        // Exercise the exact preparation function called by EmergencyPause.run().
+        EmergencyPauseHarness harness = new EmergencyPauseHarness();
+        (uint256 scriptNonce, bytes32 scriptDigest) = harness.prepare(proxy, deadline);
+        bytes32 expectedStructHash =
+            keccak256(abi.encode(keccak256("EmergencyPause(uint256 nonce,uint256 deadline)"), uint256(0), deadline));
+        bytes32 expectedDigest = keccak256(abi.encodePacked("\x19\x01", domainSep, expectedStructHash));
+
+        assertEq(scriptNonce, 0, "script reads emergency lane");
+        assertEq(scriptDigest, expectedDigest, "script produces canonical pause digest");
+
+        proxy.emergencyPause(scriptNonce, deadline, bitmap, MultisigHelper.signAll(vm, scriptDigest, pks));
+
+        assertTrue(bridge.paused(), "emergency pause succeeds");
+        assertEq(proxy.emergencyNonce(), 1, "emergency lane advanced");
+        assertEq(proxy.proposalNonce(), 1, "regular lane unchanged");
+    }
+
+    /// @dev R-I-09 known-answer regression for the production unpause script.
+    ///      Both lanes are deliberately non-equal before digest construction.
+    function test_R_I_09_emergencyUnpauseScriptUsesEmergencyNonceAfterLanesDiverge() public {
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+
+        uint256 pauseNonce = proxy.emergencyNonce();
+        uint256 pauseDeadline = block.timestamp + 1 hours;
+        bytes32 pauseDigest = MultisigHelper.digestEmergencyPause(domainSep, pauseNonce, pauseDeadline);
+        proxy.emergencyPause(pauseNonce, pauseDeadline, bitmap, MultisigHelper.signAll(vm, pauseDigest, pks));
+        assertTrue(bridge.paused(), "precondition: bridge paused");
+
+        // Advance the regular lane twice so proposalNonce=2, emergencyNonce=1.
+        for (uint256 i = 0; i < 2; i++) {
+            uint256 regularNonce = proxy.proposalNonce();
+            uint256 regularDeadline = block.timestamp + 1 days;
+            address newBridge = makeAddr(string.concat("ri09-unpause-regular-proposal-", vm.toString(i)));
+            bytes32 regularDigest =
+                MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, regularNonce, regularDeadline);
+            proxy.proposeUpdateBridge(
+                newBridge, regularNonce, regularDeadline, bitmap, MultisigHelper.signAll(vm, regularDigest, pks)
+            );
+        }
+
+        assertEq(proxy.proposalNonce(), 2, "regular lane advanced independently");
+        assertEq(proxy.emergencyNonce(), 1, "pause advanced emergency lane once");
+
+        uint256 deadline = block.timestamp + 1 hours;
+        EmergencyUnpauseHarness harness = new EmergencyUnpauseHarness();
+        (uint256 scriptNonce, bytes32 scriptDigest) = harness.prepare(proxy, deadline);
+        bytes32 expectedStructHash =
+            keccak256(abi.encode(keccak256("EmergencyUnpause(uint256 nonce,uint256 deadline)"), uint256(1), deadline));
+        bytes32 expectedDigest = keccak256(abi.encodePacked("\x19\x01", domainSep, expectedStructHash));
+
+        assertEq(scriptNonce, 1, "script reads emergency lane");
+        assertEq(scriptDigest, expectedDigest, "script produces canonical unpause digest");
+
+        proxy.emergencyUnpause(scriptNonce, deadline, bitmap, MultisigHelper.signAll(vm, scriptDigest, pks));
+
+        assertFalse(bridge.paused(), "emergency unpause succeeds");
+        assertEq(proxy.emergencyNonce(), 2, "emergency lane advanced");
+        assertEq(proxy.proposalNonce(), 2, "regular lane unchanged");
     }
 
     // ========================================================================
@@ -3227,22 +3173,14 @@ contract MultisigProxyTest is Test {
         assertEq(routeRegistry.pendingOwner(), newOwner, "RR transfer started via new op");
     }
 
-    // The typed commission-withdraw path pins the recipient to
-    // commissionRecipient, while generic CM admin execution forwards arbitrary
-    // calldata and lets the encoded withdrawal recipient win.
-    // R-W-15 after-fix: the generic AdminExecuteCommissionManager path can no
-    // longer reach a commission-withdrawal selector, so it cannot re-point
-    // commission away from the pinned `commissionRecipient`. The guard fires at
-    // propose time (before signature verification), so no valid federation
-    // signatures are needed to observe it.
+    // Standard CM withdrawals stay on the dedicated typed operations. Recipient
+    // safety no longer depends on this blocklist: CM enforces it immutably.
     function test_adminExecuteCommissionManager_rejectsWithdrawSelectors_afterFix() public {
         bytes[] memory callDatas = new bytes[](4);
-        callDatas[0] = abi.encodeWithSignature(
-            "withdrawTokenCommission(address,address,uint256)", address(token), user, uint256(1)
-        );
-        callDatas[1] = abi.encodeWithSignature("withdrawNativeCommission(address,uint256)", user, uint256(1));
-        callDatas[2] = abi.encodeWithSignature("withdrawAllTokenCommission(address,address)", address(token), user);
-        callDatas[3] = abi.encodeWithSignature("withdrawAllNativeCommission(address)", user);
+        callDatas[0] = abi.encodeWithSignature("withdrawTokenCommission(address,uint256)", address(token), uint256(1));
+        callDatas[1] = abi.encodeWithSignature("withdrawNativeCommission(uint256)", uint256(1));
+        callDatas[2] = abi.encodeWithSignature("withdrawAllTokenCommission(address)", address(token));
+        callDatas[3] = abi.encodeWithSignature("withdrawAllNativeCommission()");
 
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
@@ -3256,8 +3194,46 @@ contract MultisigProxyTest is Test {
         }
     }
 
-    // The generic path stays open for non-withdrawal CommissionManager setters.
-    function test_adminExecuteCommissionManager_allowsNonWithdrawSelector() public {
+    // R-W-15 / alternate-target regression: even if governance aliases the LZ
+    // adapter target to CM and transfers CM ownership through that unfiltered
+    // raw-call path, the new owner cannot choose a withdrawal recipient. The
+    // asset layer always sends commission to CM's immutable recipient.
+    function test_R_W_15_adapterAliasTransferredOwnerCannotRedirectCommission() public {
+        _setLzAdapter(address(cm));
+
+        uint256 amount = 10 ether;
+        token.mint(address(cm), amount);
+        vm.prank(address(bridge));
+        cm.receiveTokenCommission(address(token), amount);
+
+        bytes memory callData = abi.encodeWithSignature("transferOwnership(address)", user);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest =
+            MultisigHelper.digestProposeAdminExecuteAdapter(domainSep, bytes4(callData), callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, callData);
+
+        vm.prank(user);
+        cm.acceptOwnership();
+        assertEq(cm.owner(), user, "governed CM ownership migration still works");
+
+        uint256 pinnedBefore = token.balanceOf(commissionReceiver);
+        uint256 attackerBefore = token.balanceOf(user);
+        vm.prank(user);
+        cm.withdrawTokenCommission(address(token), amount);
+
+        assertEq(token.balanceOf(commissionReceiver), pinnedBefore + amount, "immutable recipient paid");
+        assertEq(token.balanceOf(user), attackerBefore, "new owner cannot redirect commission to itself");
+        assertEq(proxy.commissionRecipient(), commissionReceiver, "proxy reports CM's immutable recipient");
+    }
+
+    // The generic path stays open for permitted CommissionManager setters.
+    function test_adminExecuteCommissionManager_allowsConfigSelector() public {
         bytes memory callData = abi.encodeWithSignature(
             "setGlobalDefaults(uint256,uint8,uint8,uint8)", uint256(0), uint8(100), uint8(0), uint8(0)
         );
@@ -3269,7 +3245,22 @@ contract MultisigProxyTest is Test {
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         bytes32 id = proxy.proposeAdminExecuteCommissionManager(callData, nonce, deadline, bitmap, sigs);
-        assertTrue(id != bytes32(0), "non-withdrawal CM selector accepted on the generic path");
+        assertTrue(id != bytes32(0), "CM config selector accepted on the generic path");
+    }
+
+    // Deployment compatibility: the deployer initiates CM's Ownable2Step handoff
+    // directly, then the proxy must be able to propose acceptOwnership().
+    function test_adminExecuteCommissionManager_allowsAcceptOwnershipSelector() public {
+        bytes memory callData = abi.encodeWithSignature("acceptOwnership()");
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest =
+            MultisigHelper.digestProposeAdminExecuteCM(domainSep, bytes4(callData), callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteCommissionManager(callData, nonce, deadline, bitmap, sigs);
+        assertTrue(id != bytes32(0), "CM acceptOwnership selector accepted on the generic path");
     }
 
     // ========================================================================
@@ -3627,7 +3618,7 @@ contract MultisigProxyTest is Test {
         address[] memory enc = _validEnc();
         address[] memory fed = _validFed();
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(0)));
-        new MultisigProxy(address(bridge), address(cm), enc, 2, 0, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, 0, fed, 2, TIMELOCK, MIN_TIMELOCK);
     }
 
     /// @dev ...and rejected up front by proposeUpdateEnclaveSigners (before sigs).

--- a/ethereum/test/RollingOutflowLimiter.t.sol
+++ b/ethereum/test/RollingOutflowLimiter.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import {Test} from "forge-std/Test.sol";
+
+import {RollingOutflowLimiterHarness} from "./mocks/RollingOutflowLimiterHarness.sol";
+
+contract RollingOutflowLimiterTest is Test {
+    RollingOutflowLimiterHarness harness;
+
+    function setUp() public {
+        harness = new RollingOutflowLimiterHarness();
+        vm.warp(1_000_000);
+    }
+
+    function test_current_startsAtZero() public view {
+        assertEq(harness.current(), 0);
+    }
+
+    function test_consume_accumulatesWithinOneSlot() public {
+        assertEq(harness.consume(10), 10);
+        assertEq(harness.consume(15), 25);
+        assertEq(harness.current(), 25);
+    }
+
+    function test_usageDoesNotExpireBeforeFull24Hours() public {
+        uint256 start = block.timestamp;
+        harness.consume(100);
+
+        vm.warp(start + 24 hours);
+        assertEq(harness.current(), 100, "hour-slot rounding must never expire usage early");
+    }
+
+    function test_usageExpiresAfterConservative25HourBound() public {
+        harness.consume(100);
+
+        vm.warp(block.timestamp + 25 hours);
+        assertEq(harness.current(), 0);
+        assertEq(harness.consume(7), 7, "stale ring state cleared before new usage");
+    }
+
+    function test_rollingExpiryRemovesOnlyExpiredSlots() public {
+        harness.consume(10);
+        vm.warp(block.timestamp + 10 hours);
+        harness.consume(20);
+        vm.warp(block.timestamp + 15 hours);
+
+        assertEq(harness.current(), 20, "old slot expired while newer slot remains");
+        assertEq(harness.consume(5), 25);
+    }
+
+    function testFuzz_currentEqualsSumOfNonExpiredSlots(uint128 a, uint128 b, uint128 c) public {
+        a = uint128(bound(a, 0, type(uint96).max));
+        b = uint128(bound(b, 0, type(uint96).max));
+        c = uint128(bound(c, 0, type(uint96).max));
+
+        harness.consume(a);
+        vm.warp(block.timestamp + 5 hours);
+        harness.consume(b);
+        vm.warp(block.timestamp + 20 hours);
+
+        assertEq(harness.current(), b, "first slot expired at 25 epochs");
+
+        harness.consume(c);
+        assertEq(harness.current(), uint256(b) + uint256(c));
+    }
+}

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -49,9 +49,6 @@ library MultisigHelper {
     bytes32 internal constant PROPOSE_UPDATE_BRIDGE_TYPEHASH =
         keccak256("ProposeUpdateBridge(address newBridge,uint256 nonce,uint256 deadline)");
 
-    bytes32 internal constant PROPOSE_SET_COMMISSION_RECIPIENT_TYPEHASH =
-        keccak256("ProposeSetCommissionRecipient(address newRecipient,uint256 nonce,uint256 deadline)");
-
     bytes32 internal constant PROPOSE_SET_TIMELOCK_DURATION_TYPEHASH =
         keccak256("ProposeSetTimelockDuration(uint256 newDuration,uint256 nonce,uint256 deadline)");
 

--- a/ethereum/test/mocks/RollingOutflowLimiterHarness.sol
+++ b/ethereum/test/mocks/RollingOutflowLimiterHarness.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import {RollingOutflowLimiter} from "../../src/libraries/RollingOutflowLimiter.sol";
+
+/// @title RollingOutflowLimiterHarness
+/// @notice External wrapper for isolated rolling-window unit tests.
+contract RollingOutflowLimiterHarness {
+    using RollingOutflowLimiter for RollingOutflowLimiter.Window;
+
+    RollingOutflowLimiter.Window private _window;
+
+    function consume(uint256 amount) external returns (uint256) {
+        return _window.consume(amount);
+    }
+
+    function current() external view returns (uint256) {
+        return _window.current();
+    }
+}


### PR DESCRIPTION
## Summary

Completes audit finding **R-C-01**. PR #76 introduced isolated per-chain liquidity accounting and the two-tier outflow token bucket; the re-audit found that the bucket alone was not a sufficient security boundary, because the federation could configure it at or above TVL and a single enclave-signed release could still drain the pool.

This PR adds a non-configurable ceiling underneath the bucket, and converts the bucket itself from absolute token units to percentages of liquidity.

### 1. A second layer the federation cannot touch

`MAX_CHAIN_OUTFLOW_BPS` and `MAX_GLOBAL_OUTFLOW_BPS` (2000 = 20%) are compile-time constants with no setter, enforced on every release by a bounded rolling-window limiter that retains usage for 24. `Bridge` is not upgradeable, so these cannot be raised, disabled or shortened by governance or by the enclave lane.

In PR #76 the token bucket was the only constraint on release velocity, and its parameters were fully federation-controlled. Now the bucket can only ever be *stricter* than this ceiling.

A new `totalLockedLiquidity` accumulator gives the aggregate scope a real denominator; direct token donations are deliberately excluded so they cannot inflate it.

### 2. The bucket is now relative instead of absolute

    setOutflowLimit(chainId, burstBps, refillBpsPerWindow)
    setGlobalOutflowLimit(burstBps, refillBpsPerWindow)

Allowance is held in shares of reference liquidity (`SHARE_UNIT` = 100%) rather than token units. Three consequences:

- **Validation no longer touches TVL** — both values non-zero, sum at most `MAX_*_OUTFLOW_BPS`. A percentage is well-formed without a reference, so a policy is installable before the first deposit, and there is no liquidity level at which a full-TVL policy would be accepted. Under PR #76 an absolute capacity could only be sized sensibly once a pool existed, and any attempt to bound it against current TVL is unsatisfiable at zero liquidity (20% of 0 is 0, while the limiter requires a non-zero capacity).
- **The same policy follows liquidity.** 5% is 5k at 100k TVL and 50k at 1M TVL, with no governance transaction. Under PR #76 every significant liquidity change left the absolute cap wrong in one direction or the other.
- **Both layers share one denominator** — `pre-debit liquidity + usage still counted in the rolling window` — computed once per release. PR #76's bucket had no notion of a reference at all, so there was nothing tying the configured cap to the size of the pool it was protecting.

Amount-to-share conversion rounds up, so a release is never cheaper in shares than its true fraction and dust cannot pass for free. The windows charge the **gross** amount, i.e. recipient payout plus token commission, since both leave custody.

Because shares are TVL-independent, the reference snapshots, TVL-change clamps, capacity-increase rules and fractional refill remainder that a relative-but-absolute-storage design would require do not exist. `OutflowRateLimiter` is functionally unchanged from PR #76 (one docstring noting the integration's unit is now shares).

### 3. Views that answer the real question

- `chainOutflowReference(chainId)` / `globalOutflowReference()` — the denominator every percentage is measured against.
- `effectiveAvailableOutflow(chainId)` — `min` of isolated liquidity, both buckets and both immutable allowances.

PR #76 exposed only `availableOutflow` / `availableGlobalOutflow`, which report a single bucket and therefore overstate what may actually leave.

