### PR TITLE
fix(I-09): sign emergency ops with the emergency nonce lane

### DIFF
--- a/ethereum/.env.deploy.example
+++ b/ethereum/.env.deploy.example
@@ -68,24 +68,19 @@ ETH_USD_FEED=
 # 87000 leaves ~10 min slack).
 ETH_USD_HEARTBEAT=87000
 
-# --- Arbitrum Chainlink robustness (optional) ---
+# --- Arbitrum Chainlink robustness ---
 
-# Chainlink L2 Sequencer Uptime feed. When set, NATIVE quotes are rejected while
-# the sequencer is down and for the 3600 s grace period after a restart. Set on
-# Arbitrum whenever NATIVE commission is used; leave blank on non-L2 / tests.
+# Chainlink L2 Sequencer Uptime feed. Required whenever ETH_USD_FEED enables the
+# NATIVE commission path. Quotes are rejected while the sequencer is down and
+# for the 3600 s grace period after a restart.
 #   Arbitrum One  Sequencer Uptime  0xFdB631F5EE196F0ed6FAa767959853A9F217697D
 SEQUENCER_UPTIME_FEED=
 
-# Optional ETH/USD sanity band (circuit breaker), in the feed's decimals
-# (ETH/USD = 8). Set BOTH or NEITHER (else the deploy reverts); 0 < min < max.
+# ETH/USD sanity band (circuit breaker), in the feed's decimals (ETH/USD = 8).
+# Required whenever ETH_USD_FEED is set; configure BOTH values with 0 < min < max.
 # Example for an 8-decimal feed: $100 = 10000000000, $100k = 10000000000000.
 ETH_USD_MIN_PRICE=
 ETH_USD_MAX_PRICE=
-
-# When true, the deploy reverts unless ETH_USD_FEED, SEQUENCER_UPTIME_FEED, and
-# the price band are ALL set. Recommend =true for Arbitrum production so the
-# R-I-14 guards can never be silently absent; leave false for non-L2 / tests.
-REQUIRE_CHAINLINK_HARDENING=false
 
 # -----------------------------------------------------------------------------
 # MultisigProxy
@@ -103,7 +98,9 @@ FEDERATION_SIGNERS=
 ENCLAVE_THRESHOLD=2
 FEDERATION_THRESHOLD=2
 
-# Where withdrawTokenCommission() / withdrawNativeCommission() send funds.
+# Immutable CommissionManager withdrawal destination. Changing it requires a
+# new CommissionManager deployment (and, because Bridge pins CM immutably, a
+# coordinated Bridge migration).
 COMMISSION_RECIPIENT=
 
 # Timelock between propose and execute for federation proposals (seconds).

--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -29,10 +29,10 @@ Production bridge for UTEXO. Inherits `BridgeBase`, implements `IBridge`. Route-
 
 Constructor takes four addresses: the accepted ERC-20 token (immutable), the `RouteRegistry` (mutable — federation can rotate via `UpdateRouteRegistry`), the `CommissionManager` (immutable), and the initial LayerZero adapter (mutable; `address(0)` is allowed — wire it in later via federation governance). The bridge's own chain identifier is `block.chainid` — chain IDs are `uint256` throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
 
