### PR TITLE
fix(multisig): block federation bypass of bridge release authorization

### DIFF
--- a/ethereum/.env.deploy.example
+++ b/ethereum/.env.deploy.example
@@ -108,5 +108,5 @@ TIMELOCK_DURATION=3600
 
 # Immutable lower bound for the timelock (seconds), fixed at deploy time.
 # Must be in (0, MAX_PROPOSAL_LIFETIME=30 days) and <= TIMELOCK_DURATION.
-# The timelock can never be lowered below this floor afterwards (R-W-11).
+# The timelock can never be lowered below this floor afterwards.
 MIN_TIMELOCK=3600

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -130,8 +130,8 @@ contract DeployAll is Script {
             "set both ETH_USD_MIN_PRICE and ETH_USD_MAX_PRICE, or neither"
         );
         require(ethUsdMaxPrice == 0 || ethUsdMinPrice < ethUsdMaxPrice, "ETH_USD_MIN_PRICE must be below MAX");
-        // R-I-14: enabling the NATIVE oracle path requires the full Arbitrum
-        // hardening configuration. There is no production opt-out.
+        // Enabling the NATIVE oracle path requires the full Arbitrum hardening
+        // configuration. There is no production opt-out.
         if (ethUsdFeed != address(0)) {
             require(ethUsdHb != 0, "ETH_USD_HEARTBEAT must be set when ETH_USD_FEED is provided");
             require(seqFeed != address(0), "hardening: SEQUENCER_UPTIME_FEED must be set");
@@ -187,7 +187,7 @@ contract DeployAll is Script {
         bridge.setOutflowLimit(initialSrcChain, initialChainBurstBps, initialChainRefillBps);
         bridge.setGlobalOutflowLimit(globalBurstBps, globalRefillBps);
 
-        // ---- 8. Wire R-I-14 dependencies before enabling ETH/USD quotes ----
+        // ---- 8. Wire oracle dependencies before enabling ETH/USD quotes ----
         if (seqFeed != address(0)) {
             cm.setSequencerUptimeFeed(seqFeed);
         }

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -527,7 +527,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
                 burnId: fundsOutParams.burnId,
                 sourceChainId: fundsOutParams.sourceChainId,
                 destChainId: fundsOutParams.destinationChainId,
-                sourceAddress: fundsOutParams.sourceAddress
+                sourceAddress: fundsOutParams.sourceAddress,
+                isRebalance: false
             }),
                 fundsOutParams.proof,
                 fundsOutParams.settlementData
@@ -636,7 +637,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
                 burnId: params.burnId,
                 sourceChainId: params.sourceChainId,
                 destChainId: params.destinationChainId,
-                sourceAddress: params.sourceAddress
+                sourceAddress: params.sourceAddress,
+                isRebalance: true
             }),
                 params.proof,
                 params.settlementDataOut

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -121,15 +121,24 @@ contract MultisigProxy is IMultisigProxy {
     ///         selector before it is sliced via `calldataload`.
     uint256 public constant SELECTOR_LENGTH = 4;
 
-    /// @notice CommissionManager withdrawal selectors that the generic
-    ///         `AdminExecuteCommissionManager` path is NOT allowed to call.
+    /// @notice CommissionManager withdrawal selectors that generic raw-call
+    ///         paths are NOT allowed to call.
     ///         The asset layer always pays CM's immutable recipient, while this
     ///         procedural guard keeps standard withdrawals on the dedicated,
-    ///         typed governance operations.
+    ///         typed governance operations. The guard is selector-wide so a
+    ///         mutable generic target cannot be aliased to CommissionManager.
     bytes4 private constant _SEL_WITHDRAW_TOKEN = ICommissionManager.withdrawTokenCommission.selector;
     bytes4 private constant _SEL_WITHDRAW_NATIVE = ICommissionManager.withdrawNativeCommission.selector;
     bytes4 private constant _SEL_WITHDRAW_ALL_TOKEN = ICommissionManager.withdrawAllTokenCommission.selector;
     bytes4 private constant _SEL_WITHDRAW_ALL_NATIVE = ICommissionManager.withdrawAllNativeCommission.selector;
+
+    /// @notice Bridge value-moving selectors reserved exclusively for the typed
+    ///         enclave entrypoints. They are rejected from EVERY generic raw-call
+    ///         lane, independent of its configured target, so aliasing a mutable
+    ///         CommissionManager / RouteRegistry / adapter target to Bridge cannot
+    ///         bypass the federation restriction.
+    bytes4 private constant _SEL_FUNDS_OUT = IBridge.fundsOut.selector;
+    bytes4 private constant _SEL_REBALANCE_LIQUIDITY = IBridge.rebalanceLiquidity.selector;
 
     uint256 private immutable _cachedChainId;
     bytes32 private immutable _cachedDomainSeparator;
@@ -534,6 +543,8 @@ contract MultisigProxy is IMultisigProxy {
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
 
+        _requireAllowedGenericSelector(selector);
+
         bytes32 structHash =
             keccak256(abi.encode(_PROPOSE_ADMIN_EXECUTE_TYPEHASH, selector, keccak256(callData), nonce, deadline));
 
@@ -668,7 +679,7 @@ contract MultisigProxy is IMultisigProxy {
 
         // Standard withdrawals use the dedicated typed operations; reject them
         // on this generic path up front (recipient safety remains in CM).
-        _requireNotCommissionWithdrawSelector(selector);
+        _requireAllowedGenericSelector(selector);
 
         bytes32 structHash =
             keccak256(abi.encode(_PROPOSE_ADMIN_EXECUTE_CM_TYPEHASH, selector, keccak256(callData), nonce, deadline));
@@ -690,6 +701,8 @@ contract MultisigProxy is IMultisigProxy {
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
+
+        _requireAllowedGenericSelector(selector);
 
         bytes32 structHash = keccak256(
             abi.encode(_PROPOSE_ADMIN_EXECUTE_ROUTE_REGISTRY_TYPEHASH, selector, keccak256(callData), nonce, deadline)
@@ -785,6 +798,8 @@ contract MultisigProxy is IMultisigProxy {
 
         bytes4 selector;
         assembly { selector := calldataload(callData.offset) }
+
+        _requireAllowedGenericSelector(selector);
 
         bytes32 structHash = keccak256(
             abi.encode(_PROPOSE_ADMIN_EXECUTE_ADAPTER_TYPEHASH, selector, keccak256(callData), nonce, deadline)
@@ -1046,6 +1061,7 @@ contract MultisigProxy is IMultisigProxy {
     function _executeByType(OperationType opType, bytes calldata opData) private {
         if (opType == OperationType.AdminExecute) {
             // opData = raw bridge callData
+            _requireAllowedGenericSelector(_firstSelector(opData));
             (bool ok, bytes memory ret) = bridge.call(opData);
             _propagateRevert(ok, ret);
         } else if (opType == OperationType.UpdateEnclaveSigners) {
@@ -1098,7 +1114,8 @@ contract MultisigProxy is IMultisigProxy {
             // opData = raw CommissionManager callData. Enforce (again, at the
             // execution boundary) that standard withdrawals use their typed
             // governance operations.
-            _requireNotCommissionWithdrawSelector(_firstSelector(opData));
+            bytes4 selector = _firstSelector(opData);
+            _requireAllowedGenericSelector(selector);
             (bool ok, bytes memory ret) = commissionManager.call(opData);
             _propagateRevert(ok, ret);
         } else if (opType == OperationType.AdminExecuteRouteRegistry) {
@@ -1106,6 +1123,7 @@ contract MultisigProxy is IMultisigProxy {
             // (single source of truth), same as SetRoute. Enables ownership
             // migration (transferOwnership / acceptOwnership) for the Ownable2Step
             // RouteRegistry.
+            _requireAllowedGenericSelector(_firstSelector(opData));
             address registry = IBridge(bridge).routeRegistry();
             if (registry == address(0)) revert ZeroTarget();
             (bool ok, bytes memory ret) = registry.call(opData);
@@ -1133,6 +1151,7 @@ contract MultisigProxy is IMultisigProxy {
         } else if (opType == OperationType.AdminExecuteAdapter) {
             // opData = raw LZAdapter callData. The adapter must be wired in
             // first via UpdateLZAdapter; a zero target closes the path.
+            _requireAllowedGenericSelector(_firstSelector(opData));
             if (lzAdapter == address(0)) revert ZeroTarget();
             (bool ok, bytes memory ret) = lzAdapter.call(opData);
             _propagateRevert(ok, ret);
@@ -1336,5 +1355,23 @@ contract MultisigProxy is IMultisigProxy {
         ) {
             revert ForbiddenCommissionManagerSelector(selector);
         }
+    }
+
+    /// @dev Keeps value-moving Bridge operations exclusive to the typed enclave
+    ///      entrypoints. Applied to every generic raw-call lane rather than only
+    ///      `AdminExecute`, because their mutable targets can otherwise be aliased
+    ///      to a Bridge that is owned by this proxy.
+    function _requireNotBridgeReleaseSelector(bytes4 selector) private pure {
+        if (selector == _SEL_FUNDS_OUT || selector == _SEL_REBALANCE_LIQUIDITY) {
+            revert ForbiddenBridgeReleaseSelector(selector);
+        }
+    }
+
+    /// @dev Applies every selector policy consistently to each generic raw-call
+    ///      lane. This prevents a mutable target from being aliased to either a
+    ///      Bridge or CommissionManager to bypass its typed operation.
+    function _requireAllowedGenericSelector(bytes4 selector) private pure {
+        _requireNotCommissionWithdrawSelector(selector);
+        _requireNotBridgeReleaseSelector(selector);
     }
 }

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -389,7 +389,7 @@ contract MultisigProxy is IMultisigProxy {
     ///      in one signed operation. The Bridge recipient is forced to
     ///      `lzAdapter`, and the amount sent out is the balance actually
     ///      delivered to the adapter (measured here), so the two legs are bound
-    ///      on-chain and cannot be mismatched (R-W-16).
+    ///      on-chain and cannot be mismatched.
     function lzFundsOutCall(
         LzFundsOutParams calldata params,
         uint256 nonce,
@@ -1205,7 +1205,7 @@ contract MultisigProxy is IMultisigProxy {
     /// @notice EIP-712 domain separator for this contract on the current chain.
     /// @dev Returns the value cached at deploy while `block.chainid` is
     ///      unchanged; after a chain-id change it is rebuilt, so pre-fork
-    ///      signatures are not valid on the forked chain (R-W-13).
+    ///      signatures are not valid on the forked chain.
     function DOMAIN_SEPARATOR() public view returns (bytes32) {
         return _domainSeparator();
     }
@@ -1274,8 +1274,8 @@ contract MultisigProxy is IMultisigProxy {
 
     /// @dev Reverts if any address in `candidate` also appears in `counterpart`.
     ///      Used to keep the enclave and federation signer sets disjoint so the
-    ///      two trust domains stay independent (R-W-14). O(n*m), bounded by the
-    ///      signer-set sizes.
+    ///      two trust domains stay independent. O(n*m), bounded by the signer-set
+    ///      sizes.
     function _requireDisjoint(address[] memory candidate, address[] memory counterpart) private pure {
         for (uint256 i = 0; i < candidate.length; i++) {
             for (uint256 j = 0; j < counterpart.length; j++) {
@@ -1299,7 +1299,7 @@ contract MultisigProxy is IMultisigProxy {
 
     function _validateSigners(address[] memory signers) private pure {
         // Bound the set before the O(N^2) duplicate scan below, and keep every
-        // signer index within the uint256 signature bitmap (R-I-06).
+        // signer index within the uint256 signature bitmap.
         if (signers.length > MAX_SIGNERS) revert TooManySigners(signers.length, MAX_SIGNERS);
         for (uint256 i = 0; i < signers.length; i++) {
             if (signers[i] == address(0)) revert ZeroAddressSigner();

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -212,9 +212,9 @@ interface ICommissionManager {
     /// @notice Credit `credited` token units to the commission pool. The Bridge
     ///         measures `credited` as the actual balance increase of this
     ///         contract around its `safeTransfer` (so a fee-on-transfer token is
-    ///         handled and no pre-existing/unsolicited balance is absorbed,
-    ///         R-I-04). Reverts if the resulting pool would exceed the on-chain
-    ///         balance. Callable only by the Bridge.
+    ///         handled and no pre-existing/unsolicited balance is absorbed).
+    ///         Reverts if the resulting pool would exceed the on-chain balance.
+    ///         Callable only by the Bridge.
     function receiveTokenCommission(address token, uint256 credited) external;
 
     /// @notice Native commission ingress; only `bridgeAddress` may call with non-zero value (see implementation).

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -73,6 +73,7 @@ interface IMultisigProxy {
     error UnknownOperationType();
     error ZeroTarget();
     error ForbiddenCommissionManagerSelector(bytes4 selector);
+    error ForbiddenBridgeReleaseSelector(bytes4 selector);
     error LZAdapterNotSet();
     error InvalidLZAdapter();
 
@@ -235,7 +236,11 @@ interface IMultisigProxy {
     // Federation propose (Phase 1 — timelock)
     // =========================================================================
 
-    /// @notice Propose an arbitrary Bridge call (forwarded via bridge.call).
+    /// @notice Propose a permitted administrative Bridge call (forwarded via
+    ///         `bridge.call`).
+    /// @dev `Bridge.fundsOut` and `Bridge.rebalanceLiquidity` are forbidden:
+    ///      value-moving operations must use the typed enclave-authorized
+    ///      `fundsOutCall`, `lzFundsOutCall`, or `rebalanceCall` entrypoints.
     /// @dev opData = raw ABI-encoded bridge callData (selector + args).
     function proposeAdminExecute(
         bytes calldata callData,

--- a/ethereum/src/interfaces/ISettlementModule.sol
+++ b/ethereum/src/interfaces/ISettlementModule.sol
@@ -35,11 +35,11 @@ interface ISettlementModule {
     ///                       canonical key is `ctx.operationId`.
     function onFundsIn(FundsInContext calldata ctx, bytes calldata settlementData) external returns (uint256 externalId);
 
-    /// @notice Hook invoked by `RouteRegistry.beforeFundsOut` *before* Bridge
-    ///         releases funds. The module performs any route-specific state
-    ///         updates needed to authorise the release (e.g. consumes the
-    ///         referenced RGB `fundsInIds`). Reverts if the release is not
-    ///         valid for this module's accounting view.
+    /// @notice Hook invoked by `RouteRegistry.beforeFundsOut` before a physical
+    ///         Bridge release or the debit leg of an accounting-only rebalance.
+    ///         The module performs any route-specific validation or state
+    ///         updates needed to authorise the operation. `ctx.isRebalance`
+    ///         distinguishes the two authenticated Bridge call sites.
     /// @param ctx            Canonical fundsOut context built by Bridge.
     /// @param settlementData Opaque per-route data supplied by the caller;
     ///                       layout defined by the module itself.

--- a/ethereum/src/interfaces/RouteTypes.sol
+++ b/ethereum/src/interfaces/RouteTypes.sol
@@ -68,6 +68,11 @@ struct FundsInContext {
 /// @param sourceChainId      Source chain id.
 /// @param destChainId        Destination chain id (this chain, in practice).
 /// @param sourceAddress      Sender address on the source chain.
+/// @param isRebalance        `true` only for the accounting-only debit leg of
+///                           `Bridge.rebalanceLiquidity`; `false` for a
+///                           physical `Bridge.fundsOut` token release. The
+///                           Bridge constructs this value and RouteRegistry
+///                           authenticates the Bridge as its caller.
 struct FundsOutContext {
     address token;
     address recipient;
@@ -76,6 +81,7 @@ struct FundsOutContext {
     uint256 sourceChainId;
     uint256 destChainId;
     string sourceAddress;
+    bool isRebalance;
 }
 
 /// @notice Per-route configuration stored in `RouteRegistry`.

--- a/ethereum/src/settlement/RgbOutboundSettlementModule.sol
+++ b/ethereum/src/settlement/RgbOutboundSettlementModule.sol
@@ -26,14 +26,15 @@ import {RgbSettlementModule} from "./RgbSettlementModule.sol";
 ///      auth needed on the target) instead of duplicating storage.
 ///
 ///      Hook semantics:
-///        - `beforeFundsOut`: identical existence + exact-amount + same-network
-///          verification as `RgbSettlementModule.beforeFundsOut` (same
-///          `settlementData` layout, `abi.encode(bytes32[] operationIds,
-///          uint256[] amounts)`), evaluated against the wrapped module's ledger,
-///          including its `fundsInRecordChainIds` network tag vs
-///          `ctx.sourceChainId`. Pure reads — no consumption, matching the
-///          canonical release semantics (solvency is owned by
-///          `Bridge.lockedLiquidity`, replay by `Bridge.consumedBurnIds`).
+///        - `beforeFundsOut`: requires at least one pair and performs the same
+///          existence + exact-amount + same-network verification as
+///          `RgbSettlementModule.beforeFundsOut` (same `settlementData` layout,
+///          `abi.encode(bytes32[] operationIds, uint256[] amounts)`), evaluated
+///          against the wrapped module's ledger, including its
+///          `fundsInRecordChainIds` network tag vs `ctx.sourceChainId`. Pure
+///          reads — no consumption, matching the canonical release semantics
+///          (solvency is owned by `Bridge.lockedLiquidity`, replay by
+///          `Bridge.consumedBurnIds`).
 ///        - `onFundsIn`: returns `0` and writes nothing. No record is created
 ///          (nothing was minted with a new OpId on the credit side) and Bridge
 ///          therefore emits no RGB-only `FundsIn` event for this leg.
@@ -71,6 +72,9 @@ contract RgbOutboundSettlementModule is ISettlementModule {
     /// @notice `beforeFundsOut` `settlementData` decoded to `operationIds` and
     ///         `amounts` arrays of different lengths.
     error SettlementDataLengthMismatch();
+
+    /// @notice The outbound RGB debit supplied no FundsIn accounting record.
+    error EmptySettlementRecords();
 
     // =========================================================================
     // Storage
@@ -127,9 +131,10 @@ contract RgbOutboundSettlementModule is ISettlementModule {
 
     /// @inheritdoc ISettlementModule
     /// @dev Same decoding and checks as `RgbSettlementModule.beforeFundsOut`,
-    ///      but against the wrapped module's ledger: every referenced
-    ///      `operationId` must exist there, with an exactly matching amount, and
-    ///      recorded for the release's `ctx.sourceChainId` RGB network.
+    ///      but against the wrapped module's ledger: at least one pair is
+    ///      required, and every referenced `operationId` must exist there, with
+    ///      an exactly matching amount, and recorded for the release's
+    ///      `ctx.sourceChainId` RGB network.
     function beforeFundsOut(FundsOutContext calldata ctx, bytes calldata settlementData)
         external
         view
@@ -139,6 +144,7 @@ contract RgbOutboundSettlementModule is ISettlementModule {
         (bytes32[] memory operationIds, uint256[] memory amounts) = abi.decode(settlementData, (bytes32[], uint256[]));
 
         if (operationIds.length != amounts.length) revert SettlementDataLengthMismatch();
+        if (operationIds.length == 0) revert EmptySettlementRecords();
 
         for (uint256 i = 0; i < operationIds.length; i++) {
             uint256 recorded = rgbModule.fundsInRecords(operationIds[i]);

--- a/ethereum/src/settlement/RgbSettlementModule.sol
+++ b/ethereum/src/settlement/RgbSettlementModule.sol
@@ -25,17 +25,23 @@ import {FundsInContext, FundsOutContext} from "../interfaces/RouteTypes.sol";
 ///      Release semantics (existence + exact-amount + same-network check, no
 ///      consumption):
 ///        On `beforeFundsOut` the TEE supplies the `(operationId, amount)`
-///        pairs extracted from the burn consignment. The module checks that
-///        every operation id EXISTS in `fundsInRecords`, that its recorded
-///        amount EQUALS the supplied amount, and that its recorded network
-///        EQUALS the release's `sourceChainId` — so a burn on one RGB network
-///        cannot cross-satisfy its proof-of-mint with a record minted on a
-///        different RGB network. It does NOT consume/delete the records, does
-///        NOT sum them, and does NOT tie them to the `fundsOut` amount — it only
-///        proves the referenced mints are real and belong to the burning
-///        network. This delegates to the contract the check a TEE would
-///        otherwise need an ETH light node for ("does the EVM mint event
-///        exist?").
+///        pairs extracted from the burn consignment. A physical `fundsOut`
+///        requires at least one pair. An accounting-only rebalance may supply
+///        empty arrays when its debit side deliberately has no RGB burn; its
+///        credit leg still writes the destination RGB record atomically. The
+///        operation type comes from authenticated Bridge context, not from
+///        caller-controlled `settlementData`.
+///
+///        For every supplied pair, the module checks that the operation id
+///        EXISTS in `fundsInRecords`, that its recorded amount EQUALS the
+///        supplied amount, and that its recorded network EQUALS the release's
+///        `sourceChainId` — so a burn on one RGB network cannot cross-satisfy
+///        its proof-of-mint with a record minted on a different RGB network. It
+///        does NOT consume/delete the records, does NOT sum them, and does NOT
+///        tie them to the `fundsOut` amount — it only proves the referenced
+///        mints are real and belong to the burning network. This delegates to
+///        the contract the check a TEE would otherwise need an ETH light node
+///        for ("does the EVM mint event exist?").
 ///
 ///        Solvency (no release beyond bridged liquidity) and replay protection
 ///        are owned elsewhere: `Bridge.lockedLiquidity` caps total outflow per
@@ -54,7 +60,8 @@ import {FundsInContext, FundsOutContext} from "../interfaces/RouteTypes.sol";
 ///                        is keyed by the bridge-derived `ctx.operationId`, not
 ///                        by this value.
 ///        - `beforeFundsOut`: `abi.encode(bytes32[] operationIds, uint256[] amounts)`
-///                        (equal-length parallel arrays).
+///                        (equal-length parallel arrays; non-empty for physical
+///                        releases).
 ///
 ///      This contract owns no tokens and mutates
 ///      no state on release — `beforeFundsOut` is a pure validation. Reverts
@@ -98,6 +105,11 @@ contract RgbSettlementModule is ISettlementModule {
     /// @notice `beforeFundsOut` `settlementData` decoded to `operationIds` and
     ///         `amounts` arrays of different lengths.
     error SettlementDataLengthMismatch();
+
+    /// @notice A physical `beforeFundsOut` release supplied no FundsIn
+    ///         accounting record. It must reference at least one
+    ///         `(operationId, amount)` pair from the proof-of-mint ledger.
+    error EmptySettlementRecords();
 
     // =========================================================================
     // Storage
@@ -171,9 +183,9 @@ contract RgbSettlementModule is ISettlementModule {
 
     /// @inheritdoc ISettlementModule
     /// @dev Decodes `settlementData` as `(bytes32[] operationIds, uint256[] amounts)`
-    ///      and verifies every referenced mint: each `operationId` must exist,
-    ///      its recorded amount must equal the supplied amount, and its recorded
-    ///      RGB network must equal the release's `ctx.sourceChainId`.
+    ///      and requires at least one pair for a physical release before
+    ///      verifying every referenced mint. An authenticated accounting-only
+    ///      rebalance may intentionally carry no debit-side record.
     function beforeFundsOut(FundsOutContext calldata ctx, bytes calldata settlementData)
         external
         view
@@ -183,6 +195,7 @@ contract RgbSettlementModule is ISettlementModule {
         (bytes32[] memory operationIds, uint256[] memory amounts) = abi.decode(settlementData, (bytes32[], uint256[]));
 
         if (operationIds.length != amounts.length) revert SettlementDataLengthMismatch();
+        if (operationIds.length == 0 && !ctx.isRebalance) revert EmptySettlementRecords();
 
         for (uint256 i = 0; i < operationIds.length; i++) {
             uint256 recorded = fundsInRecords[operationIds[i]];

--- a/ethereum/test/BaseBridge.t.sol
+++ b/ethereum/test/BaseBridge.t.sol
@@ -184,11 +184,11 @@ contract BaseBridgeTest is Test {
     }
 
     // ========================================================================
-    // R-W-05 — two-tier pause (inflow vs outflow / emergency)
+    // Two-tier pause (inflow vs outflow / emergency)
     // ========================================================================
 
-    /// @dev UT-FIX-08: with outflow frozen, fundsOut reverts. The
-    ///      whenOutflowNotPaused modifier runs before the body, so a dummy
+    /// @dev With outflow frozen, fundsOut reverts. The whenOutflowNotPaused
+    ///      modifier runs before the body, so a dummy
     ///      release is enough to exercise the gate.
     function test_fundsOut_revertsWhenOutflowPaused() public {
         vm.prank(user);

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -139,8 +139,8 @@ contract BridgeTest is Test {
         routeRegistry.setRoute(SOURCE_CHAIN_ID, RGB_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
         routeRegistry.setRoute(RGB_CHAIN_ID, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
 
-        // Wire the complete mandatory R-I-14 oracle config: healthy sequencer,
-        // ETH/USD circuit-breaker bounds, then the fresh ETH/USD price feed.
+        // Wire the complete mandatory oracle config: healthy sequencer, ETH/USD
+        // circuit-breaker bounds, then the fresh ETH/USD price feed.
         ethUsdFeed = new MockAggregatorV3(8, 2_000e8, block.timestamp);
         sequencerUptimeFeed = new MockAggregatorV3(0, 0, block.timestamp - 1 hours - 1);
         cm.setSequencerUptimeFeed(address(sequencerUptimeFeed));
@@ -424,7 +424,7 @@ contract BridgeTest is Test {
 
     /// @dev Ensure `requested` fits under the configured bucket burst (and
     ///      therefore also under the immutable 20% safety ceiling). Used by
-    ///      legacy success-path tests whose subject is not the C-01 limiter.
+    ///      success-path tests whose subject is not the rolling limiter.
     function _ensureRgbSafetyCapacity(uint256 requested) internal {
         uint256 requiredLiquidity = requested * bridge.BPS_DENOMINATOR() / MAX_BURST_BPS;
         uint256 currentLiquidity = bridge.lockedLiquidity(RGB_CHAIN_ID);
@@ -575,9 +575,9 @@ contract BridgeTest is Test {
     // Minimum fundsIn amount + zero-amount guards
     //
     // `minFundsInAmount` is a non-zero floor enforced on the inbound path: it
-    // rejects zero-amount deposits (R-I-07) and dust whose commission would
-    // round to zero (R-I-08). `fundsOut` is an authorized release and only
-    // rejects amount == 0. The harness deploys with the smallest floor (1), so
+    // rejects zero-amount deposits and dust whose commission would round to
+    // zero. `fundsOut` is an authorized release and only rejects amount == 0.
+    // The harness deploys with the smallest floor (1), so
     // tests that need a higher floor raise it via `setMinFundsInAmount`.
     // ========================================================================
 
@@ -613,7 +613,7 @@ contract BridgeTest is Test {
         bridge.setMinFundsInAmount(1000);
     }
 
-    // --- R-I-07: zero amount ---
+    // --- Zero amount ---
 
     function test_fundsIn_revertsOnZeroAmount() public {
         // Floor is 1 (setUp), so a zero deposit is below the minimum.
@@ -632,7 +632,7 @@ contract BridgeTest is Test {
         );
     }
 
-    // --- R-I-08: dust / below-minimum on the inbound path ---
+    // --- Dust / below-minimum on the inbound path ---
 
     function test_fundsIn_revertsBelowMinimum() public {
         vm.prank(multisig);
@@ -663,8 +663,8 @@ contract BridgeTest is Test {
 
     function test_fundsIn_dustThatRoundsCommissionToZeroIsRejected() public {
         // 4% token commission. Below 25 units the fee floors to zero
-        // (24 * 400 / 100 / 100 == 0) — the exact dust case I-08 describes.
-        // The effective fee policy itself now rejects that dust, independently
+        // (24 * 400 / 100 / 100 == 0). The effective fee policy itself rejects
+        // that dust, independently
         // of the separately configurable global minimum.
         _setFundsInTokenRule(400);
 
@@ -684,7 +684,7 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId), 24, "net = 25 - 1 commission");
     }
 
-    function test_R_I_08_fundsOutDustThatRoundsCommissionToZeroIsRejected() public {
+    function test_fundsOutDustThatRoundsCommissionToZeroIsRejected() public {
         uint256 dustAmount = 24;
         vm.prank(user);
         bytes32 opId = bridge.fundsIn(dustAmount, RGB_CHAIN_ID, DST_ADDR, _rgbData());
@@ -830,7 +830,7 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
-    // Proof length cap (R-I-12)
+    // Proof length cap
     //
     // fundsOut forwards `proof` to the route verifier, so it is capped at
     // MAX_PROOF_LENGTH to bound calldata + verifier gas. The exact cap is
@@ -1027,8 +1027,8 @@ contract BridgeTest is Test {
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
-    // Post R-W-08 the operationId is derived on-chain with a per-sender nonce,
-    // so two identical deposits from the same sender now get DISTINCT ids and
+    // The operationId is derived on-chain with a per-sender nonce, so two
+    // identical deposits from the same sender get DISTINCT ids and
     // both succeed — the caller can no longer force a DuplicateOperationId by
     // replaying params. The duplicate guard is exercised directly at the module
     // level (RgbSettlementModule.t.sol) instead.
@@ -1141,6 +1141,26 @@ contract BridgeTest is Test {
     // fundsOut — settlement-module reverts (delegated to RgbSettlementModule
     // but surfaced through Bridge)
     // ========================================================================
+
+    function test_fundsOutRejectsEmptySettlementRecords() public {
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+        _ensureRgbSafetyCapacity(AMOUNT);
+
+        bytes memory proof = _proof();
+        bytes memory settlementData = _settlementWithAmounts(new bytes32[](0), new uint256[](0));
+        uint256 burnId =
+            _deriveBurnId(recipient, AMOUNT, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData);
+        uint256 liquidityBefore = bridge.lockedLiquidity(RGB_CHAIN_ID);
+
+        vm.expectRevert(RgbSettlementModule.EmptySettlementRecords.selector);
+        vm.prank(multisig);
+        _fundsOutWithBurnId(recipient, AMOUNT, burnId, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, proof, settlementData);
+
+        assertFalse(bridge.consumedBurnIds(burnId), "reverted release does not consume burn id");
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), liquidityBefore, "reverted release does not debit liquidity");
+        assertEq(usdt0.balanceOf(recipient), 0, "reverted release transfers no tokens");
+    }
 
     function test_fundsOut_revertsOnUnknownFundsInId() public {
         vm.prank(user);
@@ -1394,8 +1414,9 @@ contract BridgeTest is Test {
     }
 
     /// @dev Fuzz the interaction between isolated liquidity and the immutable
-    ///      C-01 ceiling: overdraw still fails on isolated liquidity, while a
-    ///      full-bucket release fails and a release inside both limits succeeds.
+    ///      rolling ceiling: overdraw still fails on isolated liquidity, while
+    ///      a full-bucket release fails and a release inside both limits
+    ///      succeeds.
     function testFuzz_isolatedLiquidity_andSafetyLimit(uint256 amount) public {
         // Bound to the user's funded balance and above the dust floor; no
         // commission in setUp so net == gross.
@@ -1713,10 +1734,10 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
-    // C-01 — immutable TVL-relative rolling safety limit
+    // Immutable TVL-relative rolling safety limit
     // ========================================================================
 
-    function test_C01_usageCannotExpireBefore24Hours_andNewLimitUsesLowerTVL() public {
+    function test_usageCannotExpireBefore24Hours_andNewLimitUsesLowerTVL() public {
         // Align to a ring slot boundary so expiry happens exactly at H+25.
         vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
         uint256 bucketBurst = 100 ether;
@@ -1726,7 +1747,7 @@ contract BridgeTest is Test {
         assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 200 ether);
         assertEq(bridge.availableGlobalSafetyOutflow(), 200 ether);
 
-        _releaseRGBTo(makeAddr("c01-window-first"), bucketBurst, BURN_ID);
+        _releaseRGBTo(makeAddr("rolling-window-first"), bucketBurst, BURN_ID);
         assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 100 ether);
         assertEq(bridge.availableGlobalSafetyOutflow(), 100 ether);
 
@@ -1739,7 +1760,7 @@ contract BridgeTest is Test {
         // One extra second fully restores the slightly conservative, integer-
         // rounded bucket refill while the first rolling-window spend remains.
         vm.warp(block.timestamp + 1);
-        _releaseRGBTo(makeAddr("c01-window-second"), bucketBurst, BURN_ID + 1);
+        _releaseRGBTo(makeAddr("rolling-window-second"), bucketBurst, BURN_ID + 1);
         assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 0);
         assertEq(bridge.availableGlobalSafetyOutflow(), 0);
 
@@ -1757,11 +1778,11 @@ contract BridgeTest is Test {
         vm.warp(block.timestamp + bridge.OUTFLOW_SAFETY_WINDOW());
         assertEq(bridge.chainOutflowReference(RGB_CHAIN_ID), 800 ether);
         assertEq(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), nextWindowLimit);
-        _releaseRGBTo(makeAddr("c01-window-third"), nextWindowLimit, BURN_ID + 2);
+        _releaseRGBTo(makeAddr("rolling-window-third"), nextWindowLimit, BURN_ID + 2);
         assertEq(bridge.totalLockedLiquidity(), 720 ether);
     }
 
-    function test_C01_directTokenDonationCannotInflateGlobalSafetyAllowance() public {
+    function test_directTokenDonationCannotInflateGlobalSafetyAllowance() public {
         _seedRGB(100 ether); // accounted TVL 1000 ether; global hard limit 200
         uint256 beforeAllowance = bridge.availableGlobalSafetyOutflow();
 
@@ -1781,7 +1802,7 @@ contract BridgeTest is Test {
     ///      release into shares rounds up, so splitting can cost a sub-share more
     ///      than one combined release. That is the conservative direction, and
     ///      the aggregate bound is what this asserts.
-    function testFuzz_C01_arbitrarySplitCannotExceedRollingLimit(uint96 firstPartSeed) public {
+    function testFuzz_arbitrarySplitCannotExceedRollingLimit(uint96 firstPartSeed) public {
         vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
         _seedRGB(100 ether); // chain liquidity 1000; bucket burst 100; hard limit 200
         uint256 poolBefore = usdt0.balanceOf(address(bridge));
@@ -1792,7 +1813,7 @@ contract BridgeTest is Test {
 
         // Vary recipients so every split has a distinct canonical burn intent,
         // even when two fuzzed amounts happen to be equal.
-        _releaseRGBTo(makeAddr("c01-first"), firstPart, BURN_ID);
+        _releaseRGBTo(makeAddr("rolling-limit-first"), firstPart, BURN_ID);
 
         // The reference does not move inside the window, so the remaining
         // immutable allowance is exactly the complement of the first part.
@@ -1803,24 +1824,24 @@ contract BridgeTest is Test {
         // the conservative rolling window, then take everything still permitted.
         vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
         uint256 secondPart = bridge.effectiveAvailableOutflow(RGB_CHAIN_ID);
-        if (secondPart != 0) _releaseRGBTo(makeAddr("c01-second"), secondPart, BURN_ID + 1);
+        if (secondPart != 0) _releaseRGBTo(makeAddr("rolling-limit-second"), secondPart, BURN_ID + 1);
 
-        // The C-01 invariant: however the drain is split, the pool never loses
-        // more than 20% of the window's reference, and nothing further may leave.
+        // However the drain is split, the pool never loses more than 20% of the
+        // window's reference, and nothing further may leave.
         assertLe(firstPart + secondPart, hardLimit, "rolling cap never exceeded");
         assertEq(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), 0, "allowance exhausted");
         assertGe(usdt0.balanceOf(address(bridge)), poolBefore - hardLimit, "at least 80% of the pool remains");
 
         // Which layer refuses the next unit depends on where the sub-share
         // rounding lands, so that is asserted deterministically instead in
-        // `test_C01_usageCannotExpireBefore24Hours_andNewLimitUsesLowerTVL` (bucket)
-        // and `MultisigProxy.t.sol::test_C01_split...` (immutable limiter).
+        // `test_usageCannotExpireBefore24Hours_andNewLimitUsesLowerTVL` (bucket)
+        // and `MultisigProxy.t.sol::test_splitTransactions...` (immutable limiter).
     }
 
     /// @dev The global rolling window aggregates physical outflow from every
     ///      source chain. Two chains may each consume their own allowance, but
     ///      splitting a drain across chains cannot bypass the global accounting.
-    function test_C01_globalRollingUsageAggregatesAcrossSourceChains() public {
+    function test_globalRollingUsageAggregatesAcrossSourceChains() public {
         vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
 
         uint256 otherChain = 888;
@@ -1916,11 +1937,11 @@ contract BridgeTest is Test {
         bridge.setOutflowLimit(RGB_CHAIN_ID, 500, 0);
     }
 
-    /// @dev C-01 remaining issue: the federation must not be able to configure a
-    ///      bucket that covers TVL. `burstBps` is bounded by the immutable
+    /// @dev The federation must not be able to configure a bucket that covers
+    ///      TVL. `burstBps` is bounded by the immutable
     ///      `MAX_CHAIN_OUTFLOW_BPS`, so no policy authorises more than 20% of
     ///      reference liquidity in one release — at any liquidity level.
-    function test_C01_setOutflowLimit_rejectsBurstAboveImmutableCeiling() public {
+    function test_setOutflowLimit_rejectsBurstAboveImmutableCeiling() public {
         uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
 
         vm.prank(multisig);
@@ -1928,7 +1949,7 @@ contract BridgeTest is Test {
         bridge.setOutflowLimit(RGB_CHAIN_ID, maxBps + 1, 1);
     }
 
-    function test_C01_setOutflowLimit_rejectsRefillAboveImmutableCeiling() public {
+    function test_setOutflowLimit_rejectsRefillAboveImmutableCeiling() public {
         uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
 
         vm.prank(multisig);
@@ -1938,7 +1959,7 @@ contract BridgeTest is Test {
 
     /// @dev A policy whose combined burst and refill equals the immutable
     ///      ceiling is accepted.
-    function test_C01_setOutflowLimit_acceptsCombinedCeiling() public {
+    function test_setOutflowLimit_acceptsCombinedCeiling() public {
         uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
         uint256 burstBps = 750;
         uint256 refillBps = maxBps - burstBps;
@@ -1950,7 +1971,7 @@ contract BridgeTest is Test {
         assertEq(capacity, burstBps * bridge.SHARE_UNIT() / bridge.BPS_DENOMINATOR(), "burst stored as shares");
     }
 
-    function test_C01_setOutflowLimit_rejectsCombinedPolicyAboveCeiling() public {
+    function test_setOutflowLimit_rejectsCombinedPolicyAboveCeiling() public {
         uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
         uint256 burstBps = 1_001;
         uint256 refillBps = 1_000;
@@ -1960,7 +1981,7 @@ contract BridgeTest is Test {
         bridge.setOutflowLimit(RGB_CHAIN_ID, burstBps, refillBps);
     }
 
-    function test_C01_setOutflowLimit_rejectsFullTvlPolicy() public {
+    function test_setOutflowLimit_rejectsFullTvlPolicy() public {
         uint256 denominator = bridge.BPS_DENOMINATOR();
         uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
 
@@ -1969,7 +1990,7 @@ contract BridgeTest is Test {
         bridge.setOutflowLimit(RGB_CHAIN_ID, denominator, denominator);
     }
 
-    function test_C01_setGlobalOutflowLimit_rejectsFullTvlPolicy() public {
+    function test_setGlobalOutflowLimit_rejectsFullTvlPolicy() public {
         uint256 denominator = bridge.BPS_DENOMINATOR();
         uint256 maxBps = bridge.MAX_GLOBAL_OUTFLOW_BPS();
 
@@ -1978,7 +1999,7 @@ contract BridgeTest is Test {
         bridge.setGlobalOutflowLimit(denominator, 1);
     }
 
-    function test_C01_setGlobalOutflowLimit_rejectsCombinedPolicyAboveCeiling() public {
+    function test_setGlobalOutflowLimit_rejectsCombinedPolicyAboveCeiling() public {
         uint256 maxBps = bridge.MAX_GLOBAL_OUTFLOW_BPS();
         uint256 burstBps = 1_200;
         uint256 refillBps = 801;
@@ -1992,7 +2013,7 @@ contract BridgeTest is Test {
     ///      both buckets can be configured before the first deposit exists. This
     ///      is what lets a deployment install every parameter in one pass instead
     ///      of "deploy → seed liquidity → come back and configure buckets".
-    function test_C01_outflowPolicyConfigurableAtZeroLiquidity() public {
+    function test_outflowPolicyConfigurableAtZeroLiquidity() public {
         // `setUp` deploys the Bridge and configures routes but makes no deposit.
         assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), 0, "no chain liquidity yet");
         assertEq(bridge.totalLockedLiquidity(), 0, "no global liquidity yet");
@@ -2011,7 +2032,7 @@ contract BridgeTest is Test {
 
     /// @dev The same policy scales with liquidity and needs no governance touch:
     ///      5% burst is 5 ether at 100 ether TVL and 50 ether at 1000 ether TVL.
-    function test_C01_outflowPolicyScalesWithLiquidity() public {
+    function test_outflowPolicyScalesWithLiquidity() public {
         vm.startPrank(multisig);
         bridge.setOutflowLimit(RGB_CHAIN_ID, 500, 1_500);
         bridge.setGlobalOutflowLimit(500, 1_500);
@@ -2188,10 +2209,10 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId), expectedNet, "record = net");
     }
 
-    // R-I-04 end-to-end: a token already donated directly to the CommissionManager
-    // is NOT absorbed as commission. Bridge measures the delta of its own transfer,
+    // A token already donated directly to the CommissionManager is NOT absorbed
+    // as commission. Bridge measures the delta of its own transfer,
     // so the pool grows by exactly the real fee; the donation stays a stray balance.
-    function test_fundsIn_tokenCommission_doesNotAbsorbCmDonation_afterFix() public {
+    function test_fundsIn_tokenCommission_doesNotAbsorbCmDonation() public {
         _setFundsInTokenRule(400); // 4%
         uint256 expectedCommission = (AMOUNT * 400) / 100 / 100;
 
@@ -2263,18 +2284,18 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
-    // Commission — NATIVE + FUNDS_OUT rejected at config time (R-W-04)
+    // Commission — NATIVE + FUNDS_OUT rejected at config time
     // ========================================================================
 
-    /// @dev Post R-W-04 the invalid (NATIVE, FUNDS_OUT) shape is rejected by the
-    ///      CommissionManager setter, so it can never reach (and brick) fundsOut.
+    /// @dev The invalid (NATIVE, FUNDS_OUT) shape is rejected by the
+    ///      CommissionManager setter, so it can never reach and brick fundsOut.
     function test_setCommissionRule_nativeFundsOut_reverts() public {
         vm.expectRevert(ICommissionManager.NativeCommissionNotAllowedOnFundsOut.selector);
         _setFundsOutNativeRule(100); // setCommissionRule(... NATIVE, FUNDS_OUT ...)
     }
 
     // ========================================================================
-    // Commission — I-03 bounded native quote drift
+    // Commission — bounded native quote drift
     // ========================================================================
 
     function test_fundsIn_revertsOnNativeValueMismatch_zeroRuleButValueSent() public {
@@ -2298,7 +2319,7 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
-    // I-03 — native commission drift band
+    // Native commission drift band
     //
     // Direct deposits: attach the quote plus optional headroom; exactly the
     // fresh quote is charged and the remainder refunded, so the protocol never
@@ -2307,7 +2328,7 @@ contract BridgeTest is Test {
     // symmetric and whatever arrives inside it is collected in full.
     // ========================================================================
 
-    function test_I_03_direct_exactQuoteChargedInFull() public {
+    function test_direct_exactQuoteChargedInFull() public {
         _setFundsInNativeRule(100);
         uint256 quote = _nativeQuote(AMOUNT);
         assertGt(quote, 0, "native fee quoted");
@@ -2324,9 +2345,9 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId), AMOUNT, "deposit completed");
     }
 
-    /// @dev The invariant I-03 asks for: a caller who attaches more than the
-    ///      quote is charged only the quote and refunded the surplus.
-    function test_I_03_direct_surplusIsRefundedNotCollected() public {
+    /// @dev A caller who attaches more than the quote is charged only the quote
+    ///      and refunded the surplus.
+    function test_direct_surplusIsRefundedNotCollected() public {
         _setFundsInNativeRule(100);
         uint256 quote = _nativeQuote(AMOUNT);
         uint256 attached = quote + (quote * 400) / 10_000; // +4%, inside the band
@@ -2342,7 +2363,7 @@ contract BridgeTest is Test {
         assertEq(address(bridge).balance, 0, "no native stranded in bridge");
     }
 
-    function test_I_03_direct_upperBoundaryRefunded() public {
+    function test_direct_upperBoundaryRefunded() public {
         _setFundsInNativeRule(100);
         uint256 quote = _nativeQuote(AMOUNT);
         (, uint256 maximum) = _directNativeBounds(quote);
@@ -2355,7 +2376,7 @@ contract BridgeTest is Test {
         assertEq(user.balance, maximum - quote, "full headroom refunded");
     }
 
-    function test_I_03_direct_revertsBelowQuote() public {
+    function test_direct_revertsBelowQuote() public {
         _setFundsInNativeRule(100);
         uint256 quote = _nativeQuote(AMOUNT);
         (uint256 minimum, uint256 maximum) = _directNativeBounds(quote);
@@ -2369,7 +2390,7 @@ contract BridgeTest is Test {
         bridge.fundsIn{value: provided}(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
-    function test_I_03_direct_revertsAboveUpperBoundary() public {
+    function test_direct_revertsAboveUpperBoundary() public {
         _setFundsInNativeRule(100);
         uint256 quote = _nativeQuote(AMOUNT);
         (uint256 minimum, uint256 maximum) = _directNativeBounds(quote);
@@ -2386,7 +2407,7 @@ contract BridgeTest is Test {
     /// @dev The scenario from the finding: quote, then the price moves against
     ///      the caller before the tx mines. The attached buffer absorbs it and
     ///      the deposit succeeds, charged at the FRESH (higher) quote.
-    function test_I_03_direct_adverseDriftAbsorbedByBuffer() public {
+    function test_direct_adverseDriftAbsorbedByBuffer() public {
         _setFundsInNativeRule(100);
         uint256 quotedAtSubmit = _nativeQuote(AMOUNT);
         uint256 attached = quotedAtSubmit + (quotedAtSubmit * 400) / 10_000; // +4% buffer
@@ -2408,7 +2429,7 @@ contract BridgeTest is Test {
 
     /// @dev Favorable drift simply returns more: the caller is charged the fresh
     ///      (lower) quote, never the stale higher one.
-    function test_I_03_direct_favorableDriftRefundsMore() public {
+    function test_direct_favorableDriftRefundsMore() public {
         _setFundsInNativeRule(100);
         uint256 quotedAtSubmit = _nativeQuote(AMOUNT);
 
@@ -2426,7 +2447,7 @@ contract BridgeTest is Test {
 
     /// @dev The protocol cannot be systematically under-paid: every deposit
     ///      credits exactly the quote in force at execution.
-    function test_I_03_direct_noSystematicUnderCollection() public {
+    function test_direct_noSystematicUnderCollection() public {
         _setFundsInNativeRule(100);
         uint256 expected;
 
@@ -2444,7 +2465,7 @@ contract BridgeTest is Test {
 
     /// @dev A caller that cannot accept native value must send the exact quote;
     ///      attaching a buffer it cannot be refunded reverts cleanly.
-    function test_I_03_direct_nonPayableCallerMustSendExactQuote() public {
+    function test_direct_nonPayableCallerMustSendExactQuote() public {
         _setFundsInNativeRule(100);
         NonPayableDepositor depositor = new NonPayableDepositor(bridge, usdt0);
         usdt0.mint(address(depositor), AMOUNT * 2);
@@ -2466,7 +2487,7 @@ contract BridgeTest is Test {
         depositor.deposit(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData(RGB_OP_ID + 951), attached);
     }
 
-    function test_I_03_adapter_symmetricBandCollectedInFull() public {
+    function test_adapter_symmetricBandCollectedInFull() public {
         _setFundsInNativeRule(100);
 
         address adapter = makeAddr("lz-adapter");
@@ -2501,7 +2522,7 @@ contract BridgeTest is Test {
         assertEq(address(bridge).balance, 0, "no native stranded in bridge");
     }
 
-    function test_I_03_adapter_revertsBelowLowerBoundary() public {
+    function test_adapter_revertsBelowLowerBoundary() public {
         _setFundsInNativeRule(100);
 
         address adapter = makeAddr("lz-adapter");
@@ -2522,7 +2543,7 @@ contract BridgeTest is Test {
         );
     }
 
-    function test_I_03_adapter_revertsAboveUpperBoundary() public {
+    function test_adapter_revertsAboveUpperBoundary() public {
         _setFundsInNativeRule(100);
 
         address adapter = makeAddr("lz-adapter");
@@ -3004,10 +3025,10 @@ contract BridgeTest is Test {
     function test_fundsOutVerifierProofStillNotRouteContextAware_currentBehavior() public {
         address alternateRecipient = makeAddr("alternateRecipient");
         uint256 releaseAmount = 37e18;
-        // R-C-01 (isolated liquidity + outflow limit) gates the `sourceChainId`
-        // dimension: a release can only draw from a funded + rate-limited source
-        // chain. So this reproduction keeps the source on the funded RGB chain.
-        // R-M-01 now binds the release intent and exact proof into burnId, but
+        // Isolated liquidity and the outflow limit gate the `sourceChainId`
+        // dimension: a release can only draw from a funded and rate-limited
+        // source chain. This reproduction keeps the source on the funded RGB
+        // chain. The burnId binds the release intent and exact proof, but
         // RGBVerifier itself still validates only BTC block commitments; it does
         // not parse route/business context from the proof.
         uint256 alternateSourceChainId = RGB_CHAIN_ID;
@@ -3077,8 +3098,8 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId), recordBefore, "record unchanged (proof-of-mint permanent)");
     }
 
-    // R-W-08 FIX: the pre-emption attack is closed. The operationId is now
-    // derived on-chain from the authenticated `sourceSender` + a per-sender
+    // The pre-emption attack is closed because operationId is derived on-chain
+    // from the authenticated `sourceSender` plus a per-sender
     // nonce, so an attacker cannot compute (let alone occupy) a victim's id by
     // copying the RGB OpId out of the mempool. A preemptor sharing the same
     // rgbOpId lands on a DIFFERENT derived id, and the victim's deposit still
@@ -3211,13 +3232,10 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId), recordBefore + AMOUNT, "record created");
     }
 
-    // Current behavior: Bridge calls the settlement hook after pulling gross
-    // funds but before forwarding token commission, so a hook can observe funds
-    // that will not remain as Bridge liquidity after the call.
-    // R-W-17 after-fix: the token commission is forwarded before the onFundsIn
-    // hook, so a settlement module reading getContractBalance during the hook
+    // The token commission is forwarded before the onFundsIn hook, so a
+    // settlement module reading getContractBalance during the hook
     // observes only the net the Bridge retains — never the in-flight commission.
-    function test_onFundsInHookSeesNetBalanceNotFutureCommission_afterFix() public {
+    function test_onFundsInHookSeesNetBalanceNotFutureCommission() public {
         uint256 percent = 400; // 4%
         _setFundsInTokenRule(percent);
 
@@ -3364,10 +3382,10 @@ contract BridgeTest is Test {
         }
     }
 
-    // A positive-net RGB deposit records net under its DERIVED operationId. Post
-    // R-W-08 a repeated identical deposit no longer collides (the per-sender
-    // nonce yields a distinct id), so the second deposit succeeds and creates a
-    // second record. The module-level DuplicateOperationId guard is covered in
+    // A positive-net RGB deposit records net under its DERIVED operationId. A
+    // repeated identical deposit does not collide because the per-sender nonce
+    // yields a distinct id, so the second deposit creates a second record. The
+    // module-level DuplicateOperationId guard is covered in
     // RgbSettlementModule.t.sol.
     function testFuzz_fundsIn_positiveNetDepositCreatesRecordAndDistinctRepeat(uint128 amountSeed, uint16 percentSeed)
         public
@@ -3436,9 +3454,9 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId2), netAmount, "second record created");
     }
 
-    /// @dev I-08 regression: the auditor's 100% fee shape is rejected before
-    ///      it can become an active route rule and create zero-net records.
-    function test_R_I_08_hundredPercentRouteRuleCannotBeConfigured() public {
+    /// @dev A 100% fee shape is rejected before it can become an active route
+    ///      rule and create zero-net records.
+    function test_hundredPercentRouteRuleCannotBeConfigured() public {
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 8_100,
             multiplier: 90,
@@ -3458,7 +3476,7 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
-    // R-W-08 — on-chain-derived, unpredictable operationId (new regression)
+    // On-chain-derived, unpredictable operationId
     // ========================================================================
 
     /// @dev The id is derived on-chain from the authenticated sender; two
@@ -3818,10 +3836,10 @@ contract BridgeTest is Test {
         s.bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
     }
 
-    /// @dev I-08: a nominally valid (<100%) commission can still consume the
-    ///      full ACTUAL receipt when the token charges a transfer fee. Equality
-    ///      must revert rather than recording a zero-net settlement.
-    function test_R_I_08_fundsInFeeTokenRevertsWhenActualNetWouldBeZero() public {
+    /// @dev A nominally valid (<100%) commission can still consume the full
+    ///      ACTUAL receipt when the token charges a transfer fee. Equality must
+    ///      revert rather than recording a zero-net settlement.
+    function test_fundsInFeeTokenRevertsWhenActualNetWouldBeZero() public {
         FeeStack memory s = _deployFeeStack(5000); // Bridge receives 50%
         _setFeeStackFundsInTokenRule(s, 5000, 100); // nominal commission is 50%
 

--- a/ethereum/test/BridgeRebalance.t.sol
+++ b/ethereum/test/BridgeRebalance.t.sol
@@ -709,6 +709,23 @@ contract BridgeRebalanceTest is Test {
     // RgbOutboundSettlementModule
     // ========================================================================
 
+    function test_outboundModule_revertsOnEmptyArrays() public {
+        FundsOutContext memory ctx = FundsOutContext({
+            token: address(usdt0),
+            recipient: address(bridge),
+            amount: AMOUNT,
+            burnId: 1,
+            sourceChainId: RGB_CHAIN_ID,
+            destChainId: ARCH_CHAIN_ID,
+            sourceAddress: RGB_SRC_ADDR,
+            isRebalance: true
+        });
+
+        vm.prank(address(routeRegistry));
+        vm.expectRevert(RgbOutboundSettlementModule.EmptySettlementRecords.selector);
+        outboundModule.beforeFundsOut(ctx, _emptySettlement());
+    }
+
     function test_outboundModule_revert_unknownRecord() public {
         bytes32 bogus = keccak256("no-such-record");
         IBridge.RebalanceParams memory p = _rgbToArchParams(AMOUNT, rgbSeedOpId);
@@ -760,7 +777,8 @@ contract BridgeRebalanceTest is Test {
                 burnId: 1,
                 sourceChainId: RGB_CHAIN_ID,
                 destChainId: ARCH_CHAIN_ID,
-                sourceAddress: RGB_SRC_ADDR
+                sourceAddress: RGB_SRC_ADDR,
+                isRebalance: true
             }),
             _emptySettlement()
         );

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -60,8 +60,8 @@ contract CommissionManagerTest is Test {
         vm.prank(owner);
         cm.setGlobalDefaults(0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
 
-        // Install a complete healthy Arbitrum oracle config. R-I-14 makes the
-        // sequencer feed and price band mandatory whenever a non-zero NATIVE
+        // Install a complete healthy Arbitrum oracle config. The sequencer feed
+        // and price band are mandatory whenever a non-zero NATIVE
         // quote consumes ETH/USD.
         ethUsdFeed = new MockAggregatorV3(FEED_DECIMALS, DEFAULT_ETH_USD, block.timestamp);
         sequencerFeed = new MockAggregatorV3(0, 0, block.timestamp - cm.SEQUENCER_GRACE_PERIOD() - 1);
@@ -184,8 +184,8 @@ contract CommissionManagerTest is Test {
 
     function test_setGlobalDefaults_updatesAndEmits() public {
         // FUNDS_IN + NATIVE is a valid shape (the user funds the native fee on
-        // deposit). NATIVE + FUNDS_OUT is rejected by the setter (R-W-04) and is
-        // covered by a dedicated revert test.
+        // deposit). NATIVE + FUNDS_OUT is rejected by the setter and is covered
+        // by a dedicated revert test.
         vm.expectEmit(true, true, true, true);
         emit GlobalDefaultsUpdated(200, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
         vm.prank(owner);
@@ -225,7 +225,7 @@ contract CommissionManagerTest is Test {
         cm.setGlobalDefaults(400, 0, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
-    /// @dev UT-FIX-07: setGlobalDefaults rejects the NATIVE + FUNDS_OUT shape.
+    /// @dev setGlobalDefaults rejects the NATIVE + FUNDS_OUT shape.
     function test_setGlobalDefaults_revertsNativeFundsOut() public {
         vm.prank(owner);
         vm.expectRevert(ICommissionManager.NativeCommissionNotAllowedOnFundsOut.selector);
@@ -442,7 +442,7 @@ contract CommissionManagerTest is Test {
         cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, t, cfg);
     }
 
-    /// @dev UT-FIX-07: setCommissionRule rejects the NATIVE + FUNDS_OUT shape.
+    /// @dev setCommissionRule rejects the NATIVE + FUNDS_OUT shape.
     function test_setCommissionRule_revertsNativeFundsOut() public {
         address t = address(token);
         CommissionConfig memory cfg = CommissionConfig({
@@ -475,7 +475,7 @@ contract CommissionManagerTest is Test {
         assertEq(uint8(stored.currency), uint8(CommissionCurrency.TOKEN));
     }
 
-    // --- Fee-shape invariant (R-W-03 / UT-FIX-06) -----------------------------
+    // --- Fee-shape invariant --------------------------------------------------
     //
     // The stable-fee formula is `amount * stablePercent / multiplier / multiplier`,
     // i.e. a fee fraction of `stablePercent / multiplier^2`. If `stablePercent`
@@ -496,7 +496,7 @@ contract CommissionManagerTest is Test {
         cm.setGlobalDefaults(101, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
-    /// @dev I-08: the exact boundary is a 100% fee and must be rejected too.
+    /// @dev The exact boundary is a 100% fee and must be rejected too.
     function test_setGlobalDefaults_revertsFeeShapeAtExactBoundary() public {
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(100), uint8(10)));
@@ -531,7 +531,7 @@ contract CommissionManagerTest is Test {
         cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), cfg);
     }
 
-    /// @dev I-08: per-route rules also reject the exact 100% boundary.
+    /// @dev Per-route rules also reject the exact 100% boundary.
     function test_setCommissionRule_revertsFeeShapeAtExactBoundary() public {
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 100,
@@ -562,14 +562,14 @@ contract CommissionManagerTest is Test {
     }
 
     /// @dev Direct regression for the auditor's `8100 / 90^2 == 100%` PoC.
-    function test_R_I_08_rejectsAuditHundredPercentConfiguration() public {
+    function test_rejectsHundredPercentFeeConfiguration() public {
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(8100), uint8(90)));
         cm.setGlobalDefaults(8100, 90, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
     /// @dev A non-zero inbound fee policy cannot silently round to zero.
-    function test_R_I_08_fundsInActiveFeeRejectsCommissionFreeDust() public {
+    function test_fundsInActiveFeeRejectsCommissionFreeDust() public {
         vm.prank(owner);
         cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
 
@@ -582,7 +582,7 @@ contract CommissionManagerTest is Test {
     }
 
     /// @dev The same runtime invariant applies to outbound fee rules.
-    function test_R_I_08_fundsOutActiveFeeRejectsCommissionFreeDust() public {
+    function test_fundsOutActiveFeeRejectsCommissionFreeDust() public {
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 400,
             multiplier: 100,
@@ -603,7 +603,7 @@ contract CommissionManagerTest is Test {
 
     /// @dev A deliberately disabled fee remains valid; only active policies
     ///      promise a non-zero commission.
-    function test_R_I_08_zeroFeePolicyStillAllowsSmallAmount() public view {
+    function test_zeroFeePolicyStillAllowsSmallAmount() public view {
         (uint256 tokenFee, uint256 nativeFee, uint256 netAmount) =
             cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 1);
         assertEq(tokenFee, 0);
@@ -649,8 +649,8 @@ contract CommissionManagerTest is Test {
         cm.receiveTokenCommission(address(token), 0);
     }
 
-    // After the R-I-04 fix the pool is credited by the passed `credited`, not by
-    // balanceOf - pool. Crediting more than the on-chain balance can back reverts
+    // The pool is credited by the passed `credited`, not by balanceOf - pool.
+    // Crediting more than the on-chain balance can back reverts
     // BalanceBelowRecordedPool (guards against over-crediting).
     function test_receiveTokenCommission_revertsWhenCreditExceedsBalance() public {
         token.mint(address(cm), 5 ether);
@@ -659,10 +659,10 @@ contract CommissionManagerTest is Test {
         cm.receiveTokenCommission(address(token), 6 ether);
     }
 
-    // R-I-04 after-fix: an unsolicited direct transfer already sitting in the CM
-    // is NOT folded into the pool. The Bridge measures only its own transfer and
+    // An unsolicited direct transfer already sitting in the CM is NOT folded
+    // into the pool. The Bridge measures only its own transfer and
     // passes that as `credited`; the donation stays as a stray balance.
-    function test_receiveTokenCommission_doesNotAbsorbUnsolicitedBalance_afterFix() public {
+    function test_receiveTokenCommission_doesNotAbsorbUnsolicitedBalance() public {
         uint256 unsolicitedAmount = 3 ether;
         uint256 legitimateAmount = 7 ether;
 

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -425,7 +425,7 @@ contract IntegrationTest is Test {
 
     function test_endToEnd_nativeCommission_inboundAndWithdraw() public {
         // Configure a NATIVE FUNDS_IN route (2% on token amount, paid in wei).
-        // Wire the complete mandatory R-I-14 config through federation
+        // Wire the complete mandatory oracle config through federation
         // governance — dependencies first, ETH/USD feed last.
         MockAggregatorV3 sequencerFeed = new MockAggregatorV3(0, 0, block.timestamp);
         ethUsdFeed = new MockAggregatorV3(8, 2_000e8, block.timestamp);

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -1664,6 +1664,39 @@ contract MultisigProxyTest is Test {
         assertTrue(bridge.paused());
     }
 
+    /// @dev Assert that a protected selector is rejected before federation
+    ///      signature verification on every generic raw-call lane. Applying
+    ///      each policy selector-wide closes mutable-target aliasing.
+    function _assertGenericPathsRejectSelector(bytes memory callData, bytes4 errorSelector) internal {
+        bytes4 selector = bytes4(callData);
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes[] memory noSigs = new bytes[](0);
+        bytes memory expected = abi.encodeWithSelector(errorSelector, selector);
+
+        vm.expectRevert(expected);
+        proxy.proposeAdminExecute(callData, nonce, deadline, 0, noSigs);
+
+        vm.expectRevert(expected);
+        proxy.proposeAdminExecuteCommissionManager(callData, nonce, deadline, 0, noSigs);
+
+        vm.expectRevert(expected);
+        proxy.proposeAdminExecuteRouteRegistry(callData, nonce, deadline, 0, noSigs);
+
+        vm.expectRevert(expected);
+        proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, 0, noSigs);
+    }
+
+    function test_federationGenericPathsCannotCallFundsOut() public {
+        bytes memory callData = abi.encodeCall(IBridge.fundsOut, (_fundsOutParams()));
+        _assertGenericPathsRejectSelector(callData, IMultisigProxy.ForbiddenBridgeReleaseSelector.selector);
+    }
+
+    function test_federationGenericPathsCannotCallRebalanceLiquidity() public {
+        bytes memory callData = abi.encodeCall(IBridge.rebalanceLiquidity, (_rebalanceParams()));
+        _assertGenericPathsRejectSelector(callData, IMultisigProxy.ForbiddenBridgeReleaseSelector.selector);
+    }
+
     // ========================================================================
     // Propose + Execute — UpdateCommissionManager
     // ========================================================================
@@ -3175,22 +3208,15 @@ contract MultisigProxyTest is Test {
 
     // Standard CM withdrawals stay on the dedicated typed operations. Recipient
     // safety no longer depends on this blocklist: CM enforces it immutably.
-    function test_adminExecuteCommissionManager_rejectsWithdrawSelectors_afterFix() public {
+    function test_genericPathsRejectCommissionWithdrawSelectors_afterFix() public {
         bytes[] memory callDatas = new bytes[](4);
         callDatas[0] = abi.encodeWithSignature("withdrawTokenCommission(address,uint256)", address(token), uint256(1));
         callDatas[1] = abi.encodeWithSignature("withdrawNativeCommission(uint256)", uint256(1));
         callDatas[2] = abi.encodeWithSignature("withdrawAllTokenCommission(address)", address(token));
         callDatas[3] = abi.encodeWithSignature("withdrawAllNativeCommission()");
 
-        uint256 nonce = proxy.proposalNonce();
-        uint256 deadline = block.timestamp + 1 days;
-        bytes[] memory noSigs = new bytes[](0); // guard reverts before sig checks
-
         for (uint256 i = 0; i < callDatas.length; i++) {
-            vm.expectRevert(
-                abi.encodeWithSelector(IMultisigProxy.ForbiddenCommissionManagerSelector.selector, bytes4(callDatas[i]))
-            );
-            proxy.proposeAdminExecuteCommissionManager(callDatas[i], nonce, deadline, 0, noSigs);
+            _assertGenericPathsRejectSelector(callDatas[i], IMultisigProxy.ForbiddenCommissionManagerSelector.selector);
         }
     }
 

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -31,7 +31,7 @@ import {EmergencyPause} from "../script/interact/EmergencyPause.s.sol";
 import {EmergencyUnpause} from "../script/interact/EmergencyUnpause.s.sol";
 
 /// @dev Exposes the exact nonce/digest preparation used by the production
-///      scripts so R-I-09 tests cannot pass against a duplicated implementation.
+///      scripts so tests cannot pass against a duplicated implementation.
 contract EmergencyPauseHarness is EmergencyPause {
     function prepare(MultisigProxy proxy, uint256 deadline) external view returns (uint256 nonce, bytes32 digest) {
         return _prepareEmergencyPause(proxy, deadline);
@@ -541,9 +541,9 @@ contract MultisigProxyTest is Test {
         );
     }
 
-    // ---- R-W-11: MIN_TIMELOCK floor (post-fix) ----
+    // ---- MIN_TIMELOCK floor ----
 
-    /// @dev UT-FIX-13: deploying with a timelock below the requested floor reverts.
+    /// @dev Deploying with a timelock below the requested floor reverts.
     function test_constructor_revertsOnTimelockBelowMinTimelock() public {
         // timelock (1h) is below the requested floor (2h) -> TimelockTooShort
         vm.expectRevert(IMultisigProxy.TimelockTooShort.selector);
@@ -588,7 +588,7 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
-    // Strict-majority signer threshold floor (R-W-12 / UT-FIX-14)
+    // Strict-majority signer threshold floor
     //
     // Both signer sets, at construction and on signer-update, must be a strict
     // majority of at least 2 signers: n >= 2, threshold >= 2, threshold <= n,
@@ -687,7 +687,7 @@ contract MultisigProxyTest is Test {
     // ---- Intrinsic set validation runs at propose time ----
     // (empty / zero-address / duplicate paths; threshold and MAX_SIGNERS are
     //  covered by the *AtPropose tests above. Disjointness stays deferred to
-    //  execute — see the R-W-14 *OverlapWith*AtExecute tests.)
+    //  execute — see the *OverlapWith*AtExecute tests.)
 
     function test_proposeUpdateEnclaveSigners_rejectsEmptySetAtPropose() public {
         address[] memory newSigners = new address[](0);
@@ -790,7 +790,7 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
-    // Disjoint signer sets (R-W-14 / UT-FIX-16)
+    // Disjoint signer sets
     //
     // The enclave and federation sets must not share an address, at construction
     // and on signer-update (validated at executeProposal). The setUp sets are
@@ -862,7 +862,7 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
-    // Signer-set size cap (R-I-06 / UT-FIX-27)
+    // Signer-set size cap
     //
     // Either set is capped at MAX_SIGNERS, at construction and on signer-update
     // (validated in _validateSigners at executeProposal). The cap bounds the
@@ -953,7 +953,7 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
-    // TEE deadline upper bound (R-I-01 / UT-FIX-23)
+    // TEE deadline upper bound
     //
     // fundsOutCall / lzFundsOutCall reject a signed deadline further than
     // MAX_TEE_DEADLINE into the future, so a leaked or pre-signed payload cannot
@@ -1288,13 +1288,13 @@ contract MultisigProxyTest is Test {
         assertFalse(bridge.paused());
     }
 
-    /// @dev R-I-09 known-answer regression for the production pause script.
+    /// @dev Known-answer regression for the production pause script.
     ///      A regular proposal first advances only `proposalNonce`, reproducing
     ///      the state in which the old script selected the wrong nonce lane.
-    function test_R_I_09_emergencyPauseScriptUsesEmergencyNonceAfterLanesDiverge() public {
+    function test_emergencyPauseScriptUsesEmergencyNonceAfterLanesDiverge() public {
         uint256 regularNonce = proxy.proposalNonce();
         uint256 regularDeadline = block.timestamp + 1 days;
-        address newBridge = makeAddr("ri09-pause-regular-proposal");
+        address newBridge = makeAddr("emergency-pause-regular-proposal");
         bytes32 regularDigest =
             MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, regularNonce, regularDeadline);
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
@@ -1331,9 +1331,9 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.proposalNonce(), 1, "regular lane unchanged");
     }
 
-    /// @dev R-I-09 known-answer regression for the production unpause script.
+    /// @dev Known-answer regression for the production unpause script.
     ///      Both lanes are deliberately non-equal before digest construction.
-    function test_R_I_09_emergencyUnpauseScriptUsesEmergencyNonceAfterLanesDiverge() public {
+    function test_emergencyUnpauseScriptUsesEmergencyNonceAfterLanesDiverge() public {
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
 
         uint256 pauseNonce = proxy.emergencyNonce();
@@ -1346,7 +1346,7 @@ contract MultisigProxyTest is Test {
         for (uint256 i = 0; i < 2; i++) {
             uint256 regularNonce = proxy.proposalNonce();
             uint256 regularDeadline = block.timestamp + 1 days;
-            address newBridge = makeAddr(string.concat("ri09-unpause-regular-proposal-", vm.toString(i)));
+            address newBridge = makeAddr(string.concat("emergency-unpause-regular-proposal-", vm.toString(i)));
             bytes32 regularDigest =
                 MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, regularNonce, regularDeadline);
             proxy.proposeUpdateBridge(
@@ -1375,11 +1375,11 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
-    // R-W-05 — two-tier pause (integration via MultisigProxy)
+    // Two-tier pause (integration via MultisigProxy)
     // ========================================================================
 
-    /// @dev After R-W-05, the no-timelock emergency pause freezes the OUTFLOW
-    ///      path too — including the enclave/TEE release, which routes through
+    /// @dev The no-timelock emergency pause freezes the OUTFLOW path too —
+    ///      including the enclave/TEE release, which routes through
     ///      Bridge.fundsOut. A signed fundsOut executed straight after
     ///      emergencyPause must revert OutflowEnforcedPause, and inbound deposits
     ///      must be frozen as well.
@@ -1603,9 +1603,9 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.timelockDuration(), newDuration);
     }
 
-    /// @dev UT-FIX-13: a SetTimelockDuration proposal below the immutable
-    ///      MIN_TIMELOCK floor is rejected at execution; the floor holds.
-    function test_proposeSetTimelockDuration_revertsBelowMinTimelock_afterFix() public {
+    /// @dev A SetTimelockDuration proposal below the immutable MIN_TIMELOCK
+    ///      floor is rejected at execution; the floor holds.
+    function test_proposeSetTimelockDuration_revertsBelowMinTimelock() public {
         uint256 t = block.timestamp;
         uint256 newDuration = MIN_TIMELOCK - 1; // just under the floor
         uint256 nonce = proxy.proposalNonce();
@@ -1625,7 +1625,7 @@ contract MultisigProxyTest is Test {
     }
 
     /// @dev A value exactly at MIN_TIMELOCK is still accepted (boundary).
-    function test_proposeSetTimelockDuration_acceptsAtMinTimelock_afterFix() public {
+    function test_proposeSetTimelockDuration_acceptsAtMinTimelock() public {
         uint256 t = block.timestamp;
         uint256 newDuration = MIN_TIMELOCK; // exactly the floor
         uint256 nonce = proxy.proposalNonce();
@@ -2201,14 +2201,14 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
-    // Domain separator rebuild on chain-id change (R-W-13 / UT-FIX-15)
+    // Domain separator rebuild on chain-id change
     //
     // The separator is cached at deploy with the chain id. After a chain-id
     // change (e.g. a hard fork) it is rebuilt, so a signature made before the
     // fork no longer verifies on the forked chain (no cross-fork replay).
     // ========================================================================
 
-    function test_domainSeparator_rebuiltOnChainIdChange_afterFix() public {
+    function test_domainSeparator_rebuiltOnChainIdChange() public {
         uint256 originalChainId = block.chainid;
         bytes32 dsBefore = proxy.DOMAIN_SEPARATOR();
         assertEq(dsBefore, MultisigHelper.domainSeparator(address(proxy), originalChainId), "cached on original chain");
@@ -2221,7 +2221,7 @@ contract MultisigProxyTest is Test {
         assertEq(dsAfter, MultisigHelper.domainSeparator(address(proxy), forkedChainId), "rebuilt over new chain id");
     }
 
-    function test_fundsOutCallSignatureNotReplayableAfterChainIdChange_afterFix() public {
+    function test_fundsOutCallSignatureNotReplayableAfterChainIdChange() public {
         // Sign a valid TEE fundsOut on the original chain (domainSep was cached
         // at setUp for block.chainid).
         IBridge.FundsOutParams memory params = _fundsOutParams();
@@ -2747,7 +2747,7 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
-    // R-M-03 / UT-FIX-05 — typed enclave methods are the only TEE entry points
+    // Typed enclave methods are the only TEE entry points
     //
     // The generic enclave `execute`/`executeBatch` + `teeAllowedCalls` allowlist
     // were removed. The enclave (TEE) quorum can now only trigger Bridge.fundsOut
@@ -2757,7 +2757,7 @@ contract MultisigProxyTest is Test {
     // function: enclave signatures over an admin-execute proposal are rejected.
     // ========================================================================
 
-    function test_enclaveKeysCannotDriveAdminExecute_afterFix() public {
+    function test_enclaveKeysCannotDriveAdminExecute() public {
         // A privileged call the TEE quorum might want to smuggle through.
         bytes memory callData = abi.encodeWithSignature("pauseInflow()");
         uint256 nonce = proxy.proposalNonce();
@@ -2778,7 +2778,7 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
-    // R-W-16 / UT-FIX-18 — lzFundsOutCall binds the release and send-out legs
+    // lzFundsOutCall binds the release and send-out legs
     //
     // Flow-4 release and the cross-chain send are bound on-chain in one signed
     // operation: the Bridge recipient is forced to the adapter (no params field
@@ -2788,7 +2788,7 @@ contract MultisigProxyTest is Test {
     // (net delivered) amount from the signed gross amount.
     // ========================================================================
 
-    function test_lzFundsOutCall_sendsNetDeliveredNotGross_afterFix() public {
+    function test_lzFundsOutCall_sendsNetDeliveredNotGross() public {
         // 5% FUNDS_OUT token commission so gross (AMOUNT) != net (delivered).
         vm.prank(address(proxy));
         cm.setCommissionRule(
@@ -2839,7 +2839,7 @@ contract MultisigProxyTest is Test {
     }
 
     // ========================================================================
-    // C-01 immutable TVL-relative safety limit
+    // Immutable TVL-relative safety limit
     // ========================================================================
 
     /// @dev buckets are set to a maximum-total policy, the pool is fully funded, and
@@ -2901,7 +2901,7 @@ contract MultisigProxyTest is Test {
     ///      first spend is still retained by the conservative rolling window.
     ///      The second release may consume the immutable remainder, but a third
     ///      valid 2-of-3 signed transaction cannot exceed the rolling 20% cap.
-    function test_C01_splitTransactionsCannotExceedAggregateRollingLimit() public {
+    function test_splitTransactionsCannotExceedAggregateRollingLimit() public {
         // Align to an hour boundary so the ring's 24-25h retention is exact
         // relative to the releases below rather than to an arbitrary offset.
         vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
@@ -2975,12 +2975,12 @@ contract MultisigProxyTest is Test {
         proxy.fundsOutCall(params, nonce, deadline, bitmap, sigs);
     }
 
-    /// @dev C-01 remaining issue, configuration side: a full-TVL bucket is not
-    ///      merely rejected against current liquidity, it is unrepresentable.
+    /// @dev A full-TVL bucket is not merely rejected against current liquidity;
+    ///      it is unrepresentable.
     ///      The policy is a percentage, and `burstBps + refillBpsPerWindow` is
     ///      bounded by the immutable `MAX_CHAIN_OUTFLOW_BPS`, so there is no
     ///      liquidity level at which this proposal would ever succeed.
-    function test_C01_federationCannotConfigureChainBucketForFullTvl() public {
+    function test_federationCannotConfigureChainBucketForFullTvl() public {
         uint256 fullTvlBps = bridge.BPS_DENOMINATOR(); // 10_000 bps == 100% of TVL
         uint256 maxBps = bridge.MAX_CHAIN_OUTFLOW_BPS();
         uint256 availableBefore = bridge.availableOutflow(RGB_CHAIN_ID);
@@ -3048,7 +3048,7 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.enclaveThreshold(RGB_CHAIN_ID), newThreshold, "post enclave threshold");
     }
 
-    function test_proposalUsesSnapshottedTimelock_afterFix() public {
+    function test_proposalUsesSnapshottedTimelock() public {
         uint256 proposedAt = block.timestamp;
         address newBridge = makeAddr("snapshotTimelockBridge");
         uint256 newDuration = 2 hours; // raise above the 1h in force at creation
@@ -3087,10 +3087,9 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.bridge(), newBridge, "snapshotted proposal executes despite the live timelock raise");
     }
 
-    // R-I-09 after-fix: emergency actions run on a separate `emergencyNonce`, so
-    // an emergency pause does NOT stale an already-signed regular proposal — the
-    // pre-signed proposal still submits.
-    function test_emergencyDoesNotStaleRegularProposal_afterFix() public {
+    // Emergency actions run on a separate `emergencyNonce`, so an emergency
+    // pause does NOT stale an already-signed regular proposal.
+    function test_emergencyDoesNotStaleRegularProposal() public {
         address newBridge = makeAddr("nonceCollisionBridge");
         uint256 regularNonce = proxy.proposalNonce();
         uint256 regularDeadline = block.timestamp + 1 days;
@@ -3124,7 +3123,7 @@ contract MultisigProxyTest is Test {
     // transferOwnership, but Ownable2Step only records a pendingOwner. A wrong
     // non-zero address never becomes owner, so governance is not orphaned and
     // the proxy keeps driving owner-only operations.
-    function test_ownershipTransferToWrongAddressDoesNotOrphanGovernance_afterFix() public {
+    function test_ownershipTransferToWrongAddressDoesNotOrphanGovernance() public {
         address wrongOwner = makeAddr("wrongBridgeOwner");
         uint256 startTime = block.timestamp;
 
@@ -3208,7 +3207,7 @@ contract MultisigProxyTest is Test {
 
     // Standard CM withdrawals stay on the dedicated typed operations. Recipient
     // safety no longer depends on this blocklist: CM enforces it immutably.
-    function test_genericPathsRejectCommissionWithdrawSelectors_afterFix() public {
+    function test_genericPathsRejectCommissionWithdrawSelectors() public {
         bytes[] memory callDatas = new bytes[](4);
         callDatas[0] = abi.encodeWithSignature("withdrawTokenCommission(address,uint256)", address(token), uint256(1));
         callDatas[1] = abi.encodeWithSignature("withdrawNativeCommission(uint256)", uint256(1));
@@ -3220,11 +3219,11 @@ contract MultisigProxyTest is Test {
         }
     }
 
-    // R-W-15 / alternate-target regression: even if governance aliases the LZ
-    // adapter target to CM and transfers CM ownership through that unfiltered
+    // Alternate-target regression: even if governance aliases the LZ adapter
+    // target to CM and transfers CM ownership through that unfiltered
     // raw-call path, the new owner cannot choose a withdrawal recipient. The
     // asset layer always sends commission to CM's immutable recipient.
-    function test_R_W_15_adapterAliasTransferredOwnerCannotRedirectCommission() public {
+    function test_adapterAliasTransferredOwnerCannotRedirectCommission() public {
         _setLzAdapter(address(cm));
 
         uint256 amount = 10 ether;

--- a/ethereum/test/RGBVerifier.t.sol
+++ b/ethereum/test/RGBVerifier.t.sol
@@ -19,7 +19,7 @@ contract RGBVerifierTest is Test {
     uint256 constant AMOUNT = 100e18;
     uint256 constant BURN_ID = 9_001;
 
-    // Default verifier thresholds (audit R-W-06 production values).
+    // Default production verifier thresholds.
     uint256 constant MIN_SOURCE_CONF = 6;
     uint256 constant MAX_LATEST_CONF = 1;
     uint256 constant MIN_GAP = 5;
@@ -48,7 +48,8 @@ contract RGBVerifierTest is Test {
             burnId: BURN_ID,
             sourceChainId: SOURCE_CHAIN_ID,
             destChainId: DEST_CHAIN_ID,
-            sourceAddress: "rgb:sender/utxo1src"
+            sourceAddress: "rgb:sender/utxo1src",
+            isRebalance: false
         });
     }
 
@@ -93,7 +94,7 @@ contract RGBVerifierTest is Test {
     }
 
     // =========================================================================
-    // verify — confirmation-depth invariants (the R-W-06 fix)
+    // verify — confirmation-depth invariants
     // =========================================================================
 
     function test_verify_revertsWhenSourceTooShallow() public {

--- a/ethereum/test/RgbSettlementModule.t.sol
+++ b/ethereum/test/RgbSettlementModule.t.sol
@@ -9,13 +9,14 @@ import {FundsInContext, FundsOutContext} from "../src/interfaces/RouteTypes.sol"
 /// @notice Unit tests for the standalone settlement module. The module is
 ///         driven via `vm.prank(routeRegistry)` — no actual `RouteRegistry`.
 ///
-/// @dev    Release semantics under test (post R-C-01 rework): `beforeFundsOut`
-///         is a pure (view) proof-of-mint check. It decodes
-///         `(uint256[] operationIds, uint256[] amounts)` and asserts every id
-///         EXISTS in `fundsInRecords` with an EXACTLY matching amount. It does
-///         NOT consume/delete records, does NOT sum them, and does NOT compare
-///         against `ctx.amount` — solvency and replay are owned by the Bridge
-///         (`lockedLiquidity` / `consumedBurnIds`).
+/// @dev    Release semantics under test: `beforeFundsOut` is a pure (view)
+///         proof-of-mint check. It decodes
+///         `(bytes32[] operationIds, uint256[] amounts)`. Physical releases
+///         require at least one pair; accounting-only rebalances may be empty.
+///         Every supplied id must EXIST in `fundsInRecords` with an EXACTLY
+///         matching amount. The module does NOT consume/delete records, sum
+///         them, or compare against `ctx.amount` — solvency and replay are owned
+///         by the Bridge (`lockedLiquidity` / `consumedBurnIds`).
 contract RgbSettlementModuleTest is Test {
     RgbSettlementModule module;
 
@@ -89,7 +90,8 @@ contract RgbSettlementModuleTest is Test {
             burnId: BURN_ID,
             sourceChainId: rgbChainId,
             destChainId: EVM_CHAIN_ID,
-            sourceAddress: "rgb:sender/utxo1src"
+            sourceAddress: "rgb:sender/utxo1src",
+            isRebalance: false
         });
     }
 
@@ -184,7 +186,7 @@ contract RgbSettlementModuleTest is Test {
     // beforeFundsOut — happy paths (existence + exact-amount, no consumption)
     // ========================================================================
 
-    function test_beforeFundsOut_passesOnSingleExactMatch() public {
+    function test_beforeFundsOut_acceptsOneValidPair() public {
         _record(TX_ID_1, AMOUNT);
 
         vm.prank(routeRegistry);
@@ -207,10 +209,18 @@ contract RgbSettlementModuleTest is Test {
         assertEq(module.fundsInRecords(TX_ID_2), amount2, "record 2 intact");
     }
 
-    function test_beforeFundsOut_passesOnEmptyArrays() public {
-        // Degenerate input: nothing to verify, nothing to revert on.
+    function test_beforeFundsOut_revertsOnEmptyArrays() public {
         vm.prank(routeRegistry);
+        vm.expectRevert(RgbSettlementModule.EmptySettlementRecords.selector);
         module.beforeFundsOut(_fundsOutCtx(), _settlementData(new bytes32[](0), new uint256[](0)));
+    }
+
+    function test_beforeFundsOut_allowsEmptyArraysForAccountingOnlyRebalance() public {
+        FundsOutContext memory ctx = _fundsOutCtx();
+        ctx.isRebalance = true;
+
+        vm.prank(routeRegistry);
+        module.beforeFundsOut(ctx, _settlementData(new bytes32[](0), new uint256[](0)));
     }
 
     function test_beforeFundsOut_duplicateIdsAreHarmless() public {
@@ -270,13 +280,18 @@ contract RgbSettlementModuleTest is Test {
         module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), _amt(AMOUNT - 1)));
     }
 
-    function test_beforeFundsOut_revertsOnLengthMismatch() public {
-        _record(TX_ID_1, AMOUNT);
-
-        // Two ids but one amount.
+    function test_beforeFundsOut_revertsWhenOperationIdsEmpty() public {
         vm.prank(routeRegistry);
         vm.expectRevert(RgbSettlementModule.SettlementDataLengthMismatch.selector);
-        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_pair(TX_ID_1, TX_ID_2), _amt(AMOUNT)));
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(new bytes32[](0), _amt(AMOUNT)));
+    }
+
+    function test_beforeFundsOut_revertsWhenAmountsEmpty() public {
+        _record(TX_ID_1, AMOUNT);
+
+        vm.prank(routeRegistry);
+        vm.expectRevert(RgbSettlementModule.SettlementDataLengthMismatch.selector);
+        module.beforeFundsOut(_fundsOutCtx(), _settlementData(_single(TX_ID_1), new uint256[](0)));
     }
 
     function test_beforeFundsOut_revertsOnSecondIdMismatch() public {

--- a/ethereum/test/RouteRegistry.t.sol
+++ b/ethereum/test/RouteRegistry.t.sol
@@ -78,7 +78,8 @@ contract RouteRegistryTest is Test {
             burnId: 9_001,
             sourceChainId: SOURCE_CHAIN_ID,
             destChainId: DEST_CHAIN_ID,
-            sourceAddress: "rgb:sender/utxo1src"
+            sourceAddress: "rgb:sender/utxo1src",
+            isRebalance: false
         });
     }
 


### PR DESCRIPTION
## Problem

Federation signers could use the timelocked generic `AdminExecute` mechanism to send arbitrary calldata to the Bridge.

Because `MultisigProxy` is the Bridge owner, this allowed the federation quorum to call `Bridge.fundsOut` or `Bridge.rebalanceLiquidity` directly, bypassing the typed execution paths and their enclave-signature requirements.

The same bypass could potentially be recreated through other generic execution lanes by assigning their mutable target to a Bridge contract.

## Solution

- Reserve `fundsOut` and `rebalanceLiquidity` for typed enclave-authorized operations.
- Reject these selectors on every generic raw-call path:
  - Bridge;
  - CommissionManager;
  - RouteRegistry;
  - LZ adapter.
- Validate the restriction both when a proposal is created and when it is executed.
- Keep regular administrative calls through `AdminExecute` unchanged.
- Keep `fundsOutCall`, `lzFundsOutCall`, and `rebalanceCall` unchanged.

## Security properties

Federation signatures alone can no longer invoke Bridge release or rebalance operations through generic calldata execution.

A mutable generic target cannot be pointed to the Bridge to bypass the restriction, because the selector blocklist is applied consistently to every generic execution lane.