-- `fundsIn(amount, destinationChainId, destinationAddress, operationId, settlementData)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must equal the quoted native commission. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and dispatches to the route's `SettlementModule.onFundsIn(...)` via `RouteRegistry`. The `settlementData` blob is opaque to the bridge — its layout is dictated by the destination route's settlement module (empty for routes that don't consume extra data on inbound, e.g. RGB). Emits two events:
+- `fundsIn(amount, destinationChainId, destinationAddress, settlementData)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must be between the fresh quote and 5% above it. Exactly the fresh quote is collected and any surplus is refunded to the caller. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and dispatches to the route's `SettlementModule.onFundsIn(...)` via `RouteRegistry`. The `settlementData` blob is opaque to the bridge — its layout is dictated by the destination route's settlement module (empty for routes that don't consume extra data on inbound, e.g. RGB). Emits two events:
   - `FundsIn` (from `BridgeBase`) — minimal, uses `netAmount`.
   - `BridgeFundsIn` (from `IBridge`) — full, consumed by the UTEXO backend.
-- `fundsIn(amount, sourceChainId, destinationChainId, destinationAddress, operationId, settlementData)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating `msg.sender` on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` to the bridge. Otherwise identical semantics to `fundsIn`.
+- `fundsIn(amount, sourceChainId, sourceSender, destinationChainId, destinationAddress, settlementData)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating sender on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` and `sourceSender` to the bridge. For NATIVE commission routes, the source-agreed `msg.value` must remain within the immutable ±5% band around the fresh destination quote. Cross-domain refunds are deliberately unsupported, so the complete accepted value is collected as commission.
 - `setLZAdapter(adapter)` — `onlyOwner`. Rotates the address authorized to call the adapter overload. Set to `address(0)` to close the adapter path entirely.
 - `setRouteRegistry(newRouteRegistry)` — `onlyOwner`. Rotates the `RouteRegistry` Bridge talks to. Used to migrate to a redeployed registry (the registry's `bridge` is immutable, so a new registry deploy is the only way to rotate). Reverts on `address(0)`.
 - `fundsOut(recipient, amount, burnId, sourceChainId, destChainId, sourceAddress, proof, settlementData)` — `onlyOwner`, called via `MultisigProxy.execute()` or `MultisigProxy.executeBatch()`. The four scalar amounts (`amount`, `burnId`, `sourceChainId`, `destChainId`) are `uint256`; `recipient` is an address; `sourceAddress` is a string; `proof` and `settlementData` are opaque `bytes` blobs whose layouts are dictated by the route's `FinalityVerifier` and `SettlementModule` respectively. Checks `burnId` has not been consumed yet (single-use replay guard, marks it consumed before any external interaction), calls `RouteRegistry.beforeFundsOut(...)` which routes into `FinalityVerifier.verify(proof)` and `SettlementModule.beforeFundsOut(settlementData, amount)`, quotes commission from `CommissionManager` using `(sourceChainId, destChainId, TOKEN)`, forwards any token commission to the pool, and releases `netAmount` to the recipient. Emits `BridgeFundsOut`. NATIVE commission on `fundsOut` is disallowed (the caller is the multisig, not a user) — the contract reverts `NativeCommissionNotAllowedOnFundsOut`.
@@ -76,7 +76,7 @@ Standalone fee contract. Holds protocol commissions separately from bridge liqui
 - **Config** selects per route: `side` (`FUNDS_IN` vs `FUNDS_OUT`), `currency` (`TOKEN` vs `NATIVE`), `stablePercent` (×100, capped at 9000 = 90%), and `multiplier`. Global defaults apply to any route without an override.
 - **NATIVE quotes** use a Chainlink ETH/USD aggregator (`setEthUsdFeed(feed, heartbeat)`) and the token's `decimals()`. Heartbeat enforces staleness; absent feed ⇒ NATIVE quotes revert.
 - **Ingress:** `receiveTokenCommission(token)` and `receive()` are gated by `onlyBridge` — only `Bridge` may credit commissions. Pools are updated from balance deltas, so fee-on-transfer tokens are supported.
-- **Owner** (`MultisigProxy` in production) configures rules, updates `bridgeAddress`, wires the ETH/USD feed, and withdraws accumulated pools. `renounceOwnership` is blocked.
+- **Owner** (`MultisigProxy` in production) configures rules, updates `bridgeAddress`, wires the ETH/USD feed, and withdraws accumulated pools. Every token/native withdrawal pays the immutable constructor-configured `commissionRecipient`; withdrawal functions do not accept a free recipient. `renounceOwnership` is blocked.
 
 ### MultisigProxy (`src/MultisigProxy.sol`)
 
@@ -93,12 +93,11 @@ Federation-controlled operations (`OperationType`):
 | `UpdateEnclaveSigners` | self | Rotate TEE signer set / threshold |
 | `UpdateFederationSigners` | self | Rotate federation signer set / threshold |
 | `UpdateBridge` | self | Migrate to a redeployed Bridge |
-| `SetCommissionRecipient` | self | Change destination address for CM withdrawals |
 | `SetTeeAllowedCall` | self | Add/remove a `(target, selector)` pair from the TEE allowlist |
 | `SetTimelockDuration` | self | Adjust the timelock window |
 | `AdminExecuteCommissionManager` | CommissionManager | Generic call into CM (route rules, global defaults, ETH/USD feed, `transferOwnership`, …) |
-| `WithdrawTokenCommissionCM` | CommissionManager | Withdraw ERC-20 commission to `commissionRecipient` |
-| `WithdrawNativeCommissionCM` | CommissionManager | Withdraw native commission to `commissionRecipient` |
+| `WithdrawTokenCommissionCM` | CommissionManager | Withdraw ERC-20 commission to CM's immutable `commissionRecipient` |
+| `WithdrawNativeCommissionCM` | CommissionManager | Withdraw native commission to CM's immutable `commissionRecipient` |
 | `UpdateCommissionManager` | self | Migrate to a redeployed CommissionManager |
 | `AdminExecuteAdapter` | LZAdapter | Generic call into the registered LayerZero adapter (`setTrustedEntrypoint`, `refundStuckFunds`, …). Reverts `ZeroTarget` if `MultisigProxy.lzAdapter` is unset. |
 | `UpdateLZAdapter` | self | Rotate `MultisigProxy.lzAdapter` — the routing target for `AdminExecuteAdapter`. Setting to `address(0)` closes the adapter-admin path. |
@@ -182,7 +181,7 @@ set -a && source .env.interact && set +a   # before interact scripts
 - `LZ_ADAPTER` — initial LayerZero adapter address (optional; pass `0x0` if the adapter has not been deployed yet, then wire it in via federation governance after the adapter ships)
 - `ROUTE_REGISTRY_ADDRESS` — `RouteRegistry` address (step-by-step Bridge redeploys only; `DeployAll` predicts it)
 - `COMMISSION_MANAGER` — `CommissionManager` address (step-by-step deploys only)
-- `COMMISSION_RECIPIENT` — destination for CM withdrawals
+- `COMMISSION_RECIPIENT` — immutable destination for every CM withdrawal; choose a long-lived treasury address
 - `ETH_USD_FEED` / `ETH_USD_HEARTBEAT` — Chainlink ETH/USD aggregator + staleness window (required if any route uses NATIVE commission)
 - `ENCLAVE_SIGNERS` / `FEDERATION_SIGNERS` — comma-separated addresses, ordered by bitmap bit index
 - `ENCLAVE_THRESHOLD` / `FEDERATION_THRESHOLD` — M-of-N thresholds
@@ -214,7 +213,7 @@ forge script script/deploy/DeployAll.s.sol \
 
 Predicts the Bridge address from the deployer's future nonce, deploys in order:
 
-1. `CommissionManager` (pinned to the predicted Bridge)
+1. `CommissionManager` (pinned to the predicted Bridge and immutable commission recipient)
 2. `RouteRegistry` (pinned to the predicted Bridge, deployer-owned for this batch)
 3. `Bridge` (with the live `RouteRegistry` + `CommissionManager`)
 4. `RGBVerifier` (wraps the BtcRelay)
@@ -276,16 +275,17 @@ forge script script/interact/BridgeFundsIn.s.sol --rpc-url $RPC_URL --broadcast
 1. Verify Bridge ownership: `Bridge.owner()` returns the `MultisigProxy` address.
 2. Verify RouteRegistry ownership: `RouteRegistry.owner()` returns the `MultisigProxy` address.
 3. Verify CommissionManager ownership: `CommissionManager.owner()` returns the `MultisigProxy` address.
-4. Verify Bridge ↔ Registry linkage: `Bridge.routeRegistry()` returns the live `RouteRegistry`; `RouteRegistry.bridge()` returns the live `Bridge`.
-5. Verify Bridge ↔ CM linkage: `CommissionManager.bridgeAddress()` returns the live `Bridge`; `Bridge.commissionManager()` returns the live `CommissionManager`.
-6. Verify LZ adapter wiring: `Bridge.lzAdapter()` and `MultisigProxy.lzAdapter()` both return `address(0)` immediately after deploy. Once the adapter is live, federation must run two timelocked proposals:
+4. Verify immutable commission destination: `CommissionManager.commissionRecipient()` returns the intended treasury.
+5. Verify Bridge ↔ Registry linkage: `Bridge.routeRegistry()` returns the live `RouteRegistry`; `RouteRegistry.bridge()` returns the live `Bridge`.
+6. Verify Bridge ↔ CM linkage: `CommissionManager.bridgeAddress()` returns the live `Bridge`; `Bridge.commissionManager()` returns the live `CommissionManager`.
+7. Verify LZ adapter wiring: `Bridge.lzAdapter()` and `MultisigProxy.lzAdapter()` both return `address(0)` immediately after deploy. Once the adapter is live, federation must run two timelocked proposals:
    - `proposeAdminExecute` on the proxy with calldata `Bridge.setLZAdapter(adapter)` — opens the adapter `fundsIn` data path.
    - `proposeUpdateLZAdapter(adapter)` — opens the `AdminExecuteAdapter` governance path on the proxy.
-7. Verify enclave signers: `MultisigProxy.getEnclaveSigners()` returns the TEE addresses.
-8. Verify federation signers: `MultisigProxy.getFederationSigners()` returns the governance addresses.
-9. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` for the 8-arg `fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)` selector.
-10. **Register routes.** For each supported `(sourceChainId, destChainId)` pair, federation runs `MultisigProposeSetRoute` and — after the timelock — `executeProposal` with the printed `opData`. Verify with `RouteRegistry.routes(src, dst)` that the entry is `enabled` and the plugin addresses match.
-11. Test `fundsIn` with a small amount (zero commission by default) on a registered route to confirm token transfer and event emission.
+8. Verify enclave signers: `MultisigProxy.getEnclaveSigners()` returns the TEE addresses.
+9. Verify federation signers: `MultisigProxy.getFederationSigners()` returns the governance addresses.
+10. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` for the 8-arg `fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)` selector.
+11. **Register routes.** For each supported `(sourceChainId, destChainId)` pair, federation runs `MultisigProposeSetRoute` and — after the timelock — `executeProposal` with the printed `opData`. Verify with `RouteRegistry.routes(src, dst)` that the entry is `enabled` and the plugin addresses match.
+12. Test `fundsIn` with a small amount (zero commission by default) on a registered route to confirm token transfer and event emission.
 
 ## Project structure
 

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -70,17 +70,12 @@ import {RgbOutboundSettlementModule} from "../../src/settlement/RgbOutboundSettl
 ///                       (freshness) block; must be >= 1.
 ///   MIN_CONFIRMATION_GAP     (5) — RGBVerifier: min depth gap between the
 ///                       source and latest blocks.
-///   SEQUENCER_UPTIME_FEED — (Arbitrum, R-I-14) Chainlink L2 Sequencer Uptime
-///                       feed. When set, NATIVE quotes reject prices during
-///                       sequencer downtime and the post-restart grace period.
-///                       SHOULD be set on Arbitrum when NATIVE commission is used.
-///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — (R-I-14) optional ETH/USD sanity
-///                       band in feed decimals (e.g. 100e8 / 100000e8). Set both
-///                       or neither; else 0 < min < max.
-///   REQUIRE_CHAINLINK_HARDENING (false) — when true, the deploy reverts unless
-///                       ETH_USD_FEED, SEQUENCER_UPTIME_FEED, and the price band
-///                       are all set. Recommended for Arbitrum production so the
-///                       R-I-14 guards can never be silently absent.
+///   SEQUENCER_UPTIME_FEED — Required whenever ETH_USD_FEED is set. Chainlink
+///                       Arbitrum L2 Sequencer Uptime feed used to reject NATIVE
+///                       quotes during downtime and the post-restart grace.
+///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — Required whenever ETH_USD_FEED is
+///                       set. ETH/USD sanity band in feed decimals
+///                       (e.g. 100e8 / 100000e8).
 ///
 /// Usage:
 ///   forge script script/deploy/DeployAll.s.sol \
@@ -122,7 +117,6 @@ contract DeployAll is Script {
         address seqFeed = vm.envOr("SEQUENCER_UPTIME_FEED", address(0));
         uint256 ethUsdMinPrice = vm.envOr("ETH_USD_MIN_PRICE", uint256(0));
         uint256 ethUsdMaxPrice = vm.envOr("ETH_USD_MAX_PRICE", uint256(0));
-        bool reqHardening = vm.envOr("REQUIRE_CHAINLINK_HARDENING", false);
         uint256 initialChainBurstBps = vm.envUint("INITIAL_CHAIN_BURST_BPS");
         uint256 initialChainRefillBps = vm.envUint("INITIAL_CHAIN_REFILL_BPS_PER_WINDOW");
         uint256 globalBurstBps = vm.envUint("GLOBAL_BURST_BPS");
@@ -135,11 +129,11 @@ contract DeployAll is Script {
             (ethUsdMinPrice == 0) == (ethUsdMaxPrice == 0),
             "set both ETH_USD_MIN_PRICE and ETH_USD_MAX_PRICE, or neither"
         );
-        // Opt-in prod guard (set REQUIRE_CHAINLINK_HARDENING=true for Arbitrum):
-        // when NATIVE commission is enabled, the sequencer feed and price band
-        // must be wired too, so the R-I-14 protections are not silently absent.
-        if (reqHardening) {
-            require(ethUsdFeed != address(0), "hardening: ETH_USD_FEED must be set");
+        require(ethUsdMaxPrice == 0 || ethUsdMinPrice < ethUsdMaxPrice, "ETH_USD_MIN_PRICE must be below MAX");
+        // R-I-14: enabling the NATIVE oracle path requires the full Arbitrum
+        // hardening configuration. There is no production opt-out.
+        if (ethUsdFeed != address(0)) {
+            require(ethUsdHb != 0, "ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided");
             require(seqFeed != address(0), "hardening: SEQUENCER_UPTIME_FEED must be set");
             require(ethUsdMaxPrice != 0, "hardening: ETH_USD_MIN/MAX_PRICE must be set");
         }
@@ -157,7 +151,7 @@ contract DeployAll is Script {
         vm.startBroadcast(pk);
 
         // ---- 2. CommissionManager (nonce n) ------------------------------
-        cm = new CommissionManager(predictedBridge);
+        cm = new CommissionManager(predictedBridge, commission);
 
         // ---- 3. RouteRegistry (nonce n+1) --------------------------------
         // Owned by `deployer` for this batch; transferred to the proxy below
@@ -182,7 +176,7 @@ contract DeployAll is Script {
 
         // ---- 6. MultisigProxy (nonce n+7) --------------------------------
         proxy = new MultisigProxy(
-            address(bridge), address(cm), enc, encThr, initialSrcChain, fed, fedThr, commission, timelock, minTimelock
+            address(bridge), address(cm), enc, encThr, initialSrcChain, fed, fedThr, timelock, minTimelock
         );
 
         // ---- 7. Install initial outflow policies before ownership transfer -
@@ -193,21 +187,15 @@ contract DeployAll is Script {
         bridge.setOutflowLimit(initialSrcChain, initialChainBurstBps, initialChainRefillBps);
         bridge.setGlobalOutflowLimit(globalBurstBps, globalRefillBps);
 
-        // ---- 8. Wire optional ETH/USD feed before CM ownership transfer --
-        if (ethUsdFeed != address(0)) {
-            require(ethUsdHb != 0, "ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided");
-            cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
-        }
-
-        // ---- 8b. Wire optional R-I-14 Arbitrum hardening (owner-only, before
-        //          the ownership transfer): the L2 sequencer-uptime feed and the
-        //          ETH/USD sanity band. On Arbitrum these SHOULD be set whenever
-        //          the NATIVE commission path (ETH_USD_FEED) is used.
+        // ---- 8. Wire R-I-14 dependencies before enabling ETH/USD quotes ----
         if (seqFeed != address(0)) {
             cm.setSequencerUptimeFeed(seqFeed);
         }
         if (ethUsdMaxPrice != 0) {
             cm.setEthUsdPriceBounds(ethUsdMinPrice, ethUsdMaxPrice);
+        }
+        if (ethUsdFeed != address(0)) {
+            cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
         }
 
         // ---- 9. Start two-step ownership handover to federation ----------
@@ -223,6 +211,7 @@ contract DeployAll is Script {
 
         // ---- 10. Summary -------------------------------------------------
         console2.log("CommissionManager deployed at:  ", address(cm));
+        console2.log("Immutable commission recipient:", cm.commissionRecipient());
         console2.log("RouteRegistry deployed at:      ", address(routeRegistry));
         console2.log("Bridge deployed at:             ", address(bridge));
         console2.log("RGBVerifier deployed at:        ", address(rgbVerifier));

--- a/ethereum/script/deploy/DeployCommissionManager.s.sol
+++ b/ethereum/script/deploy/DeployCommissionManager.s.sol
@@ -10,6 +10,7 @@ import {CommissionManager} from "../../src/CommissionManager.sol";
 /// Env:
 ///   PRIVATE_KEY       — deployer private key (becomes CM owner; transfer to multisig afterwards)
 ///   BRIDGE_ADDRESS    — Bridge contract that will send commissions (non-zero)
+///   COMMISSION_RECIPIENT — immutable destination for every commission withdrawal
 ///
 ///   ETH_USD_FEED      — Optional Chainlink ETH/USD aggregator address. When
 ///                       supplied (non-zero) the script also calls
@@ -21,14 +22,11 @@ import {CommissionManager} from "../../src/CommissionManager.sol";
 ///                       the feed answer is considered stale. Arbitrum One
 ///                       ETH/USD heartbeats at 86400 s — use ~87000 with a
 ///                       small buffer.
-///   SEQUENCER_UPTIME_FEED — Optional (Arbitrum, R-I-14) Chainlink L2 Sequencer
-///                       Uptime feed. When set, NATIVE quotes reject prices
-///                       during sequencer downtime + the post-restart grace.
-///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — Optional (R-I-14) ETH/USD sanity
-///                       band in feed decimals; set both or neither.
-///   REQUIRE_CHAINLINK_HARDENING (false) — when true, revert unless ETH_USD_FEED,
-///                       SEQUENCER_UPTIME_FEED, and the price band are all set
-///                       (recommended for Arbitrum production).
+///   SEQUENCER_UPTIME_FEED — Required whenever ETH_USD_FEED is set. Chainlink
+///                       Arbitrum L2 Sequencer Uptime feed used to reject NATIVE
+///                       quotes during downtime + the post-restart grace period.
+///   ETH_USD_MIN_PRICE / ETH_USD_MAX_PRICE — Required whenever ETH_USD_FEED is
+///                       set. ETH/USD sanity band in the price feed's decimals.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployCommissionManager.s.sol \
@@ -37,43 +35,44 @@ contract DeployCommissionManager is Script {
     function run() external returns (CommissionManager cm) {
         uint256 pk = vm.envUint("PRIVATE_KEY");
         address bridgeAddress = vm.envAddress("BRIDGE_ADDRESS");
+        address commissionRecipient = vm.envAddress("COMMISSION_RECIPIENT");
         address ethUsdFeed = vm.envOr("ETH_USD_FEED", address(0));
         uint256 ethUsdHb = vm.envOr("ETH_USD_HEARTBEAT", uint256(0));
         address seqFeed = vm.envOr("SEQUENCER_UPTIME_FEED", address(0));
         uint256 ethUsdMinPrice = vm.envOr("ETH_USD_MIN_PRICE", uint256(0));
         uint256 ethUsdMaxPrice = vm.envOr("ETH_USD_MAX_PRICE", uint256(0));
-        bool reqHardening = vm.envOr("REQUIRE_CHAINLINK_HARDENING", false);
 
         // Misconfiguration checks (fail-fast, before broadcast). Price band is
-        // all-or-nothing (a half-set band would be silently ignored). The opt-in
-        // prod guard enforces the full R-I-14 config when NATIVE is enabled.
+        // all-or-nothing. Hardening is mandatory whenever the NATIVE
+        // oracle path is enabled; there is no production opt-out.
         require(
             (ethUsdMinPrice == 0) == (ethUsdMaxPrice == 0),
             "set both ETH_USD_MIN_PRICE and ETH_USD_MAX_PRICE, or neither"
         );
-        if (reqHardening) {
-            require(ethUsdFeed != address(0), "hardening: ETH_USD_FEED must be set");
+        require(ethUsdMaxPrice == 0 || ethUsdMinPrice < ethUsdMaxPrice, "ETH_USD_MIN_PRICE must be below MAX");
+        if (ethUsdFeed != address(0)) {
+            require(ethUsdHb != 0, "ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided");
             require(seqFeed != address(0), "hardening: SEQUENCER_UPTIME_FEED must be set");
             require(ethUsdMaxPrice != 0, "hardening: ETH_USD_MIN/MAX_PRICE must be set");
         }
 
         vm.startBroadcast(pk);
-        cm = new CommissionManager(bridgeAddress);
-        if (ethUsdFeed != address(0)) {
-            require(ethUsdHb != 0, "ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided");
-            cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
-        }
-        // R-I-14 Arbitrum hardening (owner-only; deployer is owner here).
+        cm = new CommissionManager(bridgeAddress, commissionRecipient);
+        // Install the safety dependencies before enabling ETH/USD quotes.
         if (seqFeed != address(0)) {
             cm.setSequencerUptimeFeed(seqFeed);
         }
         if (ethUsdMaxPrice != 0) {
             cm.setEthUsdPriceBounds(ethUsdMinPrice, ethUsdMaxPrice);
         }
+        if (ethUsdFeed != address(0)) {
+            cm.setEthUsdFeed(ethUsdFeed, ethUsdHb);
+        }
         vm.stopBroadcast();
 
         console2.log("CommissionManager deployed at:", address(cm));
         console2.log("Bridge address:               ", cm.bridgeAddress());
+        console2.log("Immutable commission recipient:", cm.commissionRecipient());
         console2.log("Owner (deployer):             ", cm.owner());
         if (ethUsdFeed != address(0)) {
             console2.log("ETH/USD feed wired:           ", ethUsdFeed);

--- a/ethereum/script/deploy/DeployMultisigProxy.s.sol
+++ b/ethereum/script/deploy/DeployMultisigProxy.s.sol
@@ -17,7 +17,6 @@ import {MultisigProxy} from "../../src/MultisigProxy.sol";
 ///   INITIAL_ENCLAVE_SOURCE_CHAIN_ID — source chain id the initial enclave set authorises (non-zero)
 ///   FEDERATION_SIGNERS    — comma-separated governance signer addresses
 ///   FEDERATION_THRESHOLD  — M for federation M-of-N
-///   COMMISSION_RECIPIENT  — destination for commission withdrawals
 ///   TIMELOCK_DURATION     — seconds between propose and execute (e.g. 3600)
 ///
 /// Usage:
@@ -34,13 +33,12 @@ contract DeployMultisigProxy is Script {
         uint256 initialSrcChain = vm.envUint("INITIAL_ENCLAVE_SOURCE_CHAIN_ID");
         address[] memory fed = vm.envAddress("FEDERATION_SIGNERS", ",");
         uint256 fedThr = vm.envUint("FEDERATION_THRESHOLD");
-        address commission = vm.envAddress("COMMISSION_RECIPIENT");
         uint256 timelock = vm.envUint("TIMELOCK_DURATION");
         uint256 minTimelock = vm.envUint("MIN_TIMELOCK");
 
         vm.startBroadcast(pk);
         proxy = new MultisigProxy(
-            bridgeAddr, commissionManager, enc, encThr, initialSrcChain, fed, fedThr, commission, timelock, minTimelock
+            bridgeAddr, commissionManager, enc, encThr, initialSrcChain, fed, fedThr, timelock, minTimelock
         );
         vm.stopBroadcast();
 

--- a/ethereum/script/interact/BridgeFundsIn.s.sol
+++ b/ethereum/script/interact/BridgeFundsIn.s.sol
@@ -9,9 +9,13 @@ import {ICommissionManager} from "../../src/interfaces/ICommissionManager.sol";
 /// @title BridgeFundsIn
 /// @notice Approves and calls the public `Bridge.fundsIn()` overload as the
 ///         current signer. Quotes the native commission from CommissionManager
-///         and attaches it as `msg.value`. `sourceChainId` is filled with
-///         `block.chainid` by the Bridge — the script just reads it back to
-///         drive the quote.
+///         and attaches the quote plus `NATIVE_BUFFER_BPS` of headroom to absorb
+///         limited ETH/USD drift between quoting and execution. The call still
+///         reverts if the fresh quote exceeds the attached value or the attached
+///         value falls outside the Bridge's immutable tolerance. Bridge charges
+///         exactly the quote it computes at execution and refunds the unused
+///         buffer. `sourceChainId` is filled with `block.chainid` by the Bridge —
+///         the script just reads it back to drive the quote.
 ///
 ///         The canonical `operationId` is derived on-chain by the Bridge and
 ///         returned; this script logs it. The RGB route carries the RGB OpId
@@ -22,6 +26,11 @@ import {ICommissionManager} from "../../src/interfaces/ICommissionManager.sol";
 ///   PRIVATE_KEY, BRIDGE_ADDRESS, AMOUNT (wei),
 ///   DESTINATION_CHAIN_ID, DESTINATION_ADDRESS, RGB_OP_ID
 contract BridgeFundsIn is Script {
+    /// @dev Drift headroom attached on top of the quote. Kept below the
+    ///      Bridge's `NATIVE_COMMISSION_TOLERANCE_BPS` so a quote that is still
+    ///      current is never rejected for overpaying.
+    uint256 private constant NATIVE_BUFFER_BPS = 200; // 2%
+
     function run() external {
         uint256 pk = vm.envUint("PRIVATE_KEY");
         address bridgeAddr = vm.envAddress("BRIDGE_ADDRESS");
@@ -36,18 +45,27 @@ contract BridgeFundsIn is Script {
         ICommissionManager cm = bridge.commissionManager();
         (, uint256 nativeCommission,) = cm.calculateFundsInCommission(block.chainid, destChainId, token, amount);
 
-        console2.log("Native commission (wei):", nativeCommission);
+        // Attach the quote plus drift headroom. Bridge charges the quote it
+        // computes at execution and refunds the rest, so this is a ceiling on
+        // what may be spent, not the amount actually paid.
+        uint256 nativeValue = nativeCommission + (nativeCommission * NATIVE_BUFFER_BPS) / 10_000;
+
+        console2.log("Native commission quote (wei):", nativeCommission);
+        console2.log("Native value attached (wei):  ", nativeValue);
+
+        uint256 balanceBefore = vm.addr(pk).balance;
 
         vm.startBroadcast(pk);
         IERC20(token).approve(bridgeAddr, amount);
         // RGB route: `settlementData` carries the RGB OpId as `abi.encode(uint256)`;
         // the settlement module decodes it and surfaces it in the FundsIn event.
         // Other routes define their own blob layout.
-        bytes32 operationId = bridge.fundsIn{value: nativeCommission}(amount, destChainId, dAddr, abi.encode(rgbOpId));
+        bytes32 operationId = bridge.fundsIn{value: nativeValue}(amount, destChainId, dAddr, abi.encode(rgbOpId));
         vm.stopBroadcast();
 
         console2.log("fundsIn succeeded. Derived operationId:");
         console2.logBytes32(operationId);
+        console2.log("Native spent incl. gas (wei): ", balanceBefore - vm.addr(pk).balance);
         console2.log("Bridge balance:", IERC20(token).balanceOf(bridgeAddr));
     }
 }

--- a/ethereum/script/interact/EmergencyPause.s.sol
+++ b/ethereum/script/interact/EmergencyPause.s.sol
@@ -23,16 +23,26 @@ contract EmergencyPause is Script {
         uint256 offset = vm.envUint("DEADLINE_OFFSET");
 
         MultisigProxy proxy = MultisigProxy(proxyAddr);
-        uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + offset;
-
-        bytes32 digest = MultisigHelper.digestEmergencyPause(proxy.DOMAIN_SEPARATOR(), nonce, deadline);
+        (uint256 nonce, bytes32 digest) = _prepareEmergencyPause(proxy, deadline);
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, ks);
 
         vm.startBroadcast(pk);
         proxy.emergencyPause(nonce, deadline, bitmap, sigs);
         vm.stopBroadcast();
 
-        console2.log("emergencyPause submitted. New proposalNonce:", proxy.proposalNonce());
+        console2.log("emergencyPause submitted. New emergencyNonce:", proxy.emergencyNonce());
+    }
+
+    /// @dev Emergency actions have an independent nonce lane. Keeping nonce
+    ///      lookup and digest construction together prevents the production
+    ///      script from accidentally signing with the regular proposal nonce.
+    function _prepareEmergencyPause(MultisigProxy proxy, uint256 deadline)
+        internal
+        view
+        returns (uint256 nonce, bytes32 digest)
+    {
+        nonce = proxy.emergencyNonce();
+        digest = MultisigHelper.digestEmergencyPause(proxy.DOMAIN_SEPARATOR(), nonce, deadline);
     }
 }

--- a/ethereum/script/interact/EmergencyUnpause.s.sol
+++ b/ethereum/script/interact/EmergencyUnpause.s.sol
@@ -18,16 +18,26 @@ contract EmergencyUnpause is Script {
         uint256 offset = vm.envUint("DEADLINE_OFFSET");
 
         MultisigProxy proxy = MultisigProxy(proxyAddr);
-        uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + offset;
-
-        bytes32 digest = MultisigHelper.digestEmergencyUnpause(proxy.DOMAIN_SEPARATOR(), nonce, deadline);
+        (uint256 nonce, bytes32 digest) = _prepareEmergencyUnpause(proxy, deadline);
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, ks);
 
         vm.startBroadcast(pk);
         proxy.emergencyUnpause(nonce, deadline, bitmap, sigs);
         vm.stopBroadcast();
 
-        console2.log("emergencyUnpause submitted. New proposalNonce:", proxy.proposalNonce());
+        console2.log("emergencyUnpause submitted. New emergencyNonce:", proxy.emergencyNonce());
+    }
+
+    /// @dev Emergency actions have an independent nonce lane. Keeping nonce
+    ///      lookup and digest construction together prevents the production
+    ///      script from accidentally signing with the regular proposal nonce.
+    function _prepareEmergencyUnpause(MultisigProxy proxy, uint256 deadline)
+        internal
+        view
+        returns (uint256 nonce, bytes32 digest)
+    {
+        nonce = proxy.emergencyNonce();
+        digest = MultisigHelper.digestEmergencyUnpause(proxy.DOMAIN_SEPARATOR(), nonce, deadline);
     }
 }

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -76,6 +76,18 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     /// @notice Basis-point denominator for the immutable rolling safety limits.
     uint256 public constant BPS_DENOMINATOR = 10_000;
 
+    /// @notice Headroom allowed between the native value supplied to `fundsIn`
+    ///         and the fresh destination-side oracle quote, to absorb ETH/USD
+    ///         drift between quoting and execution.
+    ///
+    ///         Direct deposits may attach up to 5% above the quote as a buffer;
+    ///         exactly the quote is collected and the remainder is refunded, so
+    ///         the band is one-sided and costs neither party. LayerZero deposits
+    ///         carry a source-agreed value that cannot be refunded across
+    ///         domains, so there the band is symmetric — 5% either side — and
+    ///         whatever arrives inside it is collected in full.
+    uint256 public constant NATIVE_COMMISSION_TOLERANCE_BPS = 500;
+
     /// @notice Minimum rolling interval covered by the immutable safety
     ///         limiter. The bounded ring implementation retains usage for
     ///         24-25 hours, never less than this value.
@@ -393,7 +405,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         string calldata destinationAddress,
         bytes calldata settlementData
     ) external payable override whenNotPaused nonReentrant returns (bytes32 operationId) {
-        // Direct EVM deposit: the source sender IS the caller.
+        // Direct EVM deposit: the source sender IS the caller, so a native
+        // surplus can be returned to them — `refundNativeSurplus = true`.
         address caller = _msgSender();
         operationId = _fundsIn(
             caller,
@@ -402,7 +415,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             block.chainid,
             destinationChainId,
             destinationAddress,
-            settlementData
+            settlementData,
+            true
         );
     }
 
@@ -418,8 +432,20 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // LZ deposit: tokens are pulled from the adapter (`_msgSender()`), but
         // the identity bound into `operationId` is the authenticated
         // `sourceSender` forwarded from the source-chain entrypoint.
+        //
+        // `refundNativeSurplus = false`: `msg.value` is the source-agreed
+        // `expectedComposeValue`, and the payer lives on the source chain — the
+        // adapter is only its courier, so refunding `_msgSender()` would pay the
+        // wrong party. The symmetric drift band absorbs the deviation instead.
         operationId = _fundsIn(
-            _msgSender(), sourceSender, amount, sourceChainId, destinationChainId, destinationAddress, settlementData
+            _msgSender(),
+            sourceSender,
+            amount,
+            sourceChainId,
+            destinationChainId,
+            destinationAddress,
+            settlementData,
+            false
         );
     }
 
@@ -813,7 +839,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         uint256 sourceChainId,
         uint256 destinationChainId,
         string memory destinationAddress,
-        bytes calldata settlementData
+        bytes calldata settlementData,
+        bool refundNativeSurplus
     ) private returns (bytes32 operationId) {
         if (amount < minFundsInAmount) {
             revert AmountBelowMinimum(amount, minFundsInAmount);
@@ -828,20 +855,55 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         if (sourceChainId == 0) revert InvalidSourceChainId();
         if (destinationChainId == 0) revert InvalidDestinationChainId();
 
-        // Commission is quoted from the nominal `amount` so the native-commission
-        // quote (and the lower-bound `msg.value` check below) stays predictable
-        // for the caller. The nominal net is intentionally discarded — the
-        // credited net is derived from the ACTUAL received amount after the transfer.
+        // Commission is freshly quoted from the nominal `amount`. For direct
+        // calls `msg.value` is the user's submitted quote; for LayerZero it is
+        // the source-agreed expectedComposeValue authenticated by the adapter.
+        // The nominal net is intentionally discarded — the credited net is
+        // derived from the ACTUAL received amount after the transfer.
         (uint256 tokenCommission, uint256 nativeCommission,) =
             commissionManager.calculateFundsInCommission(sourceChainId, destinationChainId, TOKEN, amount);
 
-        // Native payment: require at least the freshly-quoted commission
-        // — an oracle move up between quote and execution reverts here. Any
-        // overpayment from a favorable move is collected as commission below
-        // (not refunded), so the rule is uniform for direct and LZ deposits.
-        // TOKEN-commission routes (nativeCommission == 0) accept no native.
-        if (msg.value < nativeCommission) revert NativeValueMismatch();
-        if (nativeCommission == 0 && msg.value != 0) revert NativeValueMismatch();
+        // Bound `msg.value` against the fresh quote, then decide how much of it
+        // is actually commission. Both paths accept the same 5% headroom above
+        // the quote; they differ in what happens to that headroom, because only
+        // one of them can pay it back.
+        //
+        //  - Direct deposit (`refundNativeSurplus`): the surplus is a drift
+        //    buffer. The floor is the quote itself and exactly the quote is
+        //    collected, so the protocol never under-collects and the caller is
+        //    never charged more than quoted — the surplus is returned below.
+        //  - LZ deposit: the payer is on the source chain and unreachable, so no
+        //    refund is possible. A symmetric band absorbs drift in both
+        //    directions and the whole source-agreed value is collected.
+        //
+        // TOKEN-commission routes (nativeCommission == 0) still accept no native.
+        // `minimum` and `nativeToCollect` are set together per branch on purpose:
+        // the trailing refund computes `msg.value - nativeToCollect`, so a floor
+        // below what is collected would underflow. Pairing them here makes that
+        // invariant structural rather than something a later edit must remember.
+        uint256 nativeToCollect;
+        if (nativeCommission == 0) {
+            if (msg.value != 0) revert NativeValueMismatch();
+        } else {
+            uint256 minimum;
+            if (refundNativeSurplus) {
+                minimum = nativeCommission;
+                nativeToCollect = nativeCommission;
+            } else {
+                minimum = Math.mulDiv(
+                    nativeCommission,
+                    BPS_DENOMINATOR - NATIVE_COMMISSION_TOLERANCE_BPS,
+                    BPS_DENOMINATOR,
+                    Math.Rounding.Ceil
+                );
+                nativeToCollect = msg.value;
+            }
+            uint256 maximum =
+                Math.mulDiv(nativeCommission, BPS_DENOMINATOR + NATIVE_COMMISSION_TOLERANCE_BPS, BPS_DENOMINATOR);
+            if (msg.value < minimum || msg.value > maximum) {
+                revert NativeCommissionOutOfBounds(msg.value, minimum, maximum);
+            }
+        }
 
         // Build the canonical context. The per-`(sourceChainId, sourceSender)`
         // nonce is consumed here — before any external call, so a downstream
@@ -875,10 +937,11 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         uint256 received = IERC20(TOKEN).balanceOf(address(this)) - balanceBefore;
 
         // The token commission is forwarded out of `received`; guard the
-        // subtraction so a token fee that eats more than the commission reverts
-        // cleanly instead of underflowing. A zero net (received == commission) is
-        // left to the existing zero-amount / dust handling, unchanged here.
-        if (received < tokenCommission) revert InsufficientReceived(received, tokenCommission);
+        // subtraction so a token fee that consumes all (or more) of the actual
+        // receipt reverts instead of creating a zero-net settlement or
+        // underflowing. Equality is reachable with fee-on-transfer tokens even
+        // though the nominal commission configuration is strictly below 100%.
+        if (received <= tokenCommission) revert InsufficientReceived(received, tokenCommission);
         ctx.netAmount = received - tokenCommission;
 
         // Forward token commission BEFORE the settlement hook so that any
@@ -901,12 +964,12 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         lockedLiquidity[destinationChainId] += ctx.netAmount;
         totalLockedLiquidity += ctx.netAmount;
 
-        // Forward the FULL native value to the CommissionManager pool. Any
-        // surplus over the quoted `nativeCommission` (favorable oracle drift) is
-        // collected as commission rather than refunded, so no native is
-        // ever left stranded in the Bridge.
-        if (msg.value != 0) {
-            (bool ok,) = address(commissionManager).call{value: msg.value}("");
+        // Forward the native commission actually owed — exactly the fresh quote
+        // on the direct path, the bounded source-agreed value on the LZ path.
+        // Any remainder is returned to the caller at the end of this function,
+        // so no native is ever retained in Bridge.
+        if (nativeToCollect != 0) {
+            (bool ok,) = address(commissionManager).call{value: nativeToCollect}("");
             if (!ok) revert NativeValueMismatch();
         }
 
@@ -921,11 +984,22 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
             ctx.grossAmount,
             ctx.netAmount,
             tokenCommission,
-            msg.value, // actual native collected (== nativeCommission + any drift surplus)
+            nativeToCollect, // native commission actually credited to the pool
             ctx.sourceChainId,
             ctx.destChainId,
             ctx.destAddress
         );
+
+        // Return the drift buffer LAST: after every state write and after the
+        // commission transfer, so the recipient's fallback observes only settled
+        // state. Reachable on the direct path only — the LZ path collects its
+        // whole source-agreed value, leaving nothing to refund. The overloads are
+        // `nonReentrant`, so this trailing call cannot re-enter.
+        uint256 surplus = msg.value - nativeToCollect;
+        if (surplus != 0) {
+            (bool refunded,) = payable(from).call{value: surplus}("");
+            if (!refunded) revert NativeRefundFailed(from, surplus);
+        }
 
         operationId = ctx.operationId;
     }

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -38,8 +38,9 @@ import {
  *      `ethUsdHeartbeat`) and non-positive answers revert the call.
  *
  *      **Roles:** `bridgeAddress` may call `receiveTokenCommission` and `receive()` to credit fees;
- *      `owner` configures rules and withdraws accumulated pools. `renounceOwnership` is disabled.
- *      Withdrawals use `nonReentrant` against reentrancy via ERC-20 hooks or native recipients.
+ *      `owner` configures rules and withdraws accumulated pools. Every withdrawal pays the immutable
+ *      `commissionRecipient`, regardless of the caller or call path. `renounceOwnership` is disabled.
+ *      Withdrawals use `nonReentrant` against reentrancy via ERC-20 hooks or the native recipient.
  */
 contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager {
     using SafeERC20 for IERC20;
@@ -48,6 +49,11 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
 
     /// @notice Address allowed to credit token and native commission.
     address public bridgeAddress;
+
+    /// @notice Immutable destination for every token and native commission
+    ///         withdrawal. Enforced here at the asset-custody layer so no owner
+    ///         or alternate proxy call path can redirect accrued commission.
+    address public immutable commissionRecipient;
 
     /// @notice Default `stablePercent` when no per-route rule exists (×100; 0 = no % fee until configured).
     uint256 public globalStablePercent = 0;
@@ -77,9 +83,8 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     ///         in seconds. Quotes revert `StalePrice` when the answer is older.
     uint256 public ethUsdHeartbeat;
 
-    /// @notice Chainlink L2 Sequencer Uptime feed (Arbitrum). `address(0)`
-    ///         (default) disables the check for non-L2 / test environments;
-    ///         an Arbitrum deployment MUST wire it via `setSequencerUptimeFeed`.
+    /// @notice Chainlink L2 Sequencer Uptime feed (Arbitrum). NATIVE quotes
+    ///         fail closed while this is `address(0)`.
     address public sequencerUptimeFeed;
 
     /// @notice Seconds after a sequencer restart during which NATIVE quotes are
@@ -87,9 +92,9 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     ///         recovery. Chainlink's recommended grace period is 3600s.
     uint256 public constant SEQUENCER_GRACE_PERIOD = 3600;
 
-    /// @notice Optional [min, max] sanity band on the ETH/USD answer (in feed
-    ///         decimals). `ethUsdMaxPrice == 0` (default) disables the band; when
-    ///         set, an answer outside it (e.g. an aggregator floored/capped to
+    /// @notice Mandatory [min, max] sanity band on the ETH/USD answer (in feed
+    ///         decimals). NATIVE quotes fail closed while the band is unset; an
+    ///         answer outside it (e.g. an aggregator floored/capped to
     ///         `minAnswer`/`maxAnswer` during an extreme move) reverts
     ///         `PriceOutOfBounds`.
     uint256 public ethUsdMinPrice;
@@ -106,12 +111,15 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     // ============ Constructor ============
 
     /**
-     * @notice Deploys the manager; `msg.sender` is owner; `_bridgeAddress` is the initial bridge.
+     * @notice Deploys the manager; `msg.sender` is owner.
      * @param _bridgeAddress Bridge that will send commissions (non-zero).
+     * @param _commissionRecipient Immutable destination for all withdrawals (non-zero).
      */
-    constructor(address _bridgeAddress) Ownable(msg.sender) {
+    constructor(address _bridgeAddress, address _commissionRecipient) Ownable(msg.sender) {
         if (_bridgeAddress == address(0)) revert InvalidBridgeAddress();
+        if (_commissionRecipient == address(0)) revert InvalidRecipient();
         bridgeAddress = _bridgeAddress;
+        commissionRecipient = _commissionRecipient;
     }
 
     /// @inheritdoc Ownable
@@ -152,9 +160,11 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
 
         // Calculate stable fee in token units
         uint256 stableFee = calculateStableFee(amount, config.stablePercent, config.multiplier);
+        _requireNonZeroConfiguredCommission(amount, stableFee, config);
 
         if (config.currency == CommissionCurrency.TOKEN) {
             // TOKEN commission: deduct from amount
+            if (stableFee >= amount) revert ZeroNetAmount(amount, stableFee);
             tokenCommission = stableFee;
             nativeCommission = 0;
             netAmount = amount - tokenCommission;
@@ -165,6 +175,9 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
                 nativeCommission = 0;
             } else {
                 nativeCommission = convertTokenFeeToNative(stableFee, _tokenDecimals(token));
+                if (nativeCommission == 0) {
+                    revert CommissionRoundsToZero(amount, config.stablePercent, config.multiplier);
+                }
             }
             netAmount = amount; // Full amount bridges
         }
@@ -198,8 +211,10 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
 
         // Calculate stable fee
         uint256 stableFee = calculateStableFee(amount, config.stablePercent, config.multiplier);
+        _requireNonZeroConfiguredCommission(amount, stableFee, config);
 
         if (config.currency == CommissionCurrency.TOKEN) {
+            if (stableFee >= amount) revert ZeroNetAmount(amount, stableFee);
             tokenCommission = stableFee;
             nativeCommission = 0;
             netAmount = amount - tokenCommission;
@@ -210,6 +225,9 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
                 nativeCommission = 0;
             } else {
                 nativeCommission = convertTokenFeeToNative(stableFee, _tokenDecimals(token));
+                if (nativeCommission == 0) {
+                    revert CommissionRoundsToZero(amount, config.stablePercent, config.multiplier);
+                }
             }
             netAmount = amount;
         }
@@ -244,18 +262,23 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         address feedAddr = ethUsdFeed;
         if (feedAddr == address(0)) revert EthUsdFeedNotSet();
 
-        // L2 sequencer liveness (Arbitrum). Skipped when unset so non-L2 / test
-        // environments are unaffected; an Arbitrum deployment wires it.
-        if (sequencerUptimeFeed != address(0)) _requireSequencerUp();
+        // never consume an ETH/USD answer unless both Arbitrum
+        // hardening layers are configured. Setters may be executed in separate
+        // governance proposals, but the quote path remains fail-closed
+        // throughout any partially configured state.
+        if (sequencerUptimeFeed == address(0) || ethUsdMinPrice == 0 || ethUsdMaxPrice == 0) {
+            revert ChainlinkHardeningNotConfigured();
+        }
+        _requireSequencerUp();
 
         AggregatorV3Interface feed = AggregatorV3Interface(feedAddr);
 
         (, int256 answer,, uint256 updatedAt,) = feed.latestRoundData();
         if (answer <= 0) revert InvalidPrice();
         if (block.timestamp - updatedAt > ethUsdHeartbeat) revert StalePrice();
-        // Optional circuit-breaker band (disabled when ethUsdMaxPrice == 0):
-        // rejects a floored/capped aggregator answer that `answer > 0` misses.
-        if (ethUsdMaxPrice != 0 && (uint256(answer) < ethUsdMinPrice || uint256(answer) > ethUsdMaxPrice)) {
+        // Mandatory circuit-breaker rejects a floored/capped aggregator answer
+        // that the basic `answer > 0` validity check cannot detect.
+        if (uint256(answer) < ethUsdMinPrice || uint256(answer) > ethUsdMaxPrice) {
             revert PriceOutOfBounds();
         }
 
@@ -263,14 +286,15 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         nativeFee = (tokenFee * scale) / uint256(answer);
     }
 
-    /// @dev Reverts unless the Arbitrum L2 sequencer is up and past the grace
-    ///      period. Only invoked when `sequencerUptimeFeed` is configured. The
-    ///      uptime feed is a standard `AggregatorV3Interface`: `answer == 0`
-    ///      means the sequencer is up, `answer == 1` means down; `startedAt` is
-    ///      when the current status round began (i.e. the last restart when it
-    ///      transitions back to up).
+    /// @dev Reverts unless the Arbitrum L2 sequencer round is initialized, its
+    ///      timestamp is sane, and the sequencer is up and past the grace
+    ///      period. The uptime feed is a standard `AggregatorV3Interface`:
+    ///      `answer == 0` means up, `answer == 1` means down; `startedAt` is when
+    ///      the current status round began (the last restart when it returned
+    ///      to up).
     function _requireSequencerUp() internal view {
         (, int256 answer, uint256 startedAt,,) = AggregatorV3Interface(sequencerUptimeFeed).latestRoundData();
+        if (startedAt == 0 || startedAt > block.timestamp) revert InvalidSequencerRound(startedAt);
         if (answer != 0) revert SequencerDown();
         if (block.timestamp - startedAt <= SEQUENCER_GRACE_PERIOD) revert GracePeriodNotOver();
     }
@@ -307,12 +331,12 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         if (stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (multiplier == 0) revert MultiplierZero();
         // Joint invariant: the fee fraction is `stablePercent / multiplier^2`.
-        // When `stablePercent > multiplier^2` the quoted fee exceeds the
-        // bridged amount, so `netAmount = amount - fee` underflows and bricks
-        // every subsequent funds flow on the affected route. Widen to uint256
-        // before squaring — `multiplier` is uint8 and the common `100 * 100`
-        // would itself overflow uint8.
-        if (stablePercent > uint256(multiplier) * uint256(multiplier)) {
+        // The configured fee must be strictly below 100%. Equality would make
+        // TOKEN commission consume the entire amount and create a zero-net
+        // settlement; greater values would underflow. Widen to uint256 before
+        // squaring — `multiplier` is uint8 and the common `100 * 100` would
+        // itself overflow uint8.
+        if (stablePercent >= uint256(multiplier) * uint256(multiplier)) {
             revert InvalidFeeShape(stablePercent, multiplier);
         }
         // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
@@ -350,17 +374,17 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     }
 
     /// @inheritdoc ICommissionManager
-    /// @dev `address(0)` disables the sequencer-uptime gate (non-L2 / test
-    ///      environments). On Arbitrum, federation MUST set the Chainlink
-    ///      Sequencer Uptime feed so NATIVE quotes reject prices during
-    ///      downtime and the post-restart grace period.
+    /// @dev Setting `address(0)` is allowed for staged governance changes or to
+    ///      tear down an unused oracle config, but it makes every non-zero
+    ///      NATIVE quote revert `ChainlinkHardeningNotConfigured`.
     function setSequencerUptimeFeed(address feed) external onlyOwner {
         sequencerUptimeFeed = feed;
         emit SequencerUptimeFeedUpdated(feed);
     }
 
     /// @inheritdoc ICommissionManager
-    /// @dev Pass `(0, 0)` to disable the band; otherwise require
+    /// @dev Pass `(0, 0)` to clear the band during staged governance changes or
+    ///      oracle teardown; NATIVE quotes then fail closed. Otherwise require
     ///      `0 < minPrice < maxPrice` (values in the feed's decimals, e.g.
     ///      `100e8` / `100_000e8` for an 8-decimal ETH/USD feed).
     function setEthUsdPriceBounds(uint256 minPrice, uint256 maxPrice) external onlyOwner {
@@ -394,12 +418,12 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         if (config.stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (config.multiplier == 0) revert MultiplierZero();
         // Joint invariant: the fee fraction is `stablePercent / multiplier^2`.
-        // When `stablePercent > multiplier^2` the quoted fee exceeds the
-        // bridged amount, so `netAmount = amount - fee` underflows and bricks
-        // every subsequent funds flow on the affected route. Widen to uint256
-        // before squaring — `multiplier` is uint8 and the common `100 * 100`
-        // would itself overflow uint8.
-        if (config.stablePercent > uint256(config.multiplier) * uint256(config.multiplier)) {
+        // The configured fee must be strictly below 100%. Equality would make
+        // TOKEN commission consume the entire amount and create a zero-net
+        // settlement; greater values would underflow. Widen to uint256 before
+        // squaring — `multiplier` is uint8 and the common `100 * 100` would
+        // itself overflow uint8.
+        if (config.stablePercent >= uint256(config.multiplier) * uint256(config.multiplier)) {
             revert InvalidFeeShape(config.stablePercent, config.multiplier);
         }
         // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
@@ -462,6 +486,20 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
             currency: globalCurrency,
             isSet: true
         });
+    }
+
+    /// @dev A deliberately disabled fee (`stablePercent == 0`) is valid. Once
+    ///      governance enables a fee, however, every operation governed by that
+    ///      rule must pay at least one smallest unit. This runtime check couples
+    ///      the effective per-route/global rule to the actual transfer amount,
+    ///      so later configuration changes cannot reopen commission-free dust.
+    function _requireNonZeroConfiguredCommission(uint256 amount, uint256 stableFee, CommissionConfig memory config)
+        private
+        pure
+    {
+        if (config.stablePercent != 0 && stableFee == 0) {
+            revert CommissionRoundsToZero(amount, config.stablePercent, config.multiplier);
+        }
     }
 
     /**
@@ -540,72 +578,68 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     // ============ Withdrawal Functions ============
 
     /**
-     * @notice Owner withdraws `amount` of accrued `token` commission to `to`.
+     * @notice Owner withdraws `amount` of accrued `token` commission.
      * @param token ERC-20 token (non-zero).
-     * @param to Recipient (non-zero).
      * @param amount Amount to send (≤ pool).
-     * @dev `nonReentrant`; updates pool before `safeTransfer`.
+     * @dev Always pays immutable `commissionRecipient`. `nonReentrant`; updates
+     *      pool before `safeTransfer`.
      */
-    function withdrawTokenCommission(address token, address to, uint256 amount) external onlyOwner nonReentrant {
+    function withdrawTokenCommission(address token, uint256 amount) external onlyOwner nonReentrant {
         if (token == address(0)) revert InvalidToken();
-        if (to == address(0)) revert InvalidRecipient();
         if (tokenCommissionPool[token] < amount) revert InsufficientBalance();
 
         tokenCommissionPool[token] -= amount;
-        IERC20(token).safeTransfer(to, amount);
+        IERC20(token).safeTransfer(commissionRecipient, amount);
 
-        emit TokenCommissionWithdrawn(token, to, amount);
+        emit TokenCommissionWithdrawn(token, commissionRecipient, amount);
     }
 
     /**
      * @notice Owner withdraws `amount` wei of native commission.
-     * @param to Recipient (non-zero).
      * @param amount Wei to send (≤ pool).
-     * @dev `nonReentrant`; updates pool before native transfer.
+     * @dev Always pays immutable `commissionRecipient`. `nonReentrant`; updates
+     *      pool before native transfer.
      */
-    function withdrawNativeCommission(address payable to, uint256 amount) external onlyOwner nonReentrant {
-        if (to == address(0)) revert InvalidRecipient();
+    function withdrawNativeCommission(uint256 amount) external onlyOwner nonReentrant {
         if (nativeCommissionPool < amount) revert InsufficientBalance();
 
         nativeCommissionPool -= amount;
-        (bool success,) = to.call{value: amount}("");
+        (bool success,) = payable(commissionRecipient).call{value: amount}("");
         if (!success) revert NativeTransferFailed();
 
-        emit NativeCommissionWithdrawn(to, amount);
+        emit NativeCommissionWithdrawn(commissionRecipient, amount);
     }
 
     /**
-     * @notice Owner withdraws the full accrued balance for `token` to `to`.
+     * @notice Owner withdraws the full accrued balance for `token`.
      * @param token ERC-20 token (non-zero).
-     * @param to Recipient (non-zero).
-     * @dev `nonReentrant`. Reverts `NoBalance` if pool is zero.
+     * @dev Always pays immutable `commissionRecipient`. `nonReentrant`.
+     *      Reverts `NoBalance` if pool is zero.
      */
-    function withdrawAllTokenCommission(address token, address to) external onlyOwner nonReentrant {
+    function withdrawAllTokenCommission(address token) external onlyOwner nonReentrant {
         if (token == address(0)) revert InvalidToken();
-        if (to == address(0)) revert InvalidRecipient();
         uint256 balance = tokenCommissionPool[token];
         if (balance == 0) revert NoBalance();
 
         tokenCommissionPool[token] = 0;
-        IERC20(token).safeTransfer(to, balance);
+        IERC20(token).safeTransfer(commissionRecipient, balance);
 
-        emit TokenCommissionWithdrawn(token, to, balance);
+        emit TokenCommissionWithdrawn(token, commissionRecipient, balance);
     }
 
     /**
-     * @notice Owner withdraws the full `nativeCommissionPool` to `to`.
-     * @param to Recipient (non-zero).
-     * @dev `nonReentrant`. Reverts `NoBalance` if pool is zero.
+     * @notice Owner withdraws the full `nativeCommissionPool`.
+     * @dev Always pays immutable `commissionRecipient`. `nonReentrant`.
+     *      Reverts `NoBalance` if pool is zero.
      */
-    function withdrawAllNativeCommission(address payable to) external onlyOwner nonReentrant {
-        if (to == address(0)) revert InvalidRecipient();
+    function withdrawAllNativeCommission() external onlyOwner nonReentrant {
         uint256 balance = nativeCommissionPool;
         if (balance == 0) revert NoBalance();
 
         nativeCommissionPool = 0;
-        (bool success,) = to.call{value: balance}("");
+        (bool success,) = payable(commissionRecipient).call{value: balance}("");
         if (!success) revert NativeTransferFailed();
 
-        emit NativeCommissionWithdrawn(to, balance);
+        emit NativeCommissionWithdrawn(commissionRecipient, balance);
     }
 }

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -5,6 +5,7 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IMultisigProxy} from "./interfaces/IMultisigProxy.sol";
 import {IBridge} from "./interfaces/IBridge.sol";
+import {ICommissionManager} from "./interfaces/ICommissionManager.sol";
 import {IRouteRegistry} from "./interfaces/IRouteRegistry.sol";
 
 /// @notice Minimal view of the LayerZero adapter's outbound entry point. The
@@ -58,8 +59,6 @@ contract MultisigProxy is IMultisigProxy {
 
     address[] private _federationSigners;
     uint256 public federationThreshold;
-
-    address public commissionRecipient;
 
     /// @notice Per-source-chain nonce for the typed TEE methods (`fundsOutCall`
     ///         / `lzFundsOutCall`). Each source chain has its own lane, so the
@@ -123,15 +122,14 @@ contract MultisigProxy is IMultisigProxy {
     uint256 public constant SELECTOR_LENGTH = 4;
 
     /// @notice CommissionManager withdrawal selectors that the generic
-    ///         `AdminExecuteCommissionManager` path is NOT allowed to call —
-    ///         they take a free recipient and would bypass the pinned
-    ///         `commissionRecipient`. Withdrawals must go through the
-    ///         dedicated WithdrawTokenCommissionCM / WithdrawNativeCommissionCM
-    ///         ops, which force the recipient to `commissionRecipient`.
-    bytes4 private constant _SEL_WITHDRAW_TOKEN = bytes4(keccak256("withdrawTokenCommission(address,address,uint256)"));
-    bytes4 private constant _SEL_WITHDRAW_NATIVE = bytes4(keccak256("withdrawNativeCommission(address,uint256)"));
-    bytes4 private constant _SEL_WITHDRAW_ALL_TOKEN = bytes4(keccak256("withdrawAllTokenCommission(address,address)"));
-    bytes4 private constant _SEL_WITHDRAW_ALL_NATIVE = bytes4(keccak256("withdrawAllNativeCommission(address)"));
+    ///         `AdminExecuteCommissionManager` path is NOT allowed to call.
+    ///         The asset layer always pays CM's immutable recipient, while this
+    ///         procedural guard keeps standard withdrawals on the dedicated,
+    ///         typed governance operations.
+    bytes4 private constant _SEL_WITHDRAW_TOKEN = ICommissionManager.withdrawTokenCommission.selector;
+    bytes4 private constant _SEL_WITHDRAW_NATIVE = ICommissionManager.withdrawNativeCommission.selector;
+    bytes4 private constant _SEL_WITHDRAW_ALL_TOKEN = ICommissionManager.withdrawAllTokenCommission.selector;
+    bytes4 private constant _SEL_WITHDRAW_ALL_NATIVE = ICommissionManager.withdrawAllNativeCommission.selector;
 
     uint256 private immutable _cachedChainId;
     bytes32 private immutable _cachedDomainSeparator;
@@ -161,8 +159,6 @@ contract MultisigProxy is IMultisigProxy {
     );
     bytes32 private constant _PROPOSE_UPDATE_BRIDGE_TYPEHASH =
         keccak256("ProposeUpdateBridge(address newBridge,uint256 nonce,uint256 deadline)");
-    bytes32 private constant _PROPOSE_SET_COMMISSION_RECIPIENT_TYPEHASH =
-        keccak256("ProposeSetCommissionRecipient(address newRecipient,uint256 nonce,uint256 deadline)");
     bytes32 private constant _PROPOSE_SET_TIMELOCK_DURATION_TYPEHASH =
         keccak256("ProposeSetTimelockDuration(uint256 newDuration,uint256 nonce,uint256 deadline)");
 
@@ -221,7 +217,6 @@ contract MultisigProxy is IMultisigProxy {
         uint256 initialEnclaveSourceChain_,
         address[] memory federationSigners_,
         uint256 federationThreshold_,
-        address commissionRecipient_,
         uint256 timelockDuration_,
         uint256 minTimelock_
     ) {
@@ -232,7 +227,6 @@ contract MultisigProxy is IMultisigProxy {
         _requireValidThreshold(enclaveThreshold_, enclaveSigners_.length);
         if (federationSigners_.length == 0) revert NoSigners();
         _requireValidThreshold(federationThreshold_, federationSigners_.length);
-        if (commissionRecipient_ == address(0)) revert ZeroCommissionRecipient();
         if (minTimelock_ == 0 || minTimelock_ >= MAX_PROPOSAL_LIFETIME) revert InvalidMinTimelock();
         if (timelockDuration_ < minTimelock_) revert TimelockTooShort();
         if (timelockDuration_ >= MAX_PROPOSAL_LIFETIME) revert TimelockTooLong();
@@ -250,7 +244,6 @@ contract MultisigProxy is IMultisigProxy {
         _enclaveSourceChains.push(initialEnclaveSourceChain_);
         _federationSigners = federationSigners_;
         federationThreshold = federationThreshold_;
-        commissionRecipient = commissionRecipient_;
         timelockDuration = timelockDuration_;
         MIN_TIMELOCK = minTimelock_;
 
@@ -640,29 +633,6 @@ contract MultisigProxy is IMultisigProxy {
     }
 
     /// @inheritdoc IMultisigProxy
-    function proposeSetCommissionRecipient(
-        address newRecipient,
-        uint256 nonce,
-        uint256 deadline,
-        uint256 fedBitmap,
-        bytes[] calldata fedSigs
-    ) external returns (bytes32) {
-        bytes32 structHash = keccak256(
-            abi.encode(_PROPOSE_SET_COMMISSION_RECIPIENT_TYPEHASH, newRecipient, nonce, deadline)
-        );
-
-        return _propose(
-            OperationType.SetCommissionRecipient,
-            abi.encode(newRecipient),
-            nonce,
-            deadline,
-            structHash,
-            fedBitmap,
-            fedSigs
-        );
-    }
-
-    /// @inheritdoc IMultisigProxy
     function proposeSetTimelockDuration(
         uint256 newDuration,
         uint256 nonce,
@@ -696,8 +666,8 @@ contract MultisigProxy is IMultisigProxy {
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
 
-        // Commission withdrawals must use the pinned-recipient ops; reject them
-        // on the generic path up front (fail-fast, no wasted proposal slot).
+        // Standard withdrawals use the dedicated typed operations; reject them
+        // on this generic path up front (recipient safety remains in CM).
         _requireNotCommissionWithdrawSelector(selector);
 
         bytes32 structHash =
@@ -990,6 +960,11 @@ contract MultisigProxy is IMultisigProxy {
     // =========================================================================
 
     /// @inheritdoc IMultisigProxy
+    function commissionRecipient() public view returns (address) {
+        return ICommissionManager(payable(commissionManager)).commissionRecipient();
+    }
+
+    /// @inheritdoc IMultisigProxy
     function verifyEnclaveSignature(
         uint256 sourceChainId,
         bytes32 digest,
@@ -1113,12 +1088,6 @@ contract MultisigProxy is IMultisigProxy {
             address oldBridge = bridge;
             bridge = newBridge;
             emit BridgeAddressUpdated(oldBridge, newBridge);
-        } else if (opType == OperationType.SetCommissionRecipient) {
-            address newRecipient = abi.decode(opData, (address));
-            if (newRecipient == address(0)) revert ZeroRecipient();
-            address old = commissionRecipient;
-            commissionRecipient = newRecipient;
-            emit CommissionRecipientUpdated(old, newRecipient);
         } else if (opType == OperationType.SetTimelockDuration) {
             uint256 newDuration = abi.decode(opData, (uint256));
             if (newDuration < MIN_TIMELOCK) revert TimelockTooShort();
@@ -1127,9 +1096,8 @@ contract MultisigProxy is IMultisigProxy {
             emit TimelockDurationUpdated(newDuration);
         } else if (opType == OperationType.AdminExecuteCommissionManager) {
             // opData = raw CommissionManager callData. Enforce (again, at the
-            // execution boundary) that this generic path cannot call a
-            // withdrawal selector and re-point commission away from the pinned
-            // `commissionRecipient`.
+            // execution boundary) that standard withdrawals use their typed
+            // governance operations.
             _requireNotCommissionWithdrawSelector(_firstSelector(opData));
             (bool ok, bytes memory ret) = commissionManager.call(opData);
             _propagateRevert(ok, ret);
@@ -1144,18 +1112,16 @@ contract MultisigProxy is IMultisigProxy {
             _propagateRevert(ok, ret);
         } else if (opType == OperationType.WithdrawTokenCommissionCM) {
             (address token, uint256 amount) = abi.decode(opData, (address, uint256));
-            address recipient = commissionRecipient;
-            (bool ok, bytes memory ret) = commissionManager.call(
-                abi.encodeWithSignature("withdrawTokenCommission(address,address,uint256)", token, recipient, amount)
-            );
+            address recipient = commissionRecipient();
+            (bool ok, bytes memory ret) =
+                commissionManager.call(abi.encodeCall(ICommissionManager.withdrawTokenCommission, (token, amount)));
             _propagateRevert(ok, ret);
             emit CommissionWithdrawn(token, amount, recipient);
         } else if (opType == OperationType.WithdrawNativeCommissionCM) {
             uint256 amount = abi.decode(opData, (uint256));
-            address recipient = commissionRecipient;
-            (bool ok, bytes memory ret) = commissionManager.call(
-                abi.encodeWithSignature("withdrawNativeCommission(address,uint256)", recipient, amount)
-            );
+            address recipient = commissionRecipient();
+            (bool ok, bytes memory ret) =
+                commissionManager.call(abi.encodeCall(ICommissionManager.withdrawNativeCommission, (amount)));
             _propagateRevert(ok, ret);
             emit NativeCommissionWithdrawn(amount, recipient);
         } else if (opType == OperationType.UpdateCommissionManager) {
@@ -1360,9 +1326,9 @@ contract MultisigProxy is IMultisigProxy {
         }
     }
 
-    /// @dev Reverts if `selector` is one of the CommissionManager withdrawal
-    ///      selectors, which the generic AdminExecuteCommissionManager path must
-    ///      not reach (they bypass the pinned `commissionRecipient`).
+    /// @dev Reverts for CommissionManager withdrawal selectors so the generic
+    ///      path cannot bypass the dedicated typed governance operations.
+    ///      Recipient safety itself is enforced inside CommissionManager.
     function _requireNotCommissionWithdrawSelector(bytes4 selector) private pure {
         if (
             selector == _SEL_WITHDRAW_TOKEN || selector == _SEL_WITHDRAW_NATIVE || selector == _SEL_WITHDRAW_ALL_TOKEN

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -25,6 +25,8 @@ interface IBridge {
     error InvalidBurnId(uint256 provided, uint256 expected);
     error BurnIdAlreadyConsumed(uint256 burnId);
     error NativeValueMismatch();
+    error NativeCommissionOutOfBounds(uint256 provided, uint256 minimum, uint256 maximum);
+    error NativeRefundFailed(address recipient, uint256 amount);
     error RebalanceSameChain(uint256 chainId);
     error ChainSafetyLimitExceeded(uint256 chainId, uint256 requested, uint256 spentInWindow, uint256 windowLimit);
     error GlobalSafetyLimitExceeded(uint256 requested, uint256 spentInWindow, uint256 windowLimit);
@@ -181,11 +183,15 @@ interface IBridge {
     /// @notice Direct deposit overload for EVM users on this chain. The
     ///         `sourceChainId` half of the commission route key is filled with
     ///         `block.chainid` — non-spoofable by the caller.
-    /// @dev Payable: if the active route uses NATIVE commission currency, `msg.value`
-    ///      must be at least the quoted native commission — any surplus (from
-    ///      favorable ETH/USD drift between quote and execution) is collected as
-    ///      commission, not refunded (R-I-03). If the route takes no native
-    ///      commission (TOKEN currency), `msg.value` must be 0.
+    /// @dev Payable: if the active route uses NATIVE commission currency,
+    ///      `msg.value` must be at least the freshly quoted native commission
+    ///      and at most `NATIVE_COMMISSION_TOLERANCE_BPS` above it. Attach the
+    ///      quote plus a small buffer so ETH/USD drift between quoting and
+    ///      execution cannot revert the deposit: exactly the fresh quote is
+    ///      charged and the surplus is refunded to the caller before the call
+    ///      returns. A caller that cannot receive native value must therefore
+    ///      send the exact quote. If the route takes no native commission
+    ///      (TOKEN currency), `msg.value` must be 0.
     /// @dev `settlementData` is an opaque per-route blob forwarded into the
     ///      route's `ISettlementModule.onFundsIn`. Routes whose module does not
     ///      consume any extra data (e.g. RGB) accept an empty bytes string.
@@ -208,6 +214,12 @@ interface IBridge {
     ///      overload is effectively closed. `sourceSender` is authenticated by
     ///      the source-chain entrypoint and adapter, not by an arbitrary
     ///      caller — it is bound into the derived `operationId`.
+    /// @dev Native commission here is the source-agreed value the adapter
+    ///      forwards, and its payer lives on the source chain. Because no refund
+    ///      can reach them, `msg.value` is accepted anywhere within
+    ///      `NATIVE_COMMISSION_TOLERANCE_BPS` either side of the fresh quote and
+    ///      is collected in full — unlike the direct overload, which charges the
+    ///      quote exactly and refunds the difference.
     /// @return operationId The canonical bridge-side operation id.
     function fundsIn(
         uint256 amount,

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -47,6 +47,8 @@ interface ICommissionManager {
     error StablePercentTooHigh();
     error MultiplierZero();
     error InvalidFeeShape(uint256 stablePercent, uint8 multiplier);
+    error CommissionRoundsToZero(uint256 amount, uint256 stablePercent, uint8 multiplier);
+    error ZeroNetAmount(uint256 amount, uint256 commission);
     error NativeCommissionNotAllowedOnFundsOut();
     error TokenDecimalsUnavailable();
     error BalanceBelowRecordedPool();
@@ -67,6 +69,8 @@ interface ICommissionManager {
     error GracePeriodNotOver();
     error PriceOutOfBounds();
     error InvalidPriceBounds();
+    error ChainlinkHardeningNotConfigured();
+    error InvalidSequencerRound(uint256 startedAt);
 
     // ============ Events ============
 
@@ -87,10 +91,10 @@ interface ICommissionManager {
 
     event EthUsdFeedUpdated(address indexed feed, uint256 heartbeat);
 
-    /// @notice Emitted on `setSequencerUptimeFeed` (`address(0)` disables the check).
+    /// @notice Emitted on `setSequencerUptimeFeed`; zero makes NATIVE quotes fail closed.
     event SequencerUptimeFeedUpdated(address indexed feed);
 
-    /// @notice Emitted on `setEthUsdPriceBounds` (both zero disables the band).
+    /// @notice Emitted on `setEthUsdPriceBounds`; both zero make NATIVE quotes fail closed.
     event EthUsdPriceBoundsUpdated(uint256 minPrice, uint256 maxPrice);
 
     event TokenCommissionWithdrawn(address indexed token, address indexed to, uint256 amount);
@@ -99,6 +103,8 @@ interface ICommissionManager {
     // ============ State getters ============
 
     function bridgeAddress() external view returns (address);
+
+    function commissionRecipient() external view returns (address);
 
     function globalStablePercent() external view returns (uint256);
 
@@ -143,9 +149,11 @@ interface ICommissionManager {
 
     /// @notice Convert a USD-denominated token fee (stablecoin, 1 token ≈ $1) to
     ///         native wei using the configured ETH/USD Chainlink feed. Reverts
-    ///         `EthUsdFeedNotSet` when the feed is unconfigured, `InvalidPrice`
-    ///         on non-positive answers, and `StalePrice` when `updatedAt` is
-    ///         older than the configured heartbeat.
+    ///         `EthUsdFeedNotSet` when the price feed is unconfigured,
+    ///         `ChainlinkHardeningNotConfigured` unless the sequencer feed and
+    ///         price band are both configured, `InvalidPrice` on non-positive
+    ///         answers, and `StalePrice` when `updatedAt` is older than the
+    ///         configured heartbeat.
     function convertTokenFeeToNative(uint256 tokenFee, uint256 tokenDecimals) external view returns (uint256 nativeFee);
 
     // ============ Admin / config ============
@@ -166,12 +174,13 @@ interface ICommissionManager {
     function setEthUsdFeed(address feed, uint256 heartbeat) external;
 
     /// @notice Configure (or rotate) the Chainlink L2 Sequencer Uptime feed used
-    ///         to gate NATIVE quotes on Arbitrum. Pass `address(0)` to disable
-    ///         the check (non-L2 / test environments).
+    ///         to gate NATIVE quotes on Arbitrum. Passing `address(0)` clears
+    ///         the configuration and makes non-zero NATIVE quotes fail closed.
     function setSequencerUptimeFeed(address feed) external;
 
-    /// @notice Configure the optional [min, max] sanity band on the ETH/USD
-    ///         answer (feed decimals). Pass `(0, 0)` to disable; otherwise
+    /// @notice Configure the mandatory [min, max] sanity band on the ETH/USD
+    ///         answer (feed decimals). Passing `(0, 0)` clears the configuration
+    ///         and makes non-zero NATIVE quotes fail closed; otherwise
     ///         `0 < minPrice < maxPrice`.
     function setEthUsdPriceBounds(uint256 minPrice, uint256 maxPrice) external;
 
@@ -213,11 +222,19 @@ interface ICommissionManager {
 
     // ============ Withdrawals (owner) ============
 
-    function withdrawTokenCommission(address token, address to, uint256 amount) external;
+    /// @notice Withdraw accrued token commission to the immutable
+    ///         `commissionRecipient`.
+    function withdrawTokenCommission(address token, uint256 amount) external;
 
-    function withdrawNativeCommission(address payable to, uint256 amount) external;
+    /// @notice Withdraw accrued native commission to the immutable
+    ///         `commissionRecipient`.
+    function withdrawNativeCommission(uint256 amount) external;
 
-    function withdrawAllTokenCommission(address token, address to) external;
+    /// @notice Withdraw all accrued commission for `token` to the immutable
+    ///         `commissionRecipient`.
+    function withdrawAllTokenCommission(address token) external;
 
-    function withdrawAllNativeCommission(address payable to) external;
+    /// @notice Withdraw all accrued native commission to the immutable
+    ///         `commissionRecipient`.
+    function withdrawAllNativeCommission() external;
 }

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -25,9 +25,10 @@ import {IBridge} from "./IBridge.sol";
 ///      COMMISSION MANAGER
 ///      This proxy is the owner of the CommissionManager. Federation can reach CM via:
 ///        - typed `WithdrawTokenCommissionCM` / `WithdrawNativeCommissionCM`
-///          (destination is always the stored `commissionRecipient`).
+///          (CM always pays its immutable `commissionRecipient`).
 ///        - generic `AdminExecuteCommissionManager` for rare config changes
-///          (route rules, global defaults, mock rates, transferOwnership, …).
+///          (route rules, global defaults, mock rates, ownership migration, …).
+///          Withdrawal selectors are reserved for the typed operations.
 ///        - `UpdateCommissionManager` to migrate to a redeployed CM.
 ///
 ///      BITMAP ENCODING
@@ -44,7 +45,6 @@ interface IMultisigProxy {
     error ZeroCommissionManager();
     error NoSigners();
     error InvalidThreshold();
-    error ZeroCommissionRecipient();
     error TimelockTooLong();
     error TimelockTooShort();
     error InvalidMinTimelock();
@@ -71,7 +71,6 @@ interface IMultisigProxy {
     error TooManyEnclaveSourceChains(uint256 count, uint256 max);
     error CallFailed();
     error UnknownOperationType();
-    error ZeroRecipient();
     error ZeroTarget();
     error ForbiddenCommissionManagerSelector(bytes4 selector);
     error LZAdapterNotSet();
@@ -86,20 +85,19 @@ interface IMultisigProxy {
         UpdateEnclaveSigners, // 1  — replace the enclave signer set + threshold
         UpdateFederationSigners, // 2  — replace the federation signer set + threshold
         UpdateBridge, // 3  — repoint the owned Bridge address
-        SetCommissionRecipient, // 4  — set the pinned commission payout recipient
-        SetTimelockDuration, // 5  — change the governance timelock (>= MIN_TIMELOCK)
-        AdminExecuteCommissionManager, // 6  — generic call into CommissionManager
-        WithdrawTokenCommissionCM, // 7  — CM.withdrawTokenCommission -> commissionRecipient
-        WithdrawNativeCommissionCM, // 8  — CM.withdrawNativeCommission -> commissionRecipient
-        UpdateCommissionManager, // 9  — migrate to a new CommissionManager address
-        AdminExecuteAdapter, // 10 — generic call into LZAdapter (setTrustedEntrypoint, refundStuckFunds, …)
-        UpdateLZAdapter, // 11 — rotate the routing target for AdminExecuteAdapter
-        SetRoute, // 12 — RouteRegistry.setRoute(src, dst, enabled, verifier, module)
-        UpdateRouteRegistry, // 13 — Bridge.setRouteRegistry(newRouteRegistry)
-        PauseInflow, // 14 — Bridge.pauseInflow()  (planned inflow-only freeze, timelocked)
-        UnpauseInflow, // 15 — Bridge.unpauseInflow()
-        DisableLZAdapter, // 16 — clear the routing target (explicit disable, distinct from UpdateLZAdapter rotation)
-        AdminExecuteRouteRegistry // 17 — generic call into RouteRegistry (transferOwnership/acceptOwnership, setRoute, …)
+        SetTimelockDuration, // 4  — change the governance timelock (>= MIN_TIMELOCK)
+        AdminExecuteCommissionManager, // 5  — generic call into CommissionManager
+        WithdrawTokenCommissionCM, // 6  — CM.withdrawTokenCommission -> immutable recipient
+        WithdrawNativeCommissionCM, // 7  — CM.withdrawNativeCommission -> immutable recipient
+        UpdateCommissionManager, // 8  — migrate to a new CommissionManager address
+        AdminExecuteAdapter, // 9 — generic call into LZAdapter (setTrustedEntrypoint, refundStuckFunds, …)
+        UpdateLZAdapter, // 10 — rotate the routing target for AdminExecuteAdapter
+        SetRoute, // 11 — RouteRegistry.setRoute(src, dst, enabled, verifier, module)
+        UpdateRouteRegistry, // 12 — Bridge.setRouteRegistry(newRouteRegistry)
+        PauseInflow, // 13 — Bridge.pauseInflow()  (planned inflow-only freeze, timelocked)
+        UnpauseInflow, // 14 — Bridge.unpauseInflow()
+        DisableLZAdapter, // 15 — clear the routing target (explicit disable, distinct from UpdateLZAdapter rotation)
+        AdminExecuteRouteRegistry // 16 — generic call into RouteRegistry (transferOwnership/acceptOwnership, setRoute, …)
     }
 
     enum ProposalStatus {
@@ -176,7 +174,6 @@ interface IMultisigProxy {
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event LZAdapterDisabled(address indexed oldAdapter);
-    event CommissionRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
     event CommissionWithdrawn(address indexed token, uint256 amount, address indexed recipient);
     event NativeCommissionWithdrawn(uint256 amount, address indexed recipient);
     event TimelockDurationUpdated(uint256 newDuration);
@@ -283,17 +280,6 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose changing the commission recipient (used as the destination for
-    ///         all typed `WithdrawTokenCommissionCM` / `WithdrawNativeCommissionCM` ops).
-    /// @dev opData = abi.encode(address newRecipient)
-    function proposeSetCommissionRecipient(
-        address newRecipient,
-        uint256 nonce,
-        uint256 deadline,
-        uint256 fedBitmap,
-        bytes[] calldata fedSigs
-    ) external returns (bytes32);
-
     /// @notice Propose changing the timelock duration.
     /// @dev opData = abi.encode(uint256 newDuration)
     function proposeSetTimelockDuration(
@@ -306,9 +292,10 @@ interface IMultisigProxy {
 
     // --- CommissionManager-targeted operations ---
 
-    /// @notice Propose an arbitrary call into the CommissionManager.
+    /// @notice Propose a permitted generic call into the CommissionManager.
     /// @dev Used for rare configuration: setCommissionRule, setGlobalDefaults,
     ///      setMockTokenToNativeRate, setBridgeAddress, transferOwnership, …
+    ///      Withdrawal selectors are reserved for the typed operations.
     /// @dev opData = raw ABI-encoded CommissionManager callData (selector + args).
     function proposeAdminExecuteCommissionManager(
         bytes calldata callData,
@@ -333,8 +320,8 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose an ERC-20 commission withdrawal from the CommissionManager
-    ///         to the stored `commissionRecipient`.
+    /// @notice Propose an ERC-20 commission withdrawal from the CommissionManager.
+    ///         The CM pays its immutable `commissionRecipient`.
     /// @dev opData = abi.encode(address token, uint256 amount)
     function proposeWithdrawTokenCommissionCM(
         address token,
@@ -345,8 +332,8 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose a native commission withdrawal from the CommissionManager
-    ///         to the stored `commissionRecipient`.
+    /// @notice Propose a native commission withdrawal from the CommissionManager.
+    ///         The CM pays its immutable `commissionRecipient`.
     /// @dev opData = abi.encode(uint256 amount)
     function proposeWithdrawNativeCommissionCM(
         uint256 amount,
@@ -490,6 +477,7 @@ interface IMultisigProxy {
     function enclaveThreshold(uint256 sourceChainId) external view returns (uint256);
     function getFederationSigners() external view returns (address[] memory);
     function federationThreshold() external view returns (uint256);
+    /// @notice Immutable recipient reported by the current CommissionManager.
     function commissionRecipient() external view returns (address);
     function DOMAIN_SEPARATOR() external view returns (bytes32);
     function proposalNonce() external view returns (uint256);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -27,6 +27,7 @@ import {MockSettlementModule} from "./mocks/MockSettlementModule.sol";
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract BridgeTest is Test {
     // Events re-declared locally for vm.expectEmit
@@ -69,6 +70,7 @@ contract BridgeTest is Test {
     RGBVerifier rgbVerifier;
     RgbSettlementModule rgbModule;
     MockAggregatorV3 ethUsdFeed;
+    MockAggregatorV3 sequencerUptimeFeed;
 
     address deployer = makeAddr("deployer");
     address user = makeAddr("user");
@@ -99,6 +101,10 @@ contract BridgeTest is Test {
     uint256 constant LATEST_CONFIRMATIONS = 1;
 
     function setUp() public {
+        // Leave enough history for the healthy sequencer round to be past the
+        // mandatory one-hour post-restart grace period.
+        vm.warp(2 hours);
+
         usdt0 = new MockERC20("Mock USDT0", "USDT0");
         btcRelay = new MockBtcRelay();
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, CONFIRMATIONS);
@@ -116,7 +122,7 @@ contract BridgeTest is Test {
         uint64 currentNonce = vm.getNonce(deployer);
         address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
 
-        cm = new CommissionManager(predictedBridge);
+        cm = new CommissionManager(predictedBridge, recipient);
         routeRegistry = new RouteRegistry(predictedBridge, deployer);
         bridge = new Bridge(
             address(usdt0),
@@ -133,9 +139,12 @@ contract BridgeTest is Test {
         routeRegistry.setRoute(SOURCE_CHAIN_ID, RGB_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
         routeRegistry.setRoute(RGB_CHAIN_ID, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
 
-        // Wire a Chainlink ETH/USD feed ($2000 / ETH, 8 decimals, fresh) so
-        // the NATIVE commission path quotes a positive value.
+        // Wire the complete mandatory R-I-14 oracle config: healthy sequencer,
+        // ETH/USD circuit-breaker bounds, then the fresh ETH/USD price feed.
         ethUsdFeed = new MockAggregatorV3(8, 2_000e8, block.timestamp);
+        sequencerUptimeFeed = new MockAggregatorV3(0, 0, block.timestamp - 1 hours - 1);
+        cm.setSequencerUptimeFeed(address(sequencerUptimeFeed));
+        cm.setEthUsdPriceBounds(100e8, 100_000e8);
         cm.setEthUsdFeed(address(ethUsdFeed), 1 hours);
 
         // Production-flow ownership transfer of Bridge → multisig. CM and
@@ -390,6 +399,29 @@ contract BridgeTest is Test {
         );
     }
 
+    /// @dev Accepted `msg.value` band on the DIRECT overload: the floor is the
+    ///      fresh quote itself, because the headroom above it is a refundable
+    ///      drift buffer rather than extra commission.
+    function _directNativeBounds(uint256 nativeCommission) internal view returns (uint256 minimum, uint256 maximum) {
+        uint256 denominator = bridge.BPS_DENOMINATOR();
+        uint256 tolerance = bridge.NATIVE_COMMISSION_TOLERANCE_BPS();
+        minimum = nativeCommission;
+        maximum = Math.mulDiv(nativeCommission, denominator + tolerance, denominator);
+    }
+
+    /// @dev Accepted `msg.value` band on the ADAPTER overload: symmetric, since
+    ///      the source-chain payer is unreachable and nothing can be refunded.
+    function _adapterNativeBounds(uint256 nativeCommission) internal view returns (uint256 minimum, uint256 maximum) {
+        uint256 denominator = bridge.BPS_DENOMINATOR();
+        uint256 tolerance = bridge.NATIVE_COMMISSION_TOLERANCE_BPS();
+        minimum = Math.mulDiv(nativeCommission, denominator - tolerance, denominator, Math.Rounding.Ceil);
+        maximum = Math.mulDiv(nativeCommission, denominator + tolerance, denominator);
+    }
+
+    function _nativeQuote(uint256 amount) internal view returns (uint256 quote) {
+        (, quote,) = cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), amount);
+    }
+
     /// @dev Ensure `requested` fits under the configured bucket burst (and
     ///      therefore also under the immutable 20% safety ceiling). Used by
     ///      legacy success-path tests whose subject is not the C-01 limiter.
@@ -631,23 +663,50 @@ contract BridgeTest is Test {
 
     function test_fundsIn_dustThatRoundsCommissionToZeroIsRejected() public {
         // 4% token commission. Below 25 units the fee floors to zero
-        // (24 * 400 / 100 / 100 == 0) — the exact dust case R-I-08 describes.
-        // A floor of 25 keeps such dust off the inbound path; at 25 the fee is
-        // a non-zero 1 unit.
+        // (24 * 400 / 100 / 100 == 0) — the exact dust case I-08 describes.
+        // The effective fee policy itself now rejects that dust, independently
+        // of the separately configurable global minimum.
         _setFundsInTokenRule(400);
-        vm.prank(multisig);
-        bridge.setMinFundsInAmount(25);
 
         assertEq(cm.calculateStableFee(24, 400, 100), 0, "sanity: 24 pays zero commission");
 
-        vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, uint256(24), uint256(25)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICommissionManager.CommissionRoundsToZero.selector, uint256(24), uint256(400), uint8(100)
+            )
+        );
         vm.prank(user);
         bridge.fundsIn(24, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        // At the floor the deposit is accepted and pays a non-zero commission.
+        // The smallest amount that produces one fee unit is accepted.
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(25, RGB_CHAIN_ID, DST_ADDR, _rgbData());
         assertEq(rgbModule.fundsInRecords(opId), 24, "net = 25 - 1 commission");
+    }
+
+    function test_R_I_08_fundsOutDustThatRoundsCommissionToZeroIsRejected() public {
+        uint256 dustAmount = 24;
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn(dustAmount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(dustAmount);
+        _setFundsOutTokenRule(400);
+
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlementWithAmounts(_ids(opId), _one(dustAmount));
+        uint256 burnId =
+            _deriveBurnId(recipient, dustAmount, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICommissionManager.CommissionRoundsToZero.selector, dustAmount, uint256(400), uint8(100)
+            )
+        );
+        vm.prank(multisig);
+        _fundsOutWithBurnId(
+            recipient, dustAmount, burnId, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData
+        );
+
+        assertFalse(bridge.consumedBurnIds(burnId), "reverted release does not consume burn id");
     }
 
     function test_fundsInFromAdapter_revertsBelowMinimum() public {
@@ -2215,7 +2274,7 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
-    // Commission — NativeValueMismatch
+    // Commission — I-03 bounded native quote drift
     // ========================================================================
 
     function test_fundsIn_revertsOnNativeValueMismatch_zeroRuleButValueSent() public {
@@ -2228,52 +2287,260 @@ contract BridgeTest is Test {
     function test_fundsIn_revertsOnNativeValueMismatch_nativeRuleButNoValue() public {
         _setFundsInNativeRule(100);
 
-        vm.expectRevert(IBridge.NativeValueMismatch.selector);
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _directNativeBounds(quote);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeCommissionOutOfBounds.selector, uint256(0), minimum, maximum)
+        );
         vm.prank(user);
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
-    // R-I-03 after-fix: a native overpayment (favorable ETH/USD drift between
-    // quote and execution) is now accepted; the FULL msg.value is collected as
-    // commission (not refunded, not stranded) and the deposit completes.
-    function test_fundsIn_nativeOverpayAcceptedAndCollected_afterFix() public {
+    // ========================================================================
+    // I-03 — native commission drift band
+    //
+    // Direct deposits: attach the quote plus optional headroom; exactly the
+    // fresh quote is charged and the remainder refunded, so the protocol never
+    // under-collects and the caller is never overcharged.
+    // Adapter deposits: the source-chain payer is unreachable, so the band is
+    // symmetric and whatever arrives inside it is collected in full.
+    // ========================================================================
+
+    function test_I_03_direct_exactQuoteChargedInFull() public {
         _setFundsInNativeRule(100);
+        uint256 quote = _nativeQuote(AMOUNT);
+        assertGt(quote, 0, "native fee quoted");
 
-        (, uint256 nativeCommission,) =
-            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
-        assertGt(nativeCommission, 0, "native fee quoted");
-
-        uint256 sent = nativeCommission + 0.01 ether; // overpay (price moved down)
-        vm.deal(user, sent);
-
-        uint256 cmNativeBefore = address(cm).balance;
-        uint256 nativePoolBefore = cm.nativeCommissionPool();
+        vm.deal(user, quote);
+        uint256 poolBefore = cm.nativeCommissionPool();
 
         vm.prank(user);
-        bytes32 opId = bridge.fundsIn{value: sent}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        bytes32 opId = bridge.fundsIn{value: quote}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        // Full msg.value collected as commission — surplus neither refunded nor
-        // left in the Bridge.
-        assertEq(address(cm).balance, cmNativeBefore + sent, "cm received full msg.value");
-        assertEq(cm.nativeCommissionPool(), nativePoolBefore + sent, "native pool credited full msg.value");
+        assertEq(cm.nativeCommissionPool(), poolBefore + quote, "pool credited exactly the quote");
+        assertEq(user.balance, 0, "nothing to refund");
         assertEq(address(bridge).balance, 0, "no native stranded in bridge");
-        // Deposit completed: RGB record created (NATIVE rule → token commission 0, net == gross).
-        assertEq(rgbModule.fundsInRecords(opId), AMOUNT, "deposit recorded from actual amount");
+        assertEq(rgbModule.fundsInRecords(opId), AMOUNT, "deposit completed");
     }
 
-    // R-I-03: underpaying the freshly-quoted native commission (price moved up)
-    // still reverts — the lower bound is enforced.
-    function test_fundsIn_nativeUnderpayReverts_afterFix() public {
+    /// @dev The invariant I-03 asks for: a caller who attaches more than the
+    ///      quote is charged only the quote and refunded the surplus.
+    function test_I_03_direct_surplusIsRefundedNotCollected() public {
+        _setFundsInNativeRule(100);
+        uint256 quote = _nativeQuote(AMOUNT);
+        uint256 attached = quote + (quote * 400) / 10_000; // +4%, inside the band
+
+        vm.deal(user, attached);
+        uint256 poolBefore = cm.nativeCommissionPool();
+
+        vm.prank(user);
+        bridge.fundsIn{value: attached}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(cm.nativeCommissionPool(), poolBefore + quote, "protocol collected ONLY the quote");
+        assertEq(user.balance, attached - quote, "caller refunded the whole surplus");
+        assertEq(address(bridge).balance, 0, "no native stranded in bridge");
+    }
+
+    function test_I_03_direct_upperBoundaryRefunded() public {
+        _setFundsInNativeRule(100);
+        uint256 quote = _nativeQuote(AMOUNT);
+        (, uint256 maximum) = _directNativeBounds(quote);
+
+        vm.deal(user, maximum);
+        vm.prank(user);
+        bridge.fundsIn{value: maximum}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(cm.nativeCommissionPool(), quote, "still only the quote is collected");
+        assertEq(user.balance, maximum - quote, "full headroom refunded");
+    }
+
+    function test_I_03_direct_revertsBelowQuote() public {
+        _setFundsInNativeRule(100);
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _directNativeBounds(quote);
+        uint256 provided = minimum - 1;
+
+        vm.deal(user, provided);
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeCommissionOutOfBounds.selector, provided, minimum, maximum)
+        );
+        vm.prank(user);
+        bridge.fundsIn{value: provided}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+    }
+
+    function test_I_03_direct_revertsAboveUpperBoundary() public {
+        _setFundsInNativeRule(100);
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _directNativeBounds(quote);
+        uint256 provided = maximum + 1;
+
+        vm.deal(user, provided);
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeCommissionOutOfBounds.selector, provided, minimum, maximum)
+        );
+        vm.prank(user);
+        bridge.fundsIn{value: provided}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+    }
+
+    /// @dev The scenario from the finding: quote, then the price moves against
+    ///      the caller before the tx mines. The attached buffer absorbs it and
+    ///      the deposit succeeds, charged at the FRESH (higher) quote.
+    function test_I_03_direct_adverseDriftAbsorbedByBuffer() public {
+        _setFundsInNativeRule(100);
+        uint256 quotedAtSubmit = _nativeQuote(AMOUNT);
+        uint256 attached = quotedAtSubmit + (quotedAtSubmit * 400) / 10_000; // +4% buffer
+
+        // ETH depreciates ~3%: the same fee costs more wei than first quoted,
+        // but less than the 4% buffer the caller attached.
+        ethUsdFeed.setAnswer(1_940e8);
+        uint256 freshQuote = _nativeQuote(AMOUNT);
+        assertGt(freshQuote, quotedAtSubmit, "drift moved against the caller");
+        assertLe(freshQuote, attached, "the buffer covers the drift, so no revert");
+
+        vm.deal(user, attached);
+        vm.prank(user);
+        bridge.fundsIn{value: attached}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(cm.nativeCommissionPool(), freshQuote, "charged the fresh quote, not the stale one");
+        assertEq(user.balance, attached - freshQuote, "remaining buffer refunded");
+    }
+
+    /// @dev Favorable drift simply returns more: the caller is charged the fresh
+    ///      (lower) quote, never the stale higher one.
+    function test_I_03_direct_favorableDriftRefundsMore() public {
+        _setFundsInNativeRule(100);
+        uint256 quotedAtSubmit = _nativeQuote(AMOUNT);
+
+        ethUsdFeed.setAnswer(2_090e8); // ETH appreciates: the fee costs less wei
+        uint256 freshQuote = _nativeQuote(AMOUNT);
+        assertLt(freshQuote, quotedAtSubmit, "drift moved in the caller's favour");
+
+        vm.deal(user, quotedAtSubmit);
+        vm.prank(user);
+        bridge.fundsIn{value: quotedAtSubmit}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(cm.nativeCommissionPool(), freshQuote, "charged the fresh, lower quote");
+        assertEq(user.balance, quotedAtSubmit - freshQuote, "difference refunded");
+    }
+
+    /// @dev The protocol cannot be systematically under-paid: every deposit
+    ///      credits exactly the quote in force at execution.
+    function test_I_03_direct_noSystematicUnderCollection() public {
+        _setFundsInNativeRule(100);
+        uint256 expected;
+
+        for (uint256 i; i < 3; i++) {
+            uint256 quote = _nativeQuote(AMOUNT);
+            (, uint256 maximum) = _directNativeBounds(quote);
+            vm.deal(user, maximum);
+            vm.prank(user);
+            bridge.fundsIn{value: maximum}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(RGB_OP_ID + 900 + i));
+            expected += quote;
+        }
+
+        assertEq(cm.nativeCommissionPool(), expected, "collected exactly the sum of the quotes");
+    }
+
+    /// @dev A caller that cannot accept native value must send the exact quote;
+    ///      attaching a buffer it cannot be refunded reverts cleanly.
+    function test_I_03_direct_nonPayableCallerMustSendExactQuote() public {
+        _setFundsInNativeRule(100);
+        NonPayableDepositor depositor = new NonPayableDepositor(bridge, usdt0);
+        usdt0.mint(address(depositor), AMOUNT * 2);
+        depositor.approveBridge(AMOUNT * 2);
+
+        uint256 quote = _nativeQuote(AMOUNT);
+
+        // Exact quote: nothing to refund, so the deposit goes through.
+        vm.deal(address(depositor), quote);
+        depositor.deposit(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(), quote);
+        assertEq(cm.nativeCommissionPool(), quote, "exact quote accepted from a non-payable caller");
+
+        // With a buffer the refund cannot land, and the deposit reverts.
+        uint256 attached = quote + (quote * 200) / 10_000;
+        vm.deal(address(depositor), attached);
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeRefundFailed.selector, address(depositor), attached - quote)
+        );
+        depositor.deposit(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(RGB_OP_ID + 951), attached);
+    }
+
+    function test_I_03_adapter_symmetricBandCollectedInFull() public {
         _setFundsInNativeRule(100);
 
-        (, uint256 nativeCommission,) =
-            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), AMOUNT);
-        assertGt(nativeCommission, 1, "native fee quoted");
+        address adapter = makeAddr("lz-adapter");
+        vm.prank(multisig);
+        bridge.setLZAdapter(adapter);
+        usdt0.mint(adapter, AMOUNT * 2);
+        vm.prank(adapter);
+        usdt0.approve(address(bridge), AMOUNT * 2);
 
-        vm.deal(user, nativeCommission);
-        vm.expectRevert(IBridge.NativeValueMismatch.selector);
-        vm.prank(user);
-        bridge.fundsIn{value: nativeCommission - 1}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _adapterNativeBounds(quote);
+        assertLt(minimum, quote, "adapter band extends BELOW the quote");
+
+        // Below the quote is accepted here — and collected in full, since the
+        // source-chain payer cannot be refunded.
+        vm.deal(adapter, minimum);
+        vm.prank(adapter);
+        bridge.fundsIn{value: minimum}(
+            AMOUNT, SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+        assertEq(cm.nativeCommissionPool(), minimum, "source-agreed value collected in full");
+        assertEq(adapter.balance, 0, "adapter is not refunded");
+
+        // Above the quote is likewise collected in full, not refunded.
+        vm.deal(adapter, maximum);
+        vm.prank(adapter);
+        bridge.fundsIn{value: maximum}(
+            AMOUNT, SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), RGB_CHAIN_ID, DST_ADDR, _rgbData(RGB_OP_ID + 961)
+        );
+        assertEq(cm.nativeCommissionPool(), minimum + maximum, "upper bound also collected in full");
+        assertEq(adapter.balance, 0, "adapter still not refunded");
+        assertEq(address(bridge).balance, 0, "no native stranded in bridge");
+    }
+
+    function test_I_03_adapter_revertsBelowLowerBoundary() public {
+        _setFundsInNativeRule(100);
+
+        address adapter = makeAddr("lz-adapter");
+        vm.prank(multisig);
+        bridge.setLZAdapter(adapter);
+
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _adapterNativeBounds(quote);
+        uint256 provided = minimum - 1;
+        vm.deal(adapter, provided);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeCommissionOutOfBounds.selector, provided, minimum, maximum)
+        );
+        vm.prank(adapter);
+        bridge.fundsIn{value: provided}(
+            AMOUNT, SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
+    }
+
+    function test_I_03_adapter_revertsAboveUpperBoundary() public {
+        _setFundsInNativeRule(100);
+
+        address adapter = makeAddr("lz-adapter");
+        vm.prank(multisig);
+        bridge.setLZAdapter(adapter);
+
+        uint256 quote = _nativeQuote(AMOUNT);
+        (uint256 minimum, uint256 maximum) = _adapterNativeBounds(quote);
+        uint256 provided = maximum + 1;
+        vm.deal(adapter, provided);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IBridge.NativeCommissionOutOfBounds.selector, provided, minimum, maximum)
+        );
+        vm.prank(adapter);
+        bridge.fundsIn{value: provided}(
+            AMOUNT, SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), RGB_CHAIN_ID, DST_ADDR, _rgbData()
+        );
     }
 
     // ========================================================================
@@ -3169,70 +3436,25 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId2), netAmount, "second record created");
     }
 
-    // A positive gross deposit with zero net leaves a zero record — the RGB
-    // duplicate guard is value-based, so a zero record does not occupy the id.
-    // Post R-W-08 each deposit derives a distinct id anyway; this proves the
-    // zero-net record semantics still hold under a derived id.
-    function test_fundsIn_zeroNetDepositLeavesZeroRecord_currentBehavior() public {
-        // stablePercent == multiplier^2 makes tokenCommission == amount.
-        vm.prank(deployer);
-        cm.setCommissionRule(
-            SOURCE_CHAIN_ID,
-            RGB_CHAIN_ID,
-            address(usdt0),
-            CommissionConfig({
-                stablePercent: 8_100,
-                multiplier: 90,
-                side: CommissionSide.FUNDS_IN,
-                currency: CommissionCurrency.TOKEN,
-                isSet: true
-            })
+    /// @dev I-08 regression: the auditor's 100% fee shape is rejected before
+    ///      it can become an active route rule and create zero-net records.
+    function test_R_I_08_hundredPercentRouteRuleCannotBeConfigured() public {
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 8_100,
+            multiplier: 90,
+            side: CommissionSide.FUNDS_IN,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, cfg.stablePercent, cfg.multiplier)
         );
+        vm.prank(deployer);
+        cm.setCommissionRule(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), cfg);
 
-        _assertZeroNetDepositLeavesZeroRecord(1);
-        _assertZeroNetDepositLeavesZeroRecord(AMOUNT / 2);
-        _assertZeroNetDepositLeavesZeroRecord(AMOUNT);
-    }
-
-    function _assertZeroNetDepositLeavesZeroRecord(uint256 amount) internal {
-        (uint256 tokenCommission,, uint256 netAmount) =
-            cm.calculateFundsInCommission(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0), amount);
-
-        assertEq(tokenCommission, amount, "pre fee equals amount");
-        assertEq(netAmount, 0, "pre zero net");
-
-        uint256 userBefore = usdt0.balanceOf(user);
-        uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
-        uint256 cmBefore = usdt0.balanceOf(address(cm));
-        uint256 cmPoolBefore = cm.tokenCommissionPool(address(usdt0));
-        uint256 nativePoolBefore = cm.nativeCommissionPool();
-
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsIn(user, RGB_OP_ID, 0);
-        vm.prank(user);
-        bytes32 opId1 = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
-
-        assertEq(usdt0.balanceOf(user), userBefore - amount, "user spent first gross");
-        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, "bridge keeps no net");
-        assertEq(usdt0.balanceOf(address(cm)), cmBefore + amount, "cm got first gross");
-        assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore + amount, "cm pool first gross");
-        assertEq(cm.nativeCommissionPool(), nativePoolBefore, "native pool unchanged");
-        assertEq(rgbModule.fundsInRecords(opId1), 0, "zero-net leaves zero record");
-
-        // A second identical deposit derives a distinct id and also leaves a
-        // zero record — no collision, no revert.
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsIn(user, RGB_OP_ID, 0);
-        vm.prank(user);
-        bytes32 opId2 = bridge.fundsIn(amount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
-
-        assertTrue(opId2 != opId1, "second deposit distinct id");
-        assertEq(usdt0.balanceOf(user), userBefore - (2 * amount), "user spent duplicate gross");
-        assertEq(usdt0.balanceOf(address(bridge)), bridgeBefore, "bridge still keeps no net");
-        assertEq(usdt0.balanceOf(address(cm)), cmBefore + (2 * amount), "cm got duplicate gross");
-        assertEq(cm.tokenCommissionPool(address(usdt0)), cmPoolBefore + (2 * amount), "cm pool duplicate gross");
-        assertEq(cm.nativeCommissionPool(), nativePoolBefore, "duplicate native pool unchanged");
-        assertEq(rgbModule.fundsInRecords(opId2), 0, "second zero record");
+        CommissionConfig memory stored = cm.getCommissionRule(SOURCE_CHAIN_ID, RGB_CHAIN_ID, address(usdt0));
+        assertFalse(stored.isSet, "invalid rule was not stored");
     }
 
     // ========================================================================
@@ -3375,7 +3597,7 @@ contract BridgeTest is Test {
         uint64 currentNonce = vm.getNonce(deployer);
         address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
 
-        s.cm = new CommissionManager(predictedBridge);
+        s.cm = new CommissionManager(predictedBridge, recipient);
         RouteRegistry feeRouteRegistry = new RouteRegistry(predictedBridge, deployer);
         s.bridge = new Bridge(address(s.token), address(feeRouteRegistry), payable(address(s.cm)), address(0), 1);
 
@@ -3386,6 +3608,8 @@ contract BridgeTest is Test {
         feeRouteRegistry.setRoute(SOURCE_CHAIN_ID, RGB_CHAIN_ID, true, address(rgbVerifier), address(s.module));
         feeRouteRegistry.setRoute(RGB_CHAIN_ID, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(s.module));
 
+        s.cm.setSequencerUptimeFeed(address(sequencerUptimeFeed));
+        s.cm.setEthUsdPriceBounds(100e8, 100_000e8);
         s.cm.setEthUsdFeed(address(ethUsdFeed), 1 hours);
 
         s.bridge.transferOwnership(multisig);
@@ -3570,11 +3794,11 @@ contract BridgeTest is Test {
         assertEq(s.bridge.lockedLiquidity(RGB_CHAIN_ID), received * 9, "90% bucket reserve remains locked");
     }
 
-    // --- Received < tokenCommission reverts InsufficientReceived ---
+    // --- Received <= tokenCommission reverts InsufficientReceived ---
     //
     // Fee = 9000 bps (90%) → received = 10% of AMOUNT = 10e18. The fee-shape
     // guard caps the commission fraction at `stablePercent / multiplier^2`
-    // (stablePercent ≤ 9000, stablePercent ≤ multiplier^2). Choosing
+    // (stablePercent ≤ 9000, stablePercent < multiplier^2). Choosing
     // multiplier = 95, stablePercent = 9000 yields a fraction 9000/9025 ≈ 99.7%,
     // so the commission quote on the NOMINAL AMOUNT (~99.7e18) far exceeds the
     // actual received (10e18) — configurable within the guard, so no boundary
@@ -3593,4 +3817,51 @@ contract BridgeTest is Test {
         vm.prank(user);
         s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
+
+    /// @dev I-08: a nominally valid (<100%) commission can still consume the
+    ///      full ACTUAL receipt when the token charges a transfer fee. Equality
+    ///      must revert rather than recording a zero-net settlement.
+    function test_R_I_08_fundsInFeeTokenRevertsWhenActualNetWouldBeZero() public {
+        FeeStack memory s = _deployFeeStack(5000); // Bridge receives 50%
+        _setFeeStackFundsInTokenRule(s, 5000, 100); // nominal commission is 50%
+
+        uint256 received = AMOUNT - s.token.feeOn(AMOUNT);
+        uint256 tokenCommission = s.cm.calculateStableFee(AMOUNT, 5000, 100);
+        assertEq(received, tokenCommission, "sanity: actual receipt equals nominal commission");
+
+        vm.expectRevert(abi.encodeWithSelector(IBridge.InsufficientReceived.selector, received, tokenCommission));
+        vm.prank(user);
+        s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(s.bridge.lockedLiquidity(RGB_CHAIN_ID), 0, "zero-net liquidity was not recorded");
+        assertEq(s.cm.tokenCommissionPool(address(s.token)), 0, "commission transfer rolled back");
+    }
+}
+
+/// @dev Caller that deliberately cannot receive native value, used to cover the
+///      `NativeRefundFailed` path on the direct `fundsIn` overload.
+contract NonPayableDepositor {
+    Bridge private immutable _bridge;
+    MockERC20 private immutable _token;
+
+    constructor(Bridge bridge_, MockERC20 token_) {
+        _bridge = bridge_;
+        _token = token_;
+    }
+
+    function approveBridge(uint256 amount) external {
+        _token.approve(address(_bridge), amount);
+    }
+
+    function deposit(
+        uint256 amount,
+        uint256 destinationChainId,
+        string calldata destinationAddress,
+        bytes calldata settlementData,
+        uint256 nativeValue
+    ) external returns (bytes32) {
+        return _bridge.fundsIn{value: nativeValue}(amount, destinationChainId, destinationAddress, settlementData);
+    }
+
+    // no receive / fallback: any refund attempt fails
 }

--- a/ethereum/test/BridgeRebalance.t.sol
+++ b/ethereum/test/BridgeRebalance.t.sol
@@ -101,7 +101,7 @@ contract BridgeRebalanceTest is Test {
         uint64 currentNonce = vm.getNonce(deployer);
         address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
 
-        cm = new CommissionManager(predictedBridge);
+        cm = new CommissionManager(predictedBridge, deployer);
         routeRegistry = new RouteRegistry(predictedBridge, deployer);
         bridge = new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 1);
 

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -17,6 +17,7 @@ contract CommissionManagerTest is Test {
     CommissionManager internal cm;
     MockERC20 internal token;
     MockAggregatorV3 internal ethUsdFeed;
+    MockAggregatorV3 internal sequencerFeed;
 
     address internal constant BRIDGE = address(0xB01);
     address internal owner = makeAddr("owner");
@@ -35,6 +36,8 @@ contract CommissionManagerTest is Test {
     uint8 internal constant FEED_DECIMALS = 8;
     int256 internal constant DEFAULT_ETH_USD = 2_000e8; // $2000 / ETH
     uint256 internal constant HEARTBEAT = 1 hours;
+    uint256 internal constant MIN_ETH_USD = 100e8;
+    uint256 internal constant MAX_ETH_USD = 100_000e8;
 
     event BridgeAddressUpdated(address indexed newBridge);
     event GlobalDefaultsUpdated(
@@ -52,29 +55,39 @@ contract CommissionManagerTest is Test {
         vm.warp(HEARTBEAT * 10);
 
         vm.prank(owner);
-        cm = new CommissionManager(BRIDGE);
+        cm = new CommissionManager(BRIDGE, recipient);
         token = new MockERC20("Test", "TST");
         vm.prank(owner);
         cm.setGlobalDefaults(0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
 
-        // Deploy a default ETH/USD feed and wire it in. Tests that need to
-        // exercise the "feed unset" branch redeploy CM without calling
-        // `setEthUsdFeed` (see test_convertTokenFeeToNative_revertsIfFeedUnset).
+        // Install a complete healthy Arbitrum oracle config. R-I-14 makes the
+        // sequencer feed and price band mandatory whenever a non-zero NATIVE
+        // quote consumes ETH/USD.
         ethUsdFeed = new MockAggregatorV3(FEED_DECIMALS, DEFAULT_ETH_USD, block.timestamp);
-        vm.prank(owner);
+        sequencerFeed = new MockAggregatorV3(0, 0, block.timestamp - cm.SEQUENCER_GRACE_PERIOD() - 1);
+        vm.startPrank(owner);
+        cm.setSequencerUptimeFeed(address(sequencerFeed));
+        cm.setEthUsdPriceBounds(MIN_ETH_USD, MAX_ETH_USD);
         cm.setEthUsdFeed(address(ethUsdFeed), HEARTBEAT);
+        vm.stopPrank();
     }
 
     // --- Constructor ---
 
     function test_constructor_setsBridgeAndOwner() public view {
         assertEq(cm.bridgeAddress(), BRIDGE);
+        assertEq(cm.commissionRecipient(), recipient);
         assertEq(cm.owner(), owner);
     }
 
     function test_constructor_revertsOnZeroBridge() public {
         vm.expectRevert(ICommissionManager.InvalidBridgeAddress.selector);
-        new CommissionManager(address(0));
+        new CommissionManager(address(0), recipient);
+    }
+
+    function test_constructor_revertsOnZeroCommissionRecipient() public {
+        vm.expectRevert(ICommissionManager.InvalidRecipient.selector);
+        new CommissionManager(BRIDGE, address(0));
     }
 
     function test_renounceOwnership_blocked() public {
@@ -108,7 +121,7 @@ contract CommissionManagerTest is Test {
     function test_convertTokenFeeToNative_revertsIfFeedUnset() public {
         // Fresh CM with no feed configured.
         vm.prank(owner);
-        CommissionManager freshCm = new CommissionManager(BRIDGE);
+        CommissionManager freshCm = new CommissionManager(BRIDGE, recipient);
         vm.expectRevert(ICommissionManager.EthUsdFeedNotSet.selector);
         freshCm.convertTokenFeeToNative(1e18, 18);
     }
@@ -143,17 +156,14 @@ contract CommissionManagerTest is Test {
         cm.convertTokenFeeToNative(1, 19);
     }
 
-    // With the min/max band UNSET (the default), a fresh positive answer is
-    // accepted no matter how extreme — which is exactly why an Arbitrum
-    // deployment configures `setEthUsdPriceBounds`. Band-enabled rejection is
-    // covered by test_convertTokenFeeToNative_revertsWhenPriceBelowMin/AboveMax.
-    function test_convertTokenFeeToNative_allowsOutlierWhenBandUnset() public {
+    function test_convertTokenFeeToNative_revertsBeforeReadingOutlierWhenBandUnset() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(0, 0);
         ethUsdFeed.setAnswer(1); // $1e-8 — an extreme outlier
         ethUsdFeed.setUpdatedAt(block.timestamp);
 
-        uint256 nativeFee = cm.convertTokenFeeToNative(1e18, 18);
-
-        assertEq(nativeFee, 1e26, "fresh outlier accepted while band is unset");
+        vm.expectRevert(ICommissionManager.ChainlinkHardeningNotConfigured.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
     }
 
     function test_buildRouteKey_matchesEncodeHash() public view {
@@ -469,10 +479,9 @@ contract CommissionManagerTest is Test {
     //
     // The stable-fee formula is `amount * stablePercent / multiplier / multiplier`,
     // i.e. a fee fraction of `stablePercent / multiplier^2`. If `stablePercent`
-    // exceeds `multiplier^2` the quoted fee exceeds the bridged amount and the
-    // later `netAmount = amount - fee` underflows (Panic 0x11), bricking the
-    // route until the federation reconfigures. The setters must therefore reject
-    // any `(stablePercent, multiplier)` pair where `stablePercent > multiplier^2`.
+    // reaches `multiplier^2` the fee consumes the whole bridged amount; above it,
+    // `netAmount = amount - fee` underflows. The setters must therefore require
+    // `stablePercent < multiplier^2`, guaranteeing a positive nominal net.
     function test_setGlobalDefaults_revertsWhenStablePercentExceedsMultiplierSquared() public {
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(9000), uint8(1)));
@@ -487,15 +496,11 @@ contract CommissionManagerTest is Test {
         cm.setGlobalDefaults(101, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
-    /// @dev Exact boundary `stablePercent == multiplier^2` is accepted: it is a 100%
-    ///      fee (`netAmount = 0`) which is degenerate but does not underflow, so the
-    ///      invariant rejects only the strictly-greater case.
-    function test_setGlobalDefaults_acceptsFeeShapeAtExactBoundary() public {
+    /// @dev I-08: the exact boundary is a 100% fee and must be rejected too.
+    function test_setGlobalDefaults_revertsFeeShapeAtExactBoundary() public {
         vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(100), uint8(10)));
         cm.setGlobalDefaults(100, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
-        (uint256 sp, uint8 m,,) = cm.getGlobalDefaults();
-        assertEq(sp, 100);
-        assertEq(m, 10);
     }
 
     /// @dev Regression for the uint8 widening in the fix. With the default
@@ -526,8 +531,8 @@ contract CommissionManagerTest is Test {
         cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), cfg);
     }
 
-    /// @dev Exact boundary `stablePercent == multiplier^2` accepted on the route setter.
-    function test_setCommissionRule_acceptsFeeShapeAtExactBoundary() public {
+    /// @dev I-08: per-route rules also reject the exact 100% boundary.
+    function test_setCommissionRule_revertsFeeShapeAtExactBoundary() public {
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 100,
             multiplier: 10,
@@ -536,10 +541,8 @@ contract CommissionManagerTest is Test {
             isSet: true
         });
         vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(100), uint8(10)));
         cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), cfg);
-        CommissionConfig memory stored = cm.getCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token));
-        assertEq(stored.stablePercent, 100);
-        assertEq(stored.multiplier, 10);
     }
 
     /// @dev uint8-widening regression on the per-route setter: `(9000, 100)` is valid.
@@ -558,19 +561,54 @@ contract CommissionManagerTest is Test {
         assertEq(stored.multiplier, 100);
     }
 
-    /// @dev End state of the invariant: a config accepted at the exact boundary
-    ///      yields `fee == amount` and `netAmount == 0` without underflowing. This
-    ///      is what the setter guard guarantees for every storable rule — the
-    ///      `amount - fee` subtraction in the calculators can never go negative.
-    function test_calculateFundsInCommission_acceptedBoundaryDoesNotUnderflow() public {
+    /// @dev Direct regression for the auditor's `8100 / 90^2 == 100%` PoC.
+    function test_R_I_08_rejectsAuditHundredPercentConfiguration() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(100, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
-        uint256 amount = 50_000;
-        (uint256 tok, uint256 nat, uint256 net) =
-            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), amount);
-        assertEq(tok, amount); // 100% fee at the boundary
-        assertEq(nat, 0);
-        assertEq(net, 0); // no underflow
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(8100), uint8(90)));
+        cm.setGlobalDefaults(8100, 90, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    /// @dev A non-zero inbound fee policy cannot silently round to zero.
+    function test_R_I_08_fundsInActiveFeeRejectsCommissionFreeDust() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICommissionManager.CommissionRoundsToZero.selector, uint256(24), uint256(400), uint8(100)
+            )
+        );
+        cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 24);
+    }
+
+    /// @dev The same runtime invariant applies to outbound fee rules.
+    function test_R_I_08_fundsOutActiveFeeRejectsCommissionFreeDust() public {
+        CommissionConfig memory cfg = CommissionConfig({
+            stablePercent: 400,
+            multiplier: 100,
+            side: CommissionSide.FUNDS_OUT,
+            currency: CommissionCurrency.TOKEN,
+            isSet: true
+        });
+        vm.prank(owner);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), cfg);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICommissionManager.CommissionRoundsToZero.selector, uint256(24), uint256(400), uint8(100)
+            )
+        );
+        cm.calculateFundsOutCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 24);
+    }
+
+    /// @dev A deliberately disabled fee remains valid; only active policies
+    ///      promise a non-zero commission.
+    function test_R_I_08_zeroFeePolicyStillAllowsSmallAmount() public view {
+        (uint256 tokenFee, uint256 nativeFee, uint256 netAmount) =
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 1);
+        assertEq(tokenFee, 0);
+        assertEq(nativeFee, 0);
+        assertEq(netAmount, 1);
     }
 
     // --- Bridge address ---
@@ -657,7 +695,7 @@ contract CommissionManagerTest is Test {
         cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(owner);
-        cm.withdrawTokenCommission(address(token), recipient, amt);
+        cm.withdrawTokenCommission(address(token), amt);
 
         assertEq(cm.tokenCommissionPool(address(token)), 0);
         assertEq(token.balanceOf(recipient), amt);
@@ -670,7 +708,7 @@ contract CommissionManagerTest is Test {
         cm.receiveTokenCommission(address(token), amt);
 
         vm.prank(owner);
-        cm.withdrawAllTokenCommission(address(token), recipient);
+        cm.withdrawAllTokenCommission(address(token));
 
         assertEq(cm.tokenCommissionPool(address(token)), 0);
         assertEq(token.balanceOf(recipient), amt);
@@ -679,7 +717,31 @@ contract CommissionManagerTest is Test {
     function test_withdrawTokenCommission_revertsInsufficient() public {
         vm.prank(owner);
         vm.expectRevert(ICommissionManager.InsufficientBalance.selector);
-        cm.withdrawTokenCommission(address(token), recipient, 1);
+        cm.withdrawTokenCommission(address(token), 1);
+    }
+
+    function test_legacyFreeRecipientWithdrawalSelectorsUnavailable() public {
+        uint256 amount = 10 ether;
+        token.mint(address(cm), amount);
+        vm.prank(BRIDGE);
+        cm.receiveTokenCommission(address(token), amount);
+
+        bytes[] memory legacyCalls = new bytes[](4);
+        legacyCalls[0] =
+            abi.encodeWithSignature("withdrawTokenCommission(address,address,uint256)", address(token), user, amount);
+        legacyCalls[1] = abi.encodeWithSignature("withdrawNativeCommission(address,uint256)", user, amount);
+        legacyCalls[2] = abi.encodeWithSignature("withdrawAllTokenCommission(address,address)", address(token), user);
+        legacyCalls[3] = abi.encodeWithSignature("withdrawAllNativeCommission(address)", user);
+
+        for (uint256 i = 0; i < legacyCalls.length; i++) {
+            vm.prank(owner);
+            (bool ok,) = address(cm).call(legacyCalls[i]);
+            assertFalse(ok, "legacy free-recipient selector must not exist");
+        }
+
+        assertEq(cm.tokenCommissionPool(address(token)), amount, "failed legacy calls preserve pool");
+        assertEq(token.balanceOf(user), 0, "arbitrary recipient receives nothing");
+        assertEq(token.balanceOf(recipient), 0, "no valid withdrawal executed");
     }
 
     // --- Native commission ---
@@ -711,7 +773,7 @@ contract CommissionManagerTest is Test {
 
         uint256 before = recipient.balance;
         vm.prank(owner);
-        cm.withdrawNativeCommission(payable(recipient), 2 ether);
+        cm.withdrawNativeCommission(2 ether);
         assertEq(cm.nativeCommissionPool(), 0);
         assertEq(recipient.balance, before + 2 ether);
     }
@@ -724,7 +786,7 @@ contract CommissionManagerTest is Test {
 
         uint256 before = recipient.balance;
         vm.prank(owner);
-        cm.withdrawAllNativeCommission(payable(recipient));
+        cm.withdrawAllNativeCommission();
         assertEq(cm.nativeCommissionPool(), 0);
         assertEq(recipient.balance, before + 3 ether);
     }
@@ -732,7 +794,7 @@ contract CommissionManagerTest is Test {
     function test_withdrawNativeCommission_revertsInsufficient() public {
         vm.prank(owner);
         vm.expectRevert(ICommissionManager.InsufficientBalance.selector);
-        cm.withdrawNativeCommission(payable(recipient), 1 wei);
+        cm.withdrawNativeCommission(1 wei);
     }
 
     // --- Formula regression coverage ---
@@ -752,9 +814,12 @@ contract CommissionManagerTest is Test {
         // formula instead of mirroring the implementation expression.
         for (uint256 i = 0; i < tokenFees.length; i++) {
             MockAggregatorV3 feed = new MockAggregatorV3(feedDecimals[i], prices[i], block.timestamp);
+            uint256 decimalScale = 10 ** uint256(feedDecimals[i]);
 
-            vm.prank(owner);
+            vm.startPrank(owner);
+            cm.setEthUsdPriceBounds(100 * decimalScale, 100_000 * decimalScale);
             cm.setEthUsdFeed(address(feed), HEARTBEAT);
+            vm.stopPrank();
 
             assertEq(
                 cm.convertTokenFeeToNative(tokenFees[i], tokenDecimals[i]), expectedNativeFees[i], "native fee formula"
@@ -782,9 +847,12 @@ contract CommissionManagerTest is Test {
 
     // --- sequencer uptime ---
 
-    function test_convertTokenFeeToNative_noSequencerCheckWhenUnset() public view {
-        // No sequencer feed wired (setUp does not set one) → quote works.
-        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    function test_convertTokenFeeToNative_revertsWhenSequencerFeedUnset() public {
+        vm.prank(owner);
+        cm.setSequencerUptimeFeed(address(0));
+
+        vm.expectRevert(ICommissionManager.ChainlinkHardeningNotConfigured.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
     }
 
     function test_convertTokenFeeToNative_revertsWhenSequencerDown() public {
@@ -808,6 +876,19 @@ contract CommissionManagerTest is Test {
         cm.convertTokenFeeToNative(1e18, 18);
     }
 
+    function test_convertTokenFeeToNative_revertsOnUninitializedSequencerRound() public {
+        _setSequencer(0, 0);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidSequencerRound.selector, uint256(0)));
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
+    function test_convertTokenFeeToNative_revertsOnFutureSequencerRound() public {
+        uint256 futureStartedAt = block.timestamp + 1;
+        _setSequencer(0, futureStartedAt);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidSequencerRound.selector, futureStartedAt));
+        cm.convertTokenFeeToNative(1e18, 18);
+    }
+
     function test_convertTokenFeeToNative_passesWhenSequencerUpPastGrace() public {
         _setSequencer(0, block.timestamp - cm.SEQUENCER_GRACE_PERIOD() - 1);
         assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14); // same as happy path
@@ -815,9 +896,12 @@ contract CommissionManagerTest is Test {
 
     // --- min/max price band ---
 
-    function test_convertTokenFeeToNative_noBandWhenUnset() public view {
-        // No band configured in setUp → any positive fresh answer is accepted.
-        assertEq(cm.convertTokenFeeToNative(1e18, 18), 5e14);
+    function test_convertTokenFeeToNative_revertsWhenBandUnset() public {
+        vm.prank(owner);
+        cm.setEthUsdPriceBounds(0, 0);
+
+        vm.expectRevert(ICommissionManager.ChainlinkHardeningNotConfigured.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
     }
 
     function test_convertTokenFeeToNative_revertsWhenPriceBelowMin() public {
@@ -869,6 +953,9 @@ contract CommissionManagerTest is Test {
         vm.prank(owner);
         cm.setSequencerUptimeFeed(address(0));
         assertEq(cm.sequencerUptimeFeed(), address(0));
+
+        vm.expectRevert(ICommissionManager.ChainlinkHardeningNotConfigured.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
     }
 
     function test_setSequencerUptimeFeed_onlyOwner() public {
@@ -893,6 +980,9 @@ contract CommissionManagerTest is Test {
         cm.setEthUsdPriceBounds(0, 0);
         assertEq(cm.ethUsdMinPrice(), 0);
         assertEq(cm.ethUsdMaxPrice(), 0);
+
+        vm.expectRevert(ICommissionManager.ChainlinkHardeningNotConfigured.selector);
+        cm.convertTokenFeeToNative(1e18, 18);
     }
 
     function test_setEthUsdPriceBounds_revertsOnZeroMinWithNonZeroMax() public {

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -186,7 +186,7 @@ contract IntegrationTest is Test {
         uint64 currentNonce = vm.getNonce(deployer);
         address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
 
-        cm = new CommissionManager(predictedBridge);
+        cm = new CommissionManager(predictedBridge, commissionReceiver);
         routeRegistry = new RouteRegistry(predictedBridge, deployer);
         bridge = new Bridge(
             address(token),
@@ -214,9 +214,7 @@ contract IntegrationTest is Test {
         fed[1] = fedA2;
         fed[2] = fedA3;
 
-        proxy = new MultisigProxy(
-            address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        proxy = new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, TIMELOCK, MIN_TIMELOCK);
 
         cm.transferOwnership(address(proxy));
         bridge.transferOwnership(address(proxy));
@@ -427,9 +425,16 @@ contract IntegrationTest is Test {
 
     function test_endToEnd_nativeCommission_inboundAndWithdraw() public {
         // Configure a NATIVE FUNDS_IN route (2% on token amount, paid in wei).
-        // Wire up a Chainlink ETH/USD feed ($2000 / ETH, 8 decimals, fresh)
-        // via federation governance — the same path production will use.
+        // Wire the complete mandatory R-I-14 config through federation
+        // governance — dependencies first, ETH/USD feed last.
+        MockAggregatorV3 sequencerFeed = new MockAggregatorV3(0, 0, block.timestamp);
         ethUsdFeed = new MockAggregatorV3(8, 2_000e8, block.timestamp);
+        _proposeAndExecuteCmAdminCall(
+            abi.encodeWithSelector(ICommissionManager.setSequencerUptimeFeed.selector, address(sequencerFeed))
+        );
+        _proposeAndExecuteCmAdminCall(
+            abi.encodeWithSelector(ICommissionManager.setEthUsdPriceBounds.selector, uint256(100e8), uint256(100_000e8))
+        );
         _proposeAndExecuteCmAdminCall(
             abi.encodeWithSelector(ICommissionManager.setEthUsdFeed.selector, address(ethUsdFeed), uint256(1 days))
         );

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -239,7 +239,7 @@ contract MultisigProxyTest is Test {
         uint64 currentNonce = vm.getNonce(deployer);
         address predictedBridge = vm.computeCreateAddress(deployer, currentNonce + 2);
 
-        cm = new CommissionManager(predictedBridge);
+        cm = new CommissionManager(predictedBridge, commissionReceiver);
         routeRegistry = new RouteRegistry(predictedBridge, deployer);
         bridge = new Bridge(
             address(token),
@@ -267,9 +267,7 @@ contract MultisigProxyTest is Test {
         fed[1] = fedA2;
         fed[2] = fedA3;
 
-        proxy = new MultisigProxy(
-            address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        proxy = new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, TIMELOCK, MIN_TIMELOCK);
 
         // Production-flow ownership transfer.
         bridge.transferOwnership(address(proxy));
@@ -506,9 +504,7 @@ contract MultisigProxyTest is Test {
         address[] memory fed = new address[](1);
         fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroBridge.selector);
-        new MultisigProxy(
-            address(0), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        new MultisigProxy(address(0), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroCommissionManager() public {
@@ -517,9 +513,7 @@ contract MultisigProxyTest is Test {
         address[] memory fed = new address[](1);
         fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.ZeroCommissionManager.selector);
-        new MultisigProxy(
-            address(bridge), address(0), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(0), enc, 1, RGB_CHAIN_ID, fed, 1, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnNoEnclaveSigners() public {
@@ -527,9 +521,7 @@ contract MultisigProxyTest is Test {
         address[] memory fed = new address[](1);
         fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.NoSigners.selector);
-        new MultisigProxy(
-            address(bridge), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(cm), enc, 1, RGB_CHAIN_ID, fed, 1, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnBadEnclaveThreshold() public {
@@ -539,40 +531,13 @@ contract MultisigProxyTest is Test {
         address[] memory fed = new address[](1);
         fed[0] = fedA1;
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
-        new MultisigProxy(
-            address(bridge), address(cm), enc, 3, RGB_CHAIN_ID, fed, 1, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
-    }
-
-    function test_constructor_revertsOnZeroCommission() public {
-        vm.expectRevert(IMultisigProxy.ZeroCommissionRecipient.selector);
-        new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _validEnc(),
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            address(0),
-            TIMELOCK,
-            MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(cm), enc, 3, RGB_CHAIN_ID, fed, 1, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnTimelockTooLong() public {
         vm.expectRevert(IMultisigProxy.TimelockTooLong.selector);
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _validEnc(),
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            30 days,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, 30 days, MIN_TIMELOCK
         );
     }
 
@@ -582,43 +547,19 @@ contract MultisigProxyTest is Test {
     function test_constructor_revertsOnTimelockBelowMinTimelock() public {
         // timelock (1h) is below the requested floor (2h) -> TimelockTooShort
         vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
-        new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _validEnc(),
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            1 hours,
-            2 hours
-        );
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, 1 hours, 2 hours);
     }
 
     /// @dev A zero floor is rejected — it would defeat the purpose of the fix.
     function test_constructor_revertsOnZeroMinTimelock() public {
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(
-            address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, commissionReceiver, TIMELOCK, 0
-        );
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, 0);
     }
 
     /// @dev A floor at/above the upper bound leaves no valid range — rejected.
     function test_constructor_revertsOnMinTimelockTooLong() public {
         vm.expectRevert(IMultisigProxy.InvalidMinTimelock.selector);
-        new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _validEnc(),
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            30 days
-        );
+        new MultisigProxy(address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, 30 days);
     }
 
     function test_minTimelock_returnsConfiguredFloor() public view {
@@ -632,18 +573,7 @@ contract MultisigProxyTest is Test {
         enc[0] = encA1;
         enc[1] = encA1;
         vm.expectRevert(IMultisigProxy.DuplicateSigner.selector);
-        new MultisigProxy(
-            address(bridge),
-            address(cm),
-            enc,
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_revertsOnZeroAddressSigner() public {
@@ -654,18 +584,7 @@ contract MultisigProxyTest is Test {
         enc[0] = address(0);
         enc[1] = encA2;
         vm.expectRevert(IMultisigProxy.ZeroAddressSigner.selector);
-        new MultisigProxy(
-            address(bridge),
-            address(cm),
-            enc,
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK);
     }
 
     // ========================================================================
@@ -701,16 +620,7 @@ contract MultisigProxyTest is Test {
     function test_constructor_rejectsOneOfThree_enclave() public {
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(3),
-            1,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(3), 1, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK
         );
     }
 
@@ -718,16 +628,7 @@ contract MultisigProxyTest is Test {
         // n < 2 — single-key set, rejected even though 2*1 > 1.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(1),
-            1,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(1), 1, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK
         );
     }
 
@@ -735,16 +636,7 @@ contract MultisigProxyTest is Test {
         // 2-of-4: 2*2 == 4, not a strict majority.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(4),
-            2,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(4), 2, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK
         );
     }
 
@@ -752,31 +644,13 @@ contract MultisigProxyTest is Test {
         // Enclave valid, federation 1-of-3 — the floor applies to both sets.
         vm.expectRevert(IMultisigProxy.InvalidThreshold.selector);
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _validEnc(),
-            2,
-            RGB_CHAIN_ID,
-            _signers(3),
-            1,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _validEnc(), 2, RGB_CHAIN_ID, _signers(3), 1, TIMELOCK, MIN_TIMELOCK
         );
     }
 
     function test_constructor_acceptsTwoOfTwo() public {
         MultisigProxy p = new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(2),
-            2,
-            RGB_CHAIN_ID,
-            _signersB(2),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(2), 2, RGB_CHAIN_ID, _signersB(2), 2, TIMELOCK, MIN_TIMELOCK
         );
         assertEq(p.enclaveThreshold(RGB_CHAIN_ID), 2);
         assertEq(p.federationThreshold(), 2);
@@ -785,16 +659,7 @@ contract MultisigProxyTest is Test {
     function test_constructor_acceptsThreeOfFour() public {
         // Strict majority with a non-trivial set (2*3 > 4).
         MultisigProxy p = new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(4),
-            3,
-            RGB_CHAIN_ID,
-            _signersB(4),
-            3,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(4), 3, RGB_CHAIN_ID, _signersB(4), 3, TIMELOCK, MIN_TIMELOCK
         );
         assertEq(p.enclaveThreshold(RGB_CHAIN_ID), 3);
         assertEq(p.federationThreshold(), 3);
@@ -941,23 +806,12 @@ contract MultisigProxyTest is Test {
         fed[0] = encA1;
         fed[1] = fedA2;
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, encA1));
-        new MultisigProxy(
-            address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK
-        );
+        new MultisigProxy(address(bridge), address(cm), enc, 2, RGB_CHAIN_ID, fed, 2, TIMELOCK, MIN_TIMELOCK);
     }
 
     function test_constructor_acceptsDisjointSignerSets() public {
         MultisigProxy p = new MultisigProxy(
-            address(bridge),
-            address(cm),
-            _signers(2),
-            2,
-            RGB_CHAIN_ID,
-            _signersB(2),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), _signers(2), 2, RGB_CHAIN_ID, _signersB(2), 2, TIMELOCK, MIN_TIMELOCK
         );
         assertEq(p.getEnclaveSigners(RGB_CHAIN_ID).length, 2);
         assertEq(p.getFederationSigners().length, 2);
@@ -1022,16 +876,7 @@ contract MultisigProxyTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.TooManySigners.selector, max + 1, max));
         new MultisigProxy(
-            address(bridge),
-            address(cm),
-            enc,
-            encThreshold,
-            RGB_CHAIN_ID,
-            _validFed(),
-            2,
-            commissionReceiver,
-            TIMELOCK,
-            MIN_TIMELOCK
+            address(bridge), address(cm), enc, encThreshold, RGB_CHAIN_ID, _validFed(), 2, TIMELOCK, MIN_TIMELOCK
         );
     }
 
@@ -1047,7 +892,6 @@ contract MultisigProxyTest is Test {
             RGB_CHAIN_ID,
             _signersB(max),
             threshold,
-            commissionReceiver,
             TIMELOCK,
             MIN_TIMELOCK
         );
@@ -3329,22 +3173,14 @@ contract MultisigProxyTest is Test {
         assertEq(routeRegistry.pendingOwner(), newOwner, "RR transfer started via new op");
     }
 
-    // The typed commission-withdraw path pins the recipient to
-    // commissionRecipient, while generic CM admin execution forwards arbitrary
-    // calldata and lets the encoded withdrawal recipient win.
-    // R-W-15 after-fix: the generic AdminExecuteCommissionManager path can no
-    // longer reach a commission-withdrawal selector, so it cannot re-point
-    // commission away from the pinned `commissionRecipient`. The guard fires at
-    // propose time (before signature verification), so no valid federation
-    // signatures are needed to observe it.
+    // Standard CM withdrawals stay on the dedicated typed operations. Recipient
+    // safety no longer depends on this blocklist: CM enforces it immutably.
     function test_adminExecuteCommissionManager_rejectsWithdrawSelectors_afterFix() public {
         bytes[] memory callDatas = new bytes[](4);
-        callDatas[0] = abi.encodeWithSignature(
-            "withdrawTokenCommission(address,address,uint256)", address(token), user, uint256(1)
-        );
-        callDatas[1] = abi.encodeWithSignature("withdrawNativeCommission(address,uint256)", user, uint256(1));
-        callDatas[2] = abi.encodeWithSignature("withdrawAllTokenCommission(address,address)", address(token), user);
-        callDatas[3] = abi.encodeWithSignature("withdrawAllNativeCommission(address)", user);
+        callDatas[0] = abi.encodeWithSignature("withdrawTokenCommission(address,uint256)", address(token), uint256(1));
+        callDatas[1] = abi.encodeWithSignature("withdrawNativeCommission(uint256)", uint256(1));
+        callDatas[2] = abi.encodeWithSignature("withdrawAllTokenCommission(address)", address(token));
+        callDatas[3] = abi.encodeWithSignature("withdrawAllNativeCommission()");
 
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
@@ -3358,8 +3194,46 @@ contract MultisigProxyTest is Test {
         }
     }
 
-    // The generic path stays open for non-withdrawal CommissionManager setters.
-    function test_adminExecuteCommissionManager_allowsNonWithdrawSelector() public {
+    // R-W-15 / alternate-target regression: even if governance aliases the LZ
+    // adapter target to CM and transfers CM ownership through that unfiltered
+    // raw-call path, the new owner cannot choose a withdrawal recipient. The
+    // asset layer always sends commission to CM's immutable recipient.
+    function test_R_W_15_adapterAliasTransferredOwnerCannotRedirectCommission() public {
+        _setLzAdapter(address(cm));
+
+        uint256 amount = 10 ether;
+        token.mint(address(cm), amount);
+        vm.prank(address(bridge));
+        cm.receiveTokenCommission(address(token), amount);
+
+        bytes memory callData = abi.encodeWithSignature("transferOwnership(address)", user);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest =
+            MultisigHelper.digestProposeAdminExecuteAdapter(domainSep, bytes4(callData), callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, callData);
+
+        vm.prank(user);
+        cm.acceptOwnership();
+        assertEq(cm.owner(), user, "governed CM ownership migration still works");
+
+        uint256 pinnedBefore = token.balanceOf(commissionReceiver);
+        uint256 attackerBefore = token.balanceOf(user);
+        vm.prank(user);
+        cm.withdrawTokenCommission(address(token), amount);
+
+        assertEq(token.balanceOf(commissionReceiver), pinnedBefore + amount, "immutable recipient paid");
+        assertEq(token.balanceOf(user), attackerBefore, "new owner cannot redirect commission to itself");
+        assertEq(proxy.commissionRecipient(), commissionReceiver, "proxy reports CM's immutable recipient");
+    }
+
+    // The generic path stays open for permitted CommissionManager setters.
+    function test_adminExecuteCommissionManager_allowsConfigSelector() public {
         bytes memory callData = abi.encodeWithSignature(
             "setGlobalDefaults(uint256,uint8,uint8,uint8)", uint256(0), uint8(100), uint8(0), uint8(0)
         );
@@ -3371,7 +3245,22 @@ contract MultisigProxyTest is Test {
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         bytes32 id = proxy.proposeAdminExecuteCommissionManager(callData, nonce, deadline, bitmap, sigs);
-        assertTrue(id != bytes32(0), "non-withdrawal CM selector accepted on the generic path");
+        assertTrue(id != bytes32(0), "CM config selector accepted on the generic path");
+    }
+
+    // Deployment compatibility: the deployer initiates CM's Ownable2Step handoff
+    // directly, then the proxy must be able to propose acceptOwnership().
+    function test_adminExecuteCommissionManager_allowsAcceptOwnershipSelector() public {
+        bytes memory callData = abi.encodeWithSignature("acceptOwnership()");
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest =
+            MultisigHelper.digestProposeAdminExecuteCM(domainSep, bytes4(callData), callData, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        bytes32 id = proxy.proposeAdminExecuteCommissionManager(callData, nonce, deadline, bitmap, sigs);
+        assertTrue(id != bytes32(0), "CM acceptOwnership selector accepted on the generic path");
     }
 
     // ========================================================================
@@ -3729,7 +3618,7 @@ contract MultisigProxyTest is Test {
         address[] memory enc = _validEnc();
         address[] memory fed = _validFed();
         vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.UnknownSourceChain.selector, uint256(0)));
-        new MultisigProxy(address(bridge), address(cm), enc, 2, 0, fed, 2, commissionReceiver, TIMELOCK, MIN_TIMELOCK);
+        new MultisigProxy(address(bridge), address(cm), enc, 2, 0, fed, 2, TIMELOCK, MIN_TIMELOCK);
     }
 
     /// @dev ...and rejected up front by proposeUpdateEnclaveSigners (before sigs).

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -27,6 +27,22 @@ import {
 import {MockERC20} from "./mocks/MockERC20.sol";
 import {MockBtcRelay} from "./mocks/MockBtcRelay.sol";
 import {MultisigHelper} from "./mocks/MultisigHelper.sol";
+import {EmergencyPause} from "../script/interact/EmergencyPause.s.sol";
+import {EmergencyUnpause} from "../script/interact/EmergencyUnpause.s.sol";
+
+/// @dev Exposes the exact nonce/digest preparation used by the production
+///      scripts so R-I-09 tests cannot pass against a duplicated implementation.
+contract EmergencyPauseHarness is EmergencyPause {
+    function prepare(MultisigProxy proxy, uint256 deadline) external view returns (uint256 nonce, bytes32 digest) {
+        return _prepareEmergencyPause(proxy, deadline);
+    }
+}
+
+contract EmergencyUnpauseHarness is EmergencyUnpause {
+    function prepare(MultisigProxy proxy, uint256 deadline) external view returns (uint256 nonce, bytes32 digest) {
+        return _prepareEmergencyUnpause(proxy, deadline);
+    }
+}
 
 contract MockOutboundLZAdapter {
     MockERC20 public immutable token;
@@ -1426,6 +1442,92 @@ contract MultisigProxyTest is Test {
 
         proxy.emergencyUnpause(nonce, deadline, bitmap, sigs);
         assertFalse(bridge.paused());
+    }
+
+    /// @dev R-I-09 known-answer regression for the production pause script.
+    ///      A regular proposal first advances only `proposalNonce`, reproducing
+    ///      the state in which the old script selected the wrong nonce lane.
+    function test_R_I_09_emergencyPauseScriptUsesEmergencyNonceAfterLanesDiverge() public {
+        uint256 regularNonce = proxy.proposalNonce();
+        uint256 regularDeadline = block.timestamp + 1 days;
+        address newBridge = makeAddr("ri09-pause-regular-proposal");
+        bytes32 regularDigest =
+            MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, regularNonce, regularDeadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        proxy.proposeUpdateBridge(
+            newBridge, regularNonce, regularDeadline, bitmap, MultisigHelper.signAll(vm, regularDigest, pks)
+        );
+
+        assertEq(proxy.proposalNonce(), 1, "regular lane advanced");
+        assertEq(proxy.emergencyNonce(), 0, "emergency lane untouched");
+
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // Negative control: the pre-fix script read proposalNonce(), producing
+        // a correctly signed emergency digest for the wrong nonce.
+        uint256 wrongNonce = proxy.proposalNonce();
+        bytes32 wrongDigest = MultisigHelper.digestEmergencyPause(domainSep, wrongNonce, deadline);
+        vm.expectRevert(IMultisigProxy.InvalidNonce.selector);
+        proxy.emergencyPause(wrongNonce, deadline, bitmap, MultisigHelper.signAll(vm, wrongDigest, pks));
+
+        // Exercise the exact preparation function called by EmergencyPause.run().
+        EmergencyPauseHarness harness = new EmergencyPauseHarness();
+        (uint256 scriptNonce, bytes32 scriptDigest) = harness.prepare(proxy, deadline);
+        bytes32 expectedStructHash =
+            keccak256(abi.encode(keccak256("EmergencyPause(uint256 nonce,uint256 deadline)"), uint256(0), deadline));
+        bytes32 expectedDigest = keccak256(abi.encodePacked("\x19\x01", domainSep, expectedStructHash));
+
+        assertEq(scriptNonce, 0, "script reads emergency lane");
+        assertEq(scriptDigest, expectedDigest, "script produces canonical pause digest");
+
+        proxy.emergencyPause(scriptNonce, deadline, bitmap, MultisigHelper.signAll(vm, scriptDigest, pks));
+
+        assertTrue(bridge.paused(), "emergency pause succeeds");
+        assertEq(proxy.emergencyNonce(), 1, "emergency lane advanced");
+        assertEq(proxy.proposalNonce(), 1, "regular lane unchanged");
+    }
+
+    /// @dev R-I-09 known-answer regression for the production unpause script.
+    ///      Both lanes are deliberately non-equal before digest construction.
+    function test_R_I_09_emergencyUnpauseScriptUsesEmergencyNonceAfterLanesDiverge() public {
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+
+        uint256 pauseNonce = proxy.emergencyNonce();
+        uint256 pauseDeadline = block.timestamp + 1 hours;
+        bytes32 pauseDigest = MultisigHelper.digestEmergencyPause(domainSep, pauseNonce, pauseDeadline);
+        proxy.emergencyPause(pauseNonce, pauseDeadline, bitmap, MultisigHelper.signAll(vm, pauseDigest, pks));
+        assertTrue(bridge.paused(), "precondition: bridge paused");
+
+        // Advance the regular lane twice so proposalNonce=2, emergencyNonce=1.
+        for (uint256 i = 0; i < 2; i++) {
+            uint256 regularNonce = proxy.proposalNonce();
+            uint256 regularDeadline = block.timestamp + 1 days;
+            address newBridge = makeAddr(string.concat("ri09-unpause-regular-proposal-", vm.toString(i)));
+            bytes32 regularDigest =
+                MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, regularNonce, regularDeadline);
+            proxy.proposeUpdateBridge(
+                newBridge, regularNonce, regularDeadline, bitmap, MultisigHelper.signAll(vm, regularDigest, pks)
+            );
+        }
+
+        assertEq(proxy.proposalNonce(), 2, "regular lane advanced independently");
+        assertEq(proxy.emergencyNonce(), 1, "pause advanced emergency lane once");
+
+        uint256 deadline = block.timestamp + 1 hours;
+        EmergencyUnpauseHarness harness = new EmergencyUnpauseHarness();
+        (uint256 scriptNonce, bytes32 scriptDigest) = harness.prepare(proxy, deadline);
+        bytes32 expectedStructHash =
+            keccak256(abi.encode(keccak256("EmergencyUnpause(uint256 nonce,uint256 deadline)"), uint256(1), deadline));
+        bytes32 expectedDigest = keccak256(abi.encodePacked("\x19\x01", domainSep, expectedStructHash));
+
+        assertEq(scriptNonce, 1, "script reads emergency lane");
+        assertEq(scriptDigest, expectedDigest, "script produces canonical unpause digest");
+
+        proxy.emergencyUnpause(scriptNonce, deadline, bitmap, MultisigHelper.signAll(vm, scriptDigest, pks));
+
+        assertFalse(bridge.paused(), "emergency unpause succeeds");
+        assertEq(proxy.emergencyNonce(), 2, "emergency lane advanced");
+        assertEq(proxy.proposalNonce(), 2, "regular lane unchanged");
     }
 
     // ========================================================================

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -49,9 +49,6 @@ library MultisigHelper {
     bytes32 internal constant PROPOSE_UPDATE_BRIDGE_TYPEHASH =
         keccak256("ProposeUpdateBridge(address newBridge,uint256 nonce,uint256 deadline)");
 
-    bytes32 internal constant PROPOSE_SET_COMMISSION_RECIPIENT_TYPEHASH =
-        keccak256("ProposeSetCommissionRecipient(address newRecipient,uint256 nonce,uint256 deadline)");
-
     bytes32 internal constant PROPOSE_SET_TIMELOCK_DURATION_TYPEHASH =
         keccak256("ProposeSetTimelockDuration(uint256 newDuration,uint256 nonce,uint256 deadline)");
 


### PR DESCRIPTION
## Summary
The contract already had two nonce lanes; the two emergency scripts were still signing with the wrong one. `EmergencyPause.s.sol` / `EmergencyUnpause.s.sol` read `proposalNonce()` while `emergencyPause` / `emergencyUnpause` check `emergencyNonce`, so once the lanes diverge the freeze reverts `InvalidNonce` — with valid signatures and a correct quorum, at exactly the moment it needs to work first try.

## Changes
- Both scripts read `emergencyNonce()`. Nonce lookup and digest construction moved into one `_prepare*` helper so they cannot drift apart again; the closing log reports the emergency counter.
- Checked the other scripts for the same mistake: `MultisigProposeSetRoute` correctly uses `proposalNonce()`, `MultisigExecuteFundsOut` correctly uses `teeNonce(sourceChainId)`.
