### PR TITLE
feat(commission): add configurable base fees for fundsIn and fundsOut

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The EVM-side contracts in this repository are deployed on Arbitrum. Cross-chain 
 
 - **`FinalityVerifier`** — a per-route plugin consulted by `Bridge.fundsOut` to confirm that the source-side event justifying the release is final on its origin chain. The current production verifier is `RGBVerifier`, a wrapper around Atomiq's on-chain Bitcoin SPV light client (`BtcRelay`) — it stores Bitcoin block headers and validates proof-of-work continuity and the difficulty-retarget rules. This removes the need to trust any single oracle or off-chain attestation for Bitcoin finality: the EVM-side release is gated by Bitcoin's own consensus, observed on-chain. Routes that don't need finality verification (e.g. trusted-bridge EVM legs) use `NullVerifier`.
 
-- **`SettlementModule`** — a per-route plugin that owns route-specific state. For RGB-anchored transfers, `RgbSettlementModule` tracks per-`operationId` net deposit balances and consumes them on `fundsOut` (the double-spend / fake-event guard formerly built into `Bridge`). Routes whose settlement is handled entirely by an external delivery layer (e.g. LayerZero compose paths) use `NullSettlementModule`.
+- **`SettlementModule`** — a per-route plugin that owns route-specific state. `RgbSettlementModule` is the permanent proof-of-mint ledger for RGB mint/burn routes. `RgbPoolSettlementModule` gives pool routes asymmetric behavior: pool credits create no ledger record or RGB-specific event, while pool releases verify their Bridge operation ids against the mint/burn ledger. Routes whose settlement is handled entirely by an external delivery layer use `NullSettlementModule`.
 
 - **`CommissionManager`** — a dedicated fee-accounting contract that holds the protocol's commissions strictly separated from bridge liquidity. The `Bridge` consults it on every transfer to determine the per-route commission (token vs. native; charged on `FundsIn` vs. `FundsOut`) and forwards the fee to it. Withdrawal is gated by federation governance through `MultisigProxy`. Owned by `MultisigProxy`.
 
@@ -75,7 +75,7 @@ Each transfer may deduct a per-route service commission consisting of a proporti
 
 ### Replay protection
 
-Each network enforces replay protection at the smart-contract level. On EVM the `Bridge` records consumed `burnId`s on-chain (each `FundsOut` carries the `burnId` extracted from the source-side burn consignment and is rejected if already seen) and `MultisigProxy` enforces per-selector sequential nonces on `execute` plus a sequential `batchNonce` on `executeBatch`. Route-specific bookkeeping — e.g. matching `FundsOut` against the exact source-side deposits being settled — lives in the per-route `SettlementModule` (for the RGB route, `RgbSettlementModule` tracks net deposit balances and consumes them atomically with the release).
+Each network enforces replay protection at the smart-contract level. On EVM the `Bridge` records consumed `burnId`s on-chain (each `FundsOut` carries a burn id bound to the complete release intent and is rejected if already seen), while `MultisigProxy` enforces a sequential `teeNonce` for each source chain's typed enclave operations. Route-specific bookkeeping — e.g. matching `FundsOut` against the exact source-side deposits being settled — lives in the per-route `SettlementModule`.
 
 ## Third-party code
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Private keys are held inside Enclaves and cannot be extracted. Key persistence i
 
 ### Commission
 
-Each transfer deducts a service commission, configured per-route: source side (`FundsIn`) or destination side (`FundsOut`), in the bridged token or the native currency of the chain. On EVM the commission is held by the `CommissionManager` contract — kept separate from bridge liquidity — and withdrawal is controlled by federation governance through the timelock.
+Each transfer may deduct a per-route service commission consisting of a proportional component plus an optional flat `baseFee`: `fee = amount × percentageFee + baseFee`. `FundsIn` commission may be paid in the bridged token or native currency; `FundsOut` commission is token-only. The Bridge enforces separate non-zero `minFundsInAmount` and `minFundsOutAmount` floors, and a configured flat fee must leave a positive net amount at the applicable floor. On EVM the commission is held by the `CommissionManager` contract — kept separate from bridge liquidity — and withdrawal is controlled by federation governance through the timelock.
 
 ### Replay protection
 

--- a/ethereum/.env.deploy.example
+++ b/ethereum/.env.deploy.example
@@ -50,6 +50,16 @@ COMMISSION_MANAGER=
 # to the predicted Bridge address.
 ROUTE_REGISTRY_ADDRESS=
 
+# Canonical RGB mint/burn settlement ledger — required only by the standalone
+# DeployRgbPoolSettlementModule script. DeployAll wires its freshly deployed
+# RgbSettlementModule directly.
+RGB_SETTLEMENT_MODULE_ADDRESS=
+
+# Backend-assigned RGB network ids used by the standalone pool-module deploy.
+# DeployAll uses the production ids below directly.
+RGB_MINT_BURN_CHAIN_ID=96
+RGB_POOL_CHAIN_ID=97
+
 # -----------------------------------------------------------------------------
 # CommissionManager — Chainlink ETH/USD feed (NATIVE-currency commissions)
 # -----------------------------------------------------------------------------
@@ -99,8 +109,8 @@ ENCLAVE_THRESHOLD=2
 FEDERATION_THRESHOLD=2
 
 # Immutable CommissionManager withdrawal destination. Changing it requires a
-# new CommissionManager deployment (and, because Bridge pins CM immutably, a
-# coordinated Bridge migration).
+# new CommissionManager deployment, followed by the typed, timelocked
+# UpdateCommissionManager operation that atomically updates Bridge and proxy.
 COMMISSION_RECIPIENT=
 
 # Timelock between propose and execute for federation proposals (seconds).

--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -27,15 +27,15 @@ No TEE verification, no destination chain field, **no commission integration**, 
 
 Production bridge for UTEXO. Inherits `BridgeBase`, implements `IBridge`. Route-agnostic: all per-route logic (finality verification, settlement bookkeeping) is delegated to plugins registered in `RouteRegistry`.
 
-Constructor takes four addresses: the accepted ERC-20 token (immutable), the `RouteRegistry` (mutable — federation can rotate via `UpdateRouteRegistry`), the `CommissionManager` (immutable), and the initial LayerZero adapter (mutable; `address(0)` is allowed — wire it in later via federation governance). The bridge's own chain identifier is `block.chainid` — chain IDs are `uint256` throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
+Constructor takes four addresses — the accepted ERC-20 token (immutable), the `RouteRegistry` (mutable — federation can rotate via `UpdateRouteRegistry`), the `CommissionManager` (immutable), and the initial LayerZero adapter (mutable; `address(0)` is allowed) — plus non-zero `minFundsInAmount` and `minFundsOutAmount` values in token smallest units. Federation may retune either minimum through the timelocked owner path. The bridge's own chain identifier is `block.chainid` — chain IDs are `uint256` throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
 
-- `fundsIn(amount, destinationChainId, destinationAddress, settlementData)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must be between the fresh quote and 5% above it. Exactly the fresh quote is collected and any surplus is refunded to the caller. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and dispatches to the route's `SettlementModule.onFundsIn(...)` via `RouteRegistry`. The `settlementData` blob is opaque to the bridge — its layout is dictated by the destination route's settlement module (empty for routes that don't consume extra data on inbound, e.g. RGB). Emits two events:
+- `fundsIn(amount, destinationChainId, destinationAddress, settlementData)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Requires `amount >= minFundsInAmount`. Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must be between the fresh quote and 5% above it. Exactly the fresh quote is collected and any surplus is refunded to the caller. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and dispatches to the route's `SettlementModule.onFundsIn(...)` via `RouteRegistry`. The `settlementData` blob is opaque to the bridge — its layout is dictated by the destination route's settlement module (empty for routes that don't consume extra data on inbound, e.g. RGB). Emits two events:
   - `FundsIn` (from `BridgeBase`) — minimal, uses `netAmount`.
   - `BridgeFundsIn` (from `IBridge`) — full, consumed by the UTEXO backend.
 - `fundsIn(amount, sourceChainId, sourceSender, destinationChainId, destinationAddress, settlementData)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating sender on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` and `sourceSender` to the bridge. For NATIVE commission routes, the source-agreed `msg.value` must remain within the immutable ±5% band around the fresh destination quote. Cross-domain refunds are deliberately unsupported, so the complete accepted value is collected as commission.
 - `setLZAdapter(adapter)` — `onlyOwner`. Rotates the address authorized to call the adapter overload. Set to `address(0)` to close the adapter path entirely.
 - `setRouteRegistry(newRouteRegistry)` — `onlyOwner`. Rotates the `RouteRegistry` Bridge talks to. Used to migrate to a redeployed registry (the registry's `bridge` is immutable, so a new registry deploy is the only way to rotate). Reverts on `address(0)`.
-- `fundsOut(recipient, amount, burnId, sourceChainId, destChainId, sourceAddress, proof, settlementData)` — `onlyOwner`, called via `MultisigProxy.execute()` or `MultisigProxy.executeBatch()`. The four scalar amounts (`amount`, `burnId`, `sourceChainId`, `destChainId`) are `uint256`; `recipient` is an address; `sourceAddress` is a string; `proof` and `settlementData` are opaque `bytes` blobs whose layouts are dictated by the route's `FinalityVerifier` and `SettlementModule` respectively. Checks `burnId` has not been consumed yet (single-use replay guard, marks it consumed before any external interaction), calls `RouteRegistry.beforeFundsOut(...)` which routes into `FinalityVerifier.verify(proof)` and `SettlementModule.beforeFundsOut(settlementData, amount)`, quotes commission from `CommissionManager` using `(sourceChainId, destChainId, TOKEN)`, forwards any token commission to the pool, and releases `netAmount` to the recipient. Emits `BridgeFundsOut`. NATIVE commission on `fundsOut` is disallowed (the caller is the multisig, not a user) — the contract reverts `NativeCommissionNotAllowedOnFundsOut`.
+- `fundsOut(recipient, amount, burnId, sourceChainId, destChainId, sourceAddress, proof, settlementData)` — `onlyOwner`, called via `MultisigProxy.execute()` or `MultisigProxy.executeBatch()`. Requires `amount >= minFundsOutAmount`; the source-side tooling and TEE must enforce the same minimum before authorizing a burn, otherwise an undersized release cannot be settled on-chain. The four scalar amounts (`amount`, `burnId`, `sourceChainId`, `destChainId`) are `uint256`; `recipient` is an address; `sourceAddress` is a string; `proof` and `settlementData` are opaque `bytes` blobs whose layouts are dictated by the route's `FinalityVerifier` and `SettlementModule` respectively. Checks `burnId` has not been consumed yet (single-use replay guard, marks it consumed before any external interaction), calls `RouteRegistry.beforeFundsOut(...)` which routes into `FinalityVerifier.verify(proof)` and `SettlementModule.beforeFundsOut(settlementData, amount)`, quotes commission from `CommissionManager` using `(sourceChainId, destChainId, TOKEN)`, forwards any token commission to the pool, and releases `netAmount` to the recipient. Emits `BridgeFundsOut`. NATIVE commission on `fundsOut` is disallowed (the release has no native-currency payer) — the contract reverts `NativeCommissionNotAllowedOnFundsOut`.
 
 Owner **must** be `MultisigProxy`. `fundsOut` is only reachable through `MultisigProxy.execute()` (single-call) or `MultisigProxy.executeBatch()` (atomic multi-call, e.g. `Bridge.fundsOut` + `LZAdapter.sendOut` for outbound to non-Arbitrum), both of which require M-of-N TEE signatures.
 
@@ -73,7 +73,8 @@ Per-route plugin that owns route-specific bookkeeping. Interface: `onFundsIn(ctx
 Standalone fee contract. Holds protocol commissions separately from bridge liquidity so that deployment, auditing, and withdrawal of fees are independent of bridge funds.
 
 - **Route keys** are `keccak256(abi.encode(sourceChainId, destChainId, token))` where both chain IDs are `uint256` — directional, so each leg of a round trip can have its own config. EVM legs use `block.chainid`; non-EVM endpoints get backend-assigned IDs in a reserved namespace (e.g. `RGB = 1_000_001`).
-- **Config** selects per route: `side` (`FUNDS_IN` vs `FUNDS_OUT`), `currency` (`TOKEN` vs `NATIVE`), `stablePercent` (×100, capped at 9000 = 90%), and `multiplier`. Global defaults apply to any route without an override.
+- **Config** selects per route: `side` (`FUNDS_IN` vs `FUNDS_OUT`), `currency` (`TOKEN` vs `NATIVE`), `stablePercent`, `baseFee`, and `multiplier`. Global defaults apply to any route without an override. The fee in token smallest units is `amount * stablePercent / multiplier^2 + baseFee`; either component may be zero, and both zero disable commission for that rule. The effective proportional rate is capped at 90% independently of `multiplier`.
+- **Flat-fee bounds:** `baseFee` is validated together with the proportional component against the Bridge floor for the selected side. At `minFundsInAmount` or `minFundsOutAmount`, respectively, the combined fee must remain strictly below the gross amount so the operation has a positive net. `FUNDS_IN` supports `TOKEN` or `NATIVE` commission; `FUNDS_OUT` supports `TOKEN` only.
 - **NATIVE quotes** use a Chainlink ETH/USD aggregator (`setEthUsdFeed(feed, heartbeat)`) and the token's `decimals()`. Heartbeat enforces staleness; absent feed ⇒ NATIVE quotes revert.
 - **Ingress:** `receiveTokenCommission(token)` and `receive()` are gated by `onlyBridge` — only `Bridge` may credit commissions. Pools are updated from balance deltas, so fee-on-transfer tokens are supported.
 - **Owner** (`MultisigProxy` in production) configures rules, updates `bridgeAddress`, wires the ETH/USD feed, and withdraws accumulated pools. Every token/native withdrawal pays the immutable constructor-configured `commissionRecipient`; withdrawal functions do not accept a free recipient. `renounceOwnership` is blocked.
@@ -110,7 +111,7 @@ Note: `MultisigProxy.lzAdapter` and `Bridge.lzAdapter` are **separate** fields w
 
 ### FundsIn (user deposits)
 
-1. The user (or frontend) quotes commission from `CommissionManager.calculateFundsInCommission(sourceChainId, destinationChainId, token, amount)`. EVM users pass `block.chainid` as `sourceChainId`.
+1. The user (or frontend) ensures `amount >= Bridge.minFundsInAmount()` and quotes commission from `CommissionManager.calculateFundsInCommission(sourceChainId, destinationChainId, token, amount)`. EVM users pass `block.chainid` as `sourceChainId`.
 2. The user approves `amount` to `Bridge` and calls `Bridge.fundsIn{ value: nativeCommission }(amount, destinationChainId, destinationAddress, operationId, settlementData)`. No signature required — any user can lock tokens. `settlementData` is empty for the RGB route and any other route whose module ignores inbound data. Cross-chain (LayerZero compose) deposits land through the `fundsIn(amount, sourceChainId, ...)` adapter overload instead, called by the trusted `LZAdapter` with an authenticated `sourceChainId`.
 3. Bridge pulls `amount` in tokens, forwards `tokenCommission` and `nativeCommission` (if any) to `CommissionManager`, dispatches to the route's `SettlementModule.onFundsIn` via `RouteRegistry` (which may e.g. record the net deposit), and emits `FundsIn` + `BridgeFundsIn`.
 
@@ -118,10 +119,11 @@ Note: `MultisigProxy.lzAdapter` and `Bridge.lzAdapter` are **separate** fields w
 
 `Bridge.fundsOut()` is `onlyOwner`, where the owner is `MultisigProxy`. The backend collects M-of-N ECDSA signatures from TEE signers over an EIP-712 `BridgeOperation` message (selector, callData, nonce, deadline). The call data includes `burnId` (chain-agnostic replay guard) plus the two opaque blobs `proof` (consumed by the route's `FinalityVerifier`) and `settlementData` (consumed by the route's `SettlementModule`), plus `sourceChainId` and `destChainId` so both `RouteRegistry` and `CommissionManager` can pick the right route. `MultisigProxy.execute()` verifies the signatures on-chain and forwards the call to `Bridge`, which then:
 
-1. Checks `burnId` has not been consumed yet and marks it consumed (replay guard).
-2. Calls `RouteRegistry.beforeFundsOut(...)` — which gates on the route being `enabled`, calls `FinalityVerifier.verify(proof)` (for RGB: `BtcRelay.verifyBlockheaderHash`), then `SettlementModule.beforeFundsOut(settlementData, amount)` (for RGB: consumes the referenced `fundsInIds`).
-3. Quotes outbound commission via `CommissionManager.calculateFundsOutCommission(sourceChainId, destChainId, token, amount)`.
-4. Forwards any token commission to `CommissionManager` and releases `netAmount` to the recipient.
+1. Requires `amount >= Bridge.minFundsOutAmount()`; source-side tooling must apply the same floor before producing a burn or release intent.
+2. Checks `burnId` has not been consumed yet and marks it consumed (replay guard).
+3. Calls `RouteRegistry.beforeFundsOut(...)` — which gates on the route being `enabled`, calls `FinalityVerifier.verify(proof)` (for RGB: `BtcRelay.verifyBlockheaderHash`), then `SettlementModule.beforeFundsOut(settlementData, amount)` (for RGB: consumes the referenced `fundsInIds`).
+4. Quotes outbound commission via `CommissionManager.calculateFundsOutCommission(sourceChainId, destChainId, token, amount)`.
+5. Forwards any token commission (`percentage + baseFee`) to `CommissionManager` and releases `netAmount` to the recipient.
 
 ### Federation governance (two-phase timelock)
 
@@ -182,6 +184,7 @@ set -a && source .env.interact && set +a   # before interact scripts
 - `ROUTE_REGISTRY_ADDRESS` — `RouteRegistry` address (step-by-step Bridge redeploys only; `DeployAll` predicts it)
 - `COMMISSION_MANAGER` — `CommissionManager` address (step-by-step deploys only)
 - `COMMISSION_RECIPIENT` — immutable destination for every CM withdrawal; choose a long-lived treasury address
+- `MIN_FUNDS_IN_AMOUNT` / `MIN_FUNDS_OUT_AMOUNT` — required non-zero operation floors in token smallest units; configure the outbound value consistently in source-side tooling and TEE policy
 - `ETH_USD_FEED` / `ETH_USD_HEARTBEAT` — Chainlink ETH/USD aggregator + staleness window (required if any route uses NATIVE commission)
 - `ENCLAVE_SIGNERS` / `FEDERATION_SIGNERS` — comma-separated addresses, ordered by bitmap bit index
 - `ENCLAVE_THRESHOLD` / `FEDERATION_THRESHOLD` — M-of-N thresholds
@@ -215,7 +218,7 @@ Predicts the Bridge address from the deployer's future nonce, deploys in order:
 
 1. `CommissionManager` (pinned to the predicted Bridge and immutable commission recipient)
 2. `RouteRegistry` (pinned to the predicted Bridge, deployer-owned for this batch)
-3. `Bridge` (with the live `RouteRegistry` + `CommissionManager`)
+3. `Bridge` (with the live `RouteRegistry` + `CommissionManager` and the configured inbound/outbound amount floors)
 4. `RGBVerifier` (wraps the BtcRelay)
 5. `RgbSettlementModule` (paired with `RouteRegistry`)
 6. `MultisigProxy`
@@ -278,14 +281,16 @@ forge script script/interact/BridgeFundsIn.s.sol --rpc-url $RPC_URL --broadcast
 4. Verify immutable commission destination: `CommissionManager.commissionRecipient()` returns the intended treasury.
 5. Verify Bridge ↔ Registry linkage: `Bridge.routeRegistry()` returns the live `RouteRegistry`; `RouteRegistry.bridge()` returns the live `Bridge`.
 6. Verify Bridge ↔ CM linkage: `CommissionManager.bridgeAddress()` returns the live `Bridge`; `Bridge.commissionManager()` returns the live `CommissionManager`.
-7. Verify LZ adapter wiring: `Bridge.lzAdapter()` and `MultisigProxy.lzAdapter()` both return `address(0)` immediately after deploy. Once the adapter is live, federation must run two timelocked proposals:
+7. Verify amount floors: `Bridge.minFundsInAmount()` and `Bridge.minFundsOutAmount()` return the intended non-zero values, and source-side tooling rejects burns below the outbound floor.
+8. Verify LZ adapter wiring: `Bridge.lzAdapter()` and `MultisigProxy.lzAdapter()` both return `address(0)` immediately after deploy. Once the adapter is live, federation must run two timelocked proposals:
    - `proposeAdminExecute` on the proxy with calldata `Bridge.setLZAdapter(adapter)` — opens the adapter `fundsIn` data path.
    - `proposeUpdateLZAdapter(adapter)` — opens the `AdminExecuteAdapter` governance path on the proxy.
-8. Verify enclave signers: `MultisigProxy.getEnclaveSigners()` returns the TEE addresses.
-9. Verify federation signers: `MultisigProxy.getFederationSigners()` returns the governance addresses.
-10. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` for the 8-arg `fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)` selector.
-11. **Register routes.** For each supported `(sourceChainId, destChainId)` pair, federation runs `MultisigProposeSetRoute` and — after the timelock — `executeProposal` with the printed `opData`. Verify with `RouteRegistry.routes(src, dst)` that the entry is `enabled` and the plugin addresses match.
-12. Test `fundsIn` with a small amount (zero commission by default) on a registered route to confirm token transfer and event emission.
+9. Verify enclave signers: `MultisigProxy.getEnclaveSigners()` returns the TEE addresses.
+10. Verify federation signers: `MultisigProxy.getFederationSigners()` returns the governance addresses.
+11. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` for the 8-arg `fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)` selector.
+12. **Register routes.** For each supported `(sourceChainId, destChainId)` pair, federation runs `MultisigProposeSetRoute` and — after the timelock — `executeProposal` with the printed `opData`. Verify with `RouteRegistry.routes(src, dst)` that the entry is `enabled` and the plugin addresses match.
+13. Configure and verify each route's proportional and flat commission; ensure the combined fee at the applicable Bridge floor leaves a positive net amount.
+14. Test `fundsIn` with an amount at or above `minFundsInAmount` on a registered route to confirm token transfer, commission forwarding, and event emission.
 
 ## Project structure
 

--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -27,21 +27,28 @@ No TEE verification, no destination chain field, **no commission integration**, 
 
 Production bridge for UTEXO. Inherits `BridgeBase`, implements `IBridge`. Route-agnostic: all per-route logic (finality verification, settlement bookkeeping) is delegated to plugins registered in `RouteRegistry`.
 
-Constructor takes four addresses — the accepted ERC-20 token (immutable), the `RouteRegistry` (mutable — federation can rotate via `UpdateRouteRegistry`), the `CommissionManager` (immutable), and the initial LayerZero adapter (mutable; `address(0)` is allowed) — plus non-zero `minFundsInAmount` and `minFundsOutAmount` values in token smallest units. Federation may retune either minimum through the timelocked owner path. The bridge's own chain identifier is `block.chainid` — chain IDs are `uint256` throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
+Constructor takes four addresses — the accepted ERC-20 token (immutable), the `RouteRegistry` (mutable — federation can rotate via `UpdateRouteRegistry`), the initial `CommissionManager` (mutable — federation can rotate it via `UpdateCommissionManager`), and the initial LayerZero adapter (mutable; `address(0)` is allowed) — plus non-zero `minFundsInAmount` and `minFundsOutAmount` values in token smallest units. Federation may retune either minimum through the timelocked owner path. The bridge's own chain identifier is `block.chainid` — chain IDs are `uint256` throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
 
 - `fundsIn(amount, destinationChainId, destinationAddress, settlementData)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Requires `amount >= minFundsInAmount`. Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must be between the fresh quote and 5% above it. Exactly the fresh quote is collected and any surplus is refunded to the caller. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and dispatches to the route's `SettlementModule.onFundsIn(...)` via `RouteRegistry`. The `settlementData` blob is opaque to the bridge — its layout is dictated by the destination route's settlement module (empty for routes that don't consume extra data on inbound, e.g. RGB). Emits two events:
-  - `FundsIn` (from `BridgeBase`) — minimal, uses `netAmount`.
+  - `FundsIn` — RGB-only compatibility event using `netAmount`; `sender` is indexed while `rgbOpId` is carried in event data.
   - `BridgeFundsIn` (from `IBridge`) — full, consumed by the UTEXO backend.
 - `fundsIn(amount, sourceChainId, sourceSender, destinationChainId, destinationAddress, settlementData)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating sender on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` and `sourceSender` to the bridge. For NATIVE commission routes, the source-agreed `msg.value` must remain within the immutable ±5% band around the fresh destination quote. Cross-domain refunds are deliberately unsupported, so the complete accepted value is collected as commission.
 - `setLZAdapter(adapter)` — `onlyOwner`. Rotates the address authorized to call the adapter overload. Set to `address(0)` to close the adapter path entirely.
 - `setRouteRegistry(newRouteRegistry)` — `onlyOwner`. Rotates the `RouteRegistry` Bridge talks to. Used to migrate to a redeployed registry (the registry's `bridge` is immutable, so a new registry deploy is the only way to rotate). Reverts on `address(0)`.
-- `fundsOut(recipient, amount, burnId, sourceChainId, destChainId, sourceAddress, proof, settlementData)` — `onlyOwner`, called via `MultisigProxy.execute()` or `MultisigProxy.executeBatch()`. Requires `amount >= minFundsOutAmount`; the source-side tooling and TEE must enforce the same minimum before authorizing a burn, otherwise an undersized release cannot be settled on-chain. The four scalar amounts (`amount`, `burnId`, `sourceChainId`, `destChainId`) are `uint256`; `recipient` is an address; `sourceAddress` is a string; `proof` and `settlementData` are opaque `bytes` blobs whose layouts are dictated by the route's `FinalityVerifier` and `SettlementModule` respectively. Checks `burnId` has not been consumed yet (single-use replay guard, marks it consumed before any external interaction), calls `RouteRegistry.beforeFundsOut(...)` which routes into `FinalityVerifier.verify(proof)` and `SettlementModule.beforeFundsOut(settlementData, amount)`, quotes commission from `CommissionManager` using `(sourceChainId, destChainId, TOKEN)`, forwards any token commission to the pool, and releases `netAmount` to the recipient. Emits `BridgeFundsOut`. NATIVE commission on `fundsOut` is disallowed (the release has no native-currency payer) — the contract reverts `NativeCommissionNotAllowedOnFundsOut`.
+- `setCommissionManager(newCommissionManager)` — `onlyOwner`. Rotates the manager used for fee quotes and custody. Production migration uses the typed `UpdateCommissionManager` operation so the Bridge and `MultisigProxy` pointers change atomically. Reverts on `address(0)`.
+- `fundsOut(FundsOutParams)` — `onlyOwner`, called only by the typed `MultisigProxy.fundsOutCall` / `lzFundsOutCall` enclave paths. The params bind recipient, amount, burn id, source/destination chains, source address, finality proof, and settlement data. The Bridge checks replay protection and isolated liquidity/rate limits, dispatches route verification and settlement bookkeeping, charges any token commission, and releases the net amount. NATIVE commission is disallowed because the release has no native-currency payer.
 
-Owner **must** be `MultisigProxy`. `fundsOut` is only reachable through `MultisigProxy.execute()` (single-call) or `MultisigProxy.executeBatch()` (atomic multi-call, e.g. `Bridge.fundsOut` + `LZAdapter.sendOut` for outbound to non-Arbitrum), both of which require M-of-N TEE signatures.
+Owner **must** be `MultisigProxy`. `fundsOut` is reachable only through the purpose-built `fundsOutCall` or `lzFundsOutCall` entrypoints, and `rebalanceLiquidity` only through `rebalanceCall`; all require the registered source chain's M-of-N enclave signatures. These Bridge selectors are blocked from every federation generic-call lane.
 
 #### Burn-id replay guard (single-use)
 
-Every `fundsOut` call carries a `burnId` — an identifier the backend extracts from the source-side burn consignment. The `Bridge` keeps a `consumedBurnIds` mapping and **rejects** any call whose `burnId` is already recorded (`BurnIdAlreadyConsumed`). The flag is set before any token transfer (CEI ordering), so a revert anywhere downstream rolls the mark back together with the rest of the call. This complements `MultisigProxy`'s per-selector nonce: nonces stop a signature bundle from being executed twice, while `burnId` stops the same logical burn from being settled twice even under independent signature bundles. It also complements each route's `SettlementModule` bookkeeping (e.g. `RgbSettlementModule` consumes `fundsInIds`); `burnId` is the chain-agnostic guard, the module guard is route-specific.
+Every `fundsOut` call carries a `burnId` derived from the complete release intent. The `Bridge` keeps a `consumedBurnIds` mapping and **rejects** any call whose `burnId` is already recorded (`BurnIdAlreadyConsumed`). The flag is set before any token transfer (CEI ordering), so a downstream revert rolls the mark back with the rest of the call. This complements `MultisigProxy`'s per-source-chain `teeNonce`: the nonce prevents replaying one signature bundle, while `burnId` prevents independently signed duplication of the same logical release. Route-specific settlement records provide an additional guard where applicable.
+
+#### Outflow controls and reference liquidity
+
+The configurable per-chain and global token buckets store allowance as percentage shares. A release prices those shares against the actual pre-debit `lockedLiquidity[sourceChainId]` and `totalLockedLiquidity`, respectively. Consequently, bucket capacity follows real deposits, releases, and rebalances immediately, but does not change merely because an old rolling-usage slot expires.
+
+The immutable rolling safety limits are a separate defence layer. They retain each outflow for 24–25 hours and calculate their ceiling from `lockedLiquidity + rollingSpent`, preserving a stable pre-window reference while liquidity is released. `effectiveAvailableOutflow(chainId)` returns the minimum allowed by isolated liquidity, both configurable buckets, and both immutable safety limits.
 
 ### RouteRegistry (`src/RouteRegistry.sol`)
 
@@ -65,8 +72,21 @@ Adding a new finality source (e.g. an Arch light client) is just a new verifier 
 
 Per-route plugin that owns route-specific bookkeeping. Interface: `onFundsIn(ctx)` + `beforeFundsOut(ctx)`, both invoked by `RouteRegistry` on behalf of the Bridge.
 
-- **`RgbSettlementModule`** — production module for the RGB route. On `fundsIn`, stores `operationId => netAmount` so backend operators have an authoritative on-chain ledger of deposits. On `fundsOut`, expects `settlementData = abi.encode(uint256[] fundsInIds)`, walks the array, and partially consumes the referenced deposits in order: full records are deleted; the last record is decremented if its remaining balance exceeds the requested `amount` so the surplus stays available for future calls. This prevents (a) **fake event attacks** — a malicious node operator cannot feed fake `BridgeFundsIn` events to TEE because the contract is the source of truth; (b) **double-spend** — every wei of net liquidity is referenced by exactly one record at all times; (c) **liquidity loss** — partial consumption preserves the residual on the same `operationId`. Auth: `onlyRouteRegistry`.
+- **`RgbSettlementModule`** — canonical RGB mint/burn ledger. On `fundsIn`, stores the Bridge-derived `operationId => netAmount`, tags it with the destination RGB network, and returns the supplied RGB OpId so Bridge emits both `FundsIn` and `BridgeFundsIn`. On `fundsOut`, `settlementData = abi.encode(bytes32[] operationIds, uint256[] amounts)` must reference existing exact-amount records tagged with the debit network. Records are permanent proof-of-mint entries; replay and solvency are enforced independently by `consumedBurnIds` and isolated liquidity.
+- **`RgbOutboundSettlementModule`** — canonical-ledger reader for routes whose RGB debit is followed by a destination that must not create a new record. In production it serves the `96 -> 97` mint/burn-to-pool rebalance: it performs the network-scoped debit check, then returns `0` and writes nothing on the pool credit.
+- **`RgbPoolSettlementModule`** — asymmetric pool adapter pinned to immutable pool and backing-network ids. A credit into pool network `97` writes no canonical record and returns `0`, so a normal pool deposit emits only `BridgeFundsIn`. A physical release from `97` must cite exact records from the canonical mint/burn ledger tagged with network `96`.
 - **`NullSettlementModule`** — stateless no-op. Used by routes whose settlement is handled entirely by an external delivery layer (e.g. LayerZero compose) or by routes whose verifier already binds the release to a specific deposit. Stateless ⇒ no auth.
+
+Production route-module topology:
+
+| Route | Settlement module | Result |
+|---|---|---|
+| `42161 -> 96` | `RgbSettlementModule` | writes canonical record; emits `FundsIn` + `BridgeFundsIn` |
+| `96 -> 42161` | `RgbSettlementModule` | verifies a network-96 canonical record |
+| `42161 -> 97` | `RgbPoolSettlementModule` | no record; emits only `BridgeFundsIn` |
+| `97 -> 42161` | `RgbPoolSettlementModule` | verifies backing records tagged with network 96 |
+| `96 -> 97` rebalance | `RgbOutboundSettlementModule` | verifies network 96; writes no pool record |
+| `97 -> 96` rebalance | `RgbSettlementModule` | accounting-only debit; writes the new network-96 record |
 
 ### CommissionManager (`src/CommissionManager.sol`)
 
@@ -83,7 +103,7 @@ Standalone fee contract. Holds protocol commissions separately from bridge liqui
 
 Owner of `Bridge`, `RouteRegistry`, **and** `CommissionManager`. Two-level ECDSA M-of-N multisig:
 
-- **Enclave signers (TEE)** — authorize `execute()` (single-call) and `executeBatch()` (atomic multi-call) calls (M-of-N, bitmap encoding). Used for `fundsOut` (and outbound `LZAdapter.sendOut` paired in a batch). Per-selector sequential nonces prevent replay on `execute`; a sequential `batchNonce` does the same for `executeBatch`. The TEE allowlist is keyed on `(target, selector)` pairs (`teeAllowedCalls`), enabling atomic multi-target batches without granting TEE blanket admin power. Default allowlist seeded in the constructor: `Bridge.fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)`.
+- **Enclave signers (TEE)** — authorize only the purpose-built `fundsOutCall`, `lzFundsOutCall`, and `rebalanceCall` operations (M-of-N, bitmap encoding). Signer sets and replay-protection nonces are isolated per source chain; there is no generic enclave call dispatch.
 - **Federation signers (governance)** — two-phase timelock for admin operations. Instant `emergencyPause` / `emergencyUnpause` bypass the timelock.
 
 Federation-controlled operations (`OperationType`):
@@ -94,18 +114,28 @@ Federation-controlled operations (`OperationType`):
 | `UpdateEnclaveSigners` | self | Rotate TEE signer set / threshold |
 | `UpdateFederationSigners` | self | Rotate federation signer set / threshold |
 | `UpdateBridge` | self | Migrate to a redeployed Bridge |
-| `SetTeeAllowedCall` | self | Add/remove a `(target, selector)` pair from the TEE allowlist |
 | `SetTimelockDuration` | self | Adjust the timelock window |
-| `AdminExecuteCommissionManager` | CommissionManager | Generic call into CM (route rules, global defaults, ETH/USD feed, `transferOwnership`, …) |
+| `AdminExecuteCommissionManager` | CommissionManager | Permitted generic call into CM (route rules, global defaults, ETH/USD feed, …) |
 | `WithdrawTokenCommissionCM` | CommissionManager | Withdraw ERC-20 commission to CM's immutable `commissionRecipient` |
 | `WithdrawNativeCommissionCM` | CommissionManager | Withdraw native commission to CM's immutable `commissionRecipient` |
-| `UpdateCommissionManager` | self | Migrate to a redeployed CommissionManager |
+| `UpdateCommissionManager` | Bridge + self | Atomically migrate Bridge and proxy to a redeployed CommissionManager |
 | `AdminExecuteAdapter` | LZAdapter | Generic call into the registered LayerZero adapter (`setTrustedEntrypoint`, `refundStuckFunds`, …). Reverts `ZeroTarget` if `MultisigProxy.lzAdapter` is unset. |
 | `UpdateLZAdapter` | self | Rotate `MultisigProxy.lzAdapter` — the routing target for `AdminExecuteAdapter`. Setting to `address(0)` closes the adapter-admin path. |
 | `SetRoute` | RouteRegistry | Register, update, pause, or re-enable a single `(sourceChainId, destChainId)` route on the registry. The opData encodes `(src, dst, enabled, verifier, module)`. |
 | `UpdateRouteRegistry` | Bridge | Rotate `Bridge.routeRegistry` to a redeployed registry. Used when a new registry must be deployed (the registry's `bridge` is immutable). |
+| `AdminExecuteRouteRegistry` | RouteRegistry | Permitted generic registry call; ownership transfer is excluded. |
+| `TransferManagedOwnership` | managed target | Typed `transferOwnership(newOwner)` for the current Bridge, CommissionManager, LZAdapter, or RouteRegistry. |
+| `PauseInflow` / `UnpauseInflow` | Bridge | Timelocked planned inflow-only pause controls. |
+| `DisableLZAdapter` | self | Explicitly clear the adapter governance target. |
 
 Note: `MultisigProxy.lzAdapter` and `Bridge.lzAdapter` are **separate** fields with different roles. `Bridge.lzAdapter` gates the adapter `fundsIn` overload (data path); `MultisigProxy.lzAdapter` is the target of `AdminExecuteAdapter` proposals (governance path). Both default to `address(0)` and are wired in by federation after the adapter is deployed.
+
+For a CommissionManager migration, deploy and configure the replacement with
+the current Bridge as `bridgeAddress`, start its two-step ownership transfer to
+`MultisigProxy`, and prepare both `UpdateCommissionManager` and a subsequent
+`AdminExecuteCommissionManager(acceptOwnership())` proposal. After their
+timelocks, execute the update first and the ownership acceptance immediately
+after it. The update changes the Bridge and proxy pointers atomically.
 
 ## How it works
 
@@ -117,7 +147,7 @@ Note: `MultisigProxy.lzAdapter` and `Bridge.lzAdapter` are **separate** fields w
 
 ### FundsOut (bridge withdrawals)
 
-`Bridge.fundsOut()` is `onlyOwner`, where the owner is `MultisigProxy`. The backend collects M-of-N ECDSA signatures from TEE signers over an EIP-712 `BridgeOperation` message (selector, callData, nonce, deadline). The call data includes `burnId` (chain-agnostic replay guard) plus the two opaque blobs `proof` (consumed by the route's `FinalityVerifier`) and `settlementData` (consumed by the route's `SettlementModule`), plus `sourceChainId` and `destChainId` so both `RouteRegistry` and `CommissionManager` can pick the right route. `MultisigProxy.execute()` verifies the signatures on-chain and forwards the call to `Bridge`, which then:
+`Bridge.fundsOut()` is `onlyOwner`, where the owner is `MultisigProxy`. The backend collects M-of-N ECDSA signatures from the source chain's enclave signer set over the typed release intent and submits it through `fundsOutCall` (or `lzFundsOutCall` for an onward LayerZero send). The signed data includes `burnId`, both chain ids, proof and settlement data, nonce, and deadline. The proxy verifies the signatures and invokes the exact typed Bridge path, which then:
 
 1. Requires `amount >= Bridge.minFundsOutAmount()`; source-side tooling must apply the same floor before producing a burn or release intent.
 2. Checks `burnId` has not been consumed yet and marks it consumed (replay guard).
@@ -129,8 +159,10 @@ Note: `MultisigProxy.lzAdapter` and `Bridge.lzAdapter` are **separate** fields w
 
 Administrative operations (signer rotation, configuration changes, commission withdrawals, route registration) go through:
 
-1. **Propose.** A federation member submits the operation with M-of-N federation signatures. `MultisigProxy` stores the operation hash and emits `ProposalCreated`. Nothing is executed yet.
-2. **Execute.** After `timelockDuration` elapses, anyone calls `executeProposal()` with the original data. `MultisigProxy` verifies the hash, confirms the timelock, and executes.
+1. **Propose.** A federation member submits the operation with M-of-N federation signatures. `MultisigProxy` stores the operation hash together with the current `federationSignerSetVersion` and emits `ProposalCreated`. Nothing is executed yet.
+2. **Execute.** After `timelockDuration` elapses, anyone calls `executeProposal()` with the original data. `MultisigProxy` verifies the hash, timelock, and signer-set version before executing. A successful federation rotation increments the version, automatically invalidating every still-pending proposal approved by the previous signer set; the live federation may still cancel those stale records for cleanup.
+
+Raw generic calls cannot invoke `transferOwnership(address)`. Ownership migration uses the typed `TransferManagedOwnership` operation, which binds the exact allowlisted target and new owner into the federation's EIP-712 signatures and revalidates the target at execution. `acceptOwnership()` remains available through the relevant generic lane for two-step deployment and migration handoffs.
 
 **Emergency pause/unpause** bypass the timelock — federation can stop or resume `Bridge` instantly.
 
@@ -182,6 +214,7 @@ set -a && source .env.interact && set +a   # before interact scripts
 - `BTC_RELAY_ADDRESS` — Atomiq BtcRelay contract address (consumed by `RGBVerifier`)
 - `LZ_ADAPTER` — initial LayerZero adapter address (optional; pass `0x0` if the adapter has not been deployed yet, then wire it in via federation governance after the adapter ships)
 - `ROUTE_REGISTRY_ADDRESS` — `RouteRegistry` address (step-by-step Bridge redeploys only; `DeployAll` predicts it)
+- `RGB_SETTLEMENT_MODULE_ADDRESS`, `RGB_MINT_BURN_CHAIN_ID`, `RGB_POOL_CHAIN_ID` — standalone `DeployRgbPoolSettlementModule` inputs (`96` and `97` in production)
 - `COMMISSION_MANAGER` — `CommissionManager` address (step-by-step deploys only)
 - `COMMISSION_RECIPIENT` — immutable destination for every CM withdrawal; choose a long-lived treasury address
 - `MIN_FUNDS_IN_AMOUNT` / `MIN_FUNDS_OUT_AMOUNT` — required non-zero operation floors in token smallest units; configure the outbound value consistently in source-side tooling and TEE policy
@@ -220,9 +253,9 @@ Predicts the Bridge address from the deployer's future nonce, deploys in order:
 2. `RouteRegistry` (pinned to the predicted Bridge, deployer-owned for this batch)
 3. `Bridge` (with the live `RouteRegistry` + `CommissionManager` and the configured inbound/outbound amount floors)
 4. `RGBVerifier` (wraps the BtcRelay)
-5. `RgbSettlementModule` (paired with `RouteRegistry`)
+5. `RgbSettlementModule`, `NullVerifier`, `RgbOutboundSettlementModule`, `RgbPoolSettlementModule`, and `NullSettlementModule`
 6. `MultisigProxy`
-7. (optional) `CommissionManager.setEthUsdFeed`
+7. Optional `CommissionManager` oracle configuration
 8. `CommissionManager` / `Bridge` / `RouteRegistry` `transferOwnership` → `MultisigProxy`
 
 **Routes are not registered here.** Federation must run `MultisigProposeSetRoute` for each supported `(sourceChainId, destChainId)` pair before any traffic is accepted — mirrors the permanent governance path.
@@ -235,6 +268,7 @@ forge script script/deploy/DeployRouteRegistry.s.sol         --rpc-url $RPC_URL 
 forge script script/deploy/DeployBridge.s.sol                --rpc-url $RPC_URL --broadcast --verify
 forge script script/deploy/DeployRGBVerifier.s.sol           --rpc-url $RPC_URL --broadcast --verify
 forge script script/deploy/DeployRgbSettlementModule.s.sol   --rpc-url $RPC_URL --broadcast --verify
+forge script script/deploy/DeployRgbPoolSettlementModule.s.sol --rpc-url $RPC_URL --broadcast --verify
 forge script script/deploy/DeployMultisigProxy.s.sol         --rpc-url $RPC_URL --broadcast --verify
 
 # Transfer ownerships to MultisigProxy
@@ -260,7 +294,7 @@ Scripts in `script/interact/` let you exercise contracts manually before the bac
 | Script | What it does |
 |---|---|
 | `BridgeFundsIn.s.sol` | Quotes commission from `CommissionManager`, approves tokens and calls `Bridge.fundsIn{ value: nativeCommission }(...)` |
-| `MultisigExecuteFundsOut.s.sol` | Signs a `Bridge.fundsOut()` locally with `ENCLAVE_PKS` (8-arg signature: `recipient, amount, burnId, sourceChainId, destChainId, sourceAddress, proof, settlementData`) and submits via `MultisigProxy.execute()`. Packs `proof = abi.encode(blockHeight, commitmentHash)` (RGBVerifier layout) and `settlementData = abi.encode(fundsInIds[])` (RgbSettlementModule layout). |
+| `MultisigExecuteFundsOut.s.sol` | Signs a typed release locally with `ENCLAVE_PKS` and submits it through `MultisigProxy.fundsOutCall()`, using the source chain's `teeNonce`. |
 | `MultisigProposeSetRoute.s.sol` | Signs and submits a `proposeSetRoute(...)` federation proposal on `MultisigProxy`. Intentionally does **not** call `executeProposal` — prints the `proposalId` + the `opData` blob for the operator to run `cast send` after the timelock. First federation step after `DeployAll`. |
 | `EmergencyPause.s.sol` | Signs and submits `MultisigProxy.emergencyPause()` with `FED_PKS` |
 | `EmergencyUnpause.s.sol` | Signs and submits `MultisigProxy.emergencyUnpause()` with `FED_PKS` |
@@ -287,7 +321,7 @@ forge script script/interact/BridgeFundsIn.s.sol --rpc-url $RPC_URL --broadcast
    - `proposeUpdateLZAdapter(adapter)` — opens the `AdminExecuteAdapter` governance path on the proxy.
 9. Verify enclave signers: `MultisigProxy.getEnclaveSigners()` returns the TEE addresses.
 10. Verify federation signers: `MultisigProxy.getFederationSigners()` returns the governance addresses.
-11. Verify TEE-allowed call: `MultisigProxy.teeAllowedCalls(bridgeAddress, fundsOutSelector)` returns `true` for the 8-arg `fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)` selector.
+11. Verify the typed TEE path: `MultisigProxy.getEnclaveSigners(sourceChainId)`, `enclaveThreshold(sourceChainId)`, and `teeNonce(sourceChainId)` match the intended source-chain signer configuration.
 12. **Register routes.** For each supported `(sourceChainId, destChainId)` pair, federation runs `MultisigProposeSetRoute` and — after the timelock — `executeProposal` with the printed `opData`. Verify with `RouteRegistry.routes(src, dst)` that the entry is `enabled` and the plugin addresses match.
 13. Configure and verify each route's proportional and flat commission; ensure the combined fee at the applicable Bridge floor leaves a positive net amount.
 14. Test `fundsIn` with an amount at or above `minFundsInAmount` on a registered route to confirm token transfer, commission forwarding, and event emission.
@@ -306,7 +340,9 @@ src/
     RGBVerifier.sol            — Bitcoin SPV finality (wraps Atomiq BtcRelay)
     NullVerifier.sol           — Stateless no-op (routes with upstream finality)
   settlement/
-    RgbSettlementModule.sol    — RGB-route net-deposit ledger + consumption
+    RgbSettlementModule.sol    — canonical RGB mint/burn proof ledger
+    RgbOutboundSettlementModule.sol — ledger reader with stateless credit
+    RgbPoolSettlementModule.sol — pool credit no-op + mint/burn-ledger debit check
     NullSettlementModule.sol   — Stateless no-op (routes settled by external delivery)
   interfaces/
     IBridge.sol                — Bridge interface, events, and custom errors
@@ -321,7 +357,8 @@ src/
 script/
   deploy/                      — DeployAll, DeployBridge, DeployBaseBridge,
                                  DeployRouteRegistry, DeployRGBVerifier,
-                                 DeployRgbSettlementModule, DeployCommissionManager,
+                                 DeployRgbSettlementModule, DeployRgbPoolSettlementModule,
+                                 DeployCommissionManager,
                                  DeployMultisigProxy
   interact/                    — BridgeFundsIn, MultisigExecuteFundsOut,
                                  MultisigProposeSetRoute, EmergencyPause, EmergencyUnpause
@@ -330,7 +367,8 @@ test/
   Bridge.t.sol                 — Bridge tests (routing through RouteRegistry, burnId, commission)
   BaseBridge.t.sol             — BaseBridge tests
   RouteRegistry.t.sol          — RouteRegistry tests (setRoute, dispatch, enabled gating)
-  RgbSettlementModule.t.sol    — RgbSettlementModule tests (ledger, partial consumption)
+  RgbSettlementModule.t.sol    — canonical RGB ledger tests
+  RgbPoolSettlementModule.t.sol — asymmetric RGB pool settlement tests
   CommissionManager.t.sol      — CommissionManager tests (rules, pools, withdrawals, ETH/USD feed)
   MultisigProxy.t.sol          — MultisigProxy tests (EIP-712, bitmap sigs, proposals incl. SetRoute / UpdateRouteRegistry)
   Integration.t.sol            — End-to-end: user → Bridge → RouteRegistry → TEE multisig → fundsOut → CM withdrawal

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -56,7 +56,7 @@ import {NullSettlementModule} from "../../src/settlement/NullSettlementModule.so
 ///   ENCLAVE_SIGNERS, ENCLAVE_THRESHOLD, INITIAL_ENCLAVE_SOURCE_CHAIN_ID,
 ///   FEDERATION_SIGNERS, FEDERATION_THRESHOLD,
 ///   COMMISSION_RECIPIENT, TIMELOCK_DURATION, MIN_TIMELOCK,
-///   MIN_FUNDS_IN_AMOUNT,
+///   MIN_FUNDS_IN_AMOUNT, MIN_FUNDS_OUT_AMOUNT,
 ///   INITIAL_CHAIN_BURST_BPS, INITIAL_CHAIN_REFILL_BPS_PER_WINDOW,
 ///   GLOBAL_BURST_BPS, GLOBAL_REFILL_BPS_PER_WINDOW
 ///
@@ -114,6 +114,7 @@ contract DeployAll is Script {
         address ethUsdFeed = vm.envOr("ETH_USD_FEED", address(0));
         uint256 ethUsdHb = vm.envOr("ETH_USD_HEARTBEAT", uint256(0));
         uint256 minFundsIn = vm.envUint("MIN_FUNDS_IN_AMOUNT");
+        uint256 minFundsOut = vm.envUint("MIN_FUNDS_OUT_AMOUNT");
         uint256 minSourceConf = vm.envOr("MIN_SOURCE_CONFIRMATIONS", uint256(6));
         uint256 maxLatestConf = vm.envOr("MAX_LATEST_CONFIRMATIONS", uint256(1));
         uint256 minConfGap = vm.envOr("MIN_CONFIRMATION_GAP", uint256(5));
@@ -162,7 +163,7 @@ contract DeployAll is Script {
         routeRegistry = new RouteRegistry(predictedBridge, deployer);
 
         // ---- 4. Bridge (nonce n+2) ---------------------------------------
-        bridge = new Bridge(usdt0, address(routeRegistry), payable(address(cm)), address(0), minFundsIn);
+        bridge = new Bridge(usdt0, address(routeRegistry), payable(address(cm)), address(0), minFundsIn, minFundsOut);
 
         // ---- 5. Route plugins (nonce n+3 .. n+7) -------------------------
         rgbVerifier = new RGBVerifier(btcRelay, minSourceConf, maxLatestConf, minConfGap);

--- a/ethereum/script/deploy/DeployAll.s.sol
+++ b/ethereum/script/deploy/DeployAll.s.sol
@@ -11,6 +11,7 @@ import {RGBVerifier} from "../../src/verifiers/RGBVerifier.sol";
 import {NullVerifier} from "../../src/verifiers/NullVerifier.sol";
 import {RgbSettlementModule} from "../../src/settlement/RgbSettlementModule.sol";
 import {RgbOutboundSettlementModule} from "../../src/settlement/RgbOutboundSettlementModule.sol";
+import {RgbPoolSettlementModule} from "../../src/settlement/RgbPoolSettlementModule.sol";
 import {NullSettlementModule} from "../../src/settlement/NullSettlementModule.sol";
 
 /// @title DeployAll
@@ -29,9 +30,12 @@ import {NullSettlementModule} from "../../src/settlement/NullSettlementModule.so
 ///   n + 5  → NullVerifier       (explicit no-proof verifier for operational /
 ///                                 non-RGB-source routes, e.g. Arch → RGB)
 ///   n + 6  → RgbOutboundSettlementModule (debit-RGB / non-RGB-credit routes,
-///                                 e.g. RGB → Arch; wraps RgbSettlementModule)
-///   n + 7  → NullSettlementModule (stateless routes such as EVM ↔ Concordium)
-///   n + 8  → MultisigProxy
+///                                 e.g. RGB mint/burn → RGB pool; wraps
+///                                 RgbSettlementModule)
+///   n + 7  → RgbPoolSettlementModule (pool credits write nothing; pool
+///                                 releases read mint/burn records)
+///   n + 8  → NullSettlementModule (stateless routes such as EVM ↔ Concordium)
+///   n + 9  → MultisigProxy
 ///          → Bridge.setOutflowLimit for INITIAL_ENCLAVE_SOURCE_CHAIN_ID
 ///          → Bridge.setGlobalOutflowLimit
 ///          → (optional) CommissionManager config txs, each present only when
@@ -84,6 +88,8 @@ import {NullSettlementModule} from "../../src/settlement/NullSettlementModule.so
 ///     --rpc-url $RPC_URL --broadcast --verify
 contract DeployAll is Script {
     uint256 private constant MAX_OUTFLOW_POLICY_BPS = 2_000;
+    uint256 private constant RGB_MINT_BURN_CHAIN_ID = 96;
+    uint256 private constant RGB_POOL_CHAIN_ID = 97;
 
     function run()
         external
@@ -95,6 +101,7 @@ contract DeployAll is Script {
             RgbSettlementModule rgbModule,
             NullVerifier nullVerifier,
             RgbOutboundSettlementModule outboundModule,
+            RgbPoolSettlementModule poolModule,
             NullSettlementModule nullModule,
             MultisigProxy proxy
         )
@@ -165,23 +172,28 @@ contract DeployAll is Script {
         // ---- 4. Bridge (nonce n+2) ---------------------------------------
         bridge = new Bridge(usdt0, address(routeRegistry), payable(address(cm)), address(0), minFundsIn, minFundsOut);
 
-        // ---- 5. Route plugins (nonce n+3 .. n+7) -------------------------
+        // ---- 5. Route plugins (nonce n+3 .. n+8) -------------------------
         rgbVerifier = new RGBVerifier(btcRelay, minSourceConf, maxLatestConf, minConfGap);
         rgbModule = new RgbSettlementModule(address(routeRegistry));
         // NullVerifier: explicit no-proof verifier for operational / non-RGB-
         // source routes (e.g. Arch → RGB, Pool → MintBurn). One instance serves
         // every such route. Federation wires it per route via `proposeSetRoute`.
         nullVerifier = new NullVerifier();
-        // RgbOutboundSettlementModule: for debit-RGB / non-RGB-credit routes
-        // (e.g. RGB → Arch) — reads the canonical RGB ledger (amount + network
-        // tag), writes nothing on credit. Routes with an RGB credit side use the
-        // canonical `rgbModule` instead.
+        // RgbOutboundSettlementModule: reads the canonical RGB ledger on debit
+        // and writes nothing on credit. For the production topology this is the
+        // 96 (mint/burn) -> 97 (pool) rebalance module.
         outboundModule = new RgbOutboundSettlementModule(address(routeRegistry), address(rgbModule));
+        // Pool deposits intentionally do not create mint/burn records or emit
+        // the RGB-specific FundsIn event. Pool releases still have to cite
+        // canonical Bridge operation ids recorded for network 96.
+        poolModule = new RgbPoolSettlementModule(
+            address(routeRegistry), address(rgbModule), RGB_POOL_CHAIN_ID, RGB_MINT_BURN_CHAIN_ID
+        );
         // Stateless routes whose settlement/finality is handled by the TEE or
         // an external delivery layer still use an explicit non-zero module.
         nullModule = new NullSettlementModule();
 
-        // ---- 6. MultisigProxy (nonce n+8) --------------------------------
+        // ---- 6. MultisigProxy (nonce n+9) --------------------------------
         proxy = new MultisigProxy(
             address(bridge), address(cm), enc, encThr, initialSrcChain, fed, fedThr, timelock, minTimelock
         );
@@ -228,6 +240,9 @@ contract DeployAll is Script {
         console2.log("RgbSettlementModule deployed at:", address(rgbModule));
         console2.log("NullVerifier deployed at:       ", address(nullVerifier));
         console2.log("RgbOutboundSettlementModule at: ", address(outboundModule));
+        console2.log("RgbPoolSettlementModule at:     ", address(poolModule));
+        console2.log("  pool chain id:                ", poolModule.poolChainId());
+        console2.log("  backing record chain id:      ", poolModule.backingRecordChainId());
         console2.log("NullSettlementModule at:        ", address(nullModule));
         console2.log("MultisigProxy deployed at:      ", address(proxy));
         console2.log("Initial chain bucket burst bps: ", initialChainBurstBps);
@@ -262,6 +277,13 @@ contract DeployAll is Script {
         );
         require(
             address(outboundModule.rgbModule()) == address(rgbModule), "RgbOutboundSettlementModule.rgbModule mismatch"
+        );
+        require(poolModule.routeRegistry() == address(routeRegistry), "RgbPoolSettlementModule.routeRegistry mismatch");
+        require(address(poolModule.rgbModule()) == address(rgbModule), "RgbPoolSettlementModule.rgbModule mismatch");
+        require(
+            poolModule.poolChainId() == RGB_POOL_CHAIN_ID
+                && poolModule.backingRecordChainId() == RGB_MINT_BURN_CHAIN_ID,
+            "RgbPoolSettlementModule chain ids mismatch"
         );
         require(bridge.routeRegistry() == address(routeRegistry), "Bridge.routeRegistry mismatch");
         require(cm.bridgeAddress() == address(bridge), "CM.bridgeAddress mismatch");
@@ -307,6 +329,13 @@ contract DeployAll is Script {
         console2.log("  MultisigProxy.proposeSetRoute(src, dst, true, verifier, module)");
         console2.log("for each supported (sourceChainId, destChainId) pair");
         console2.log("before any fundsIn / fundsOut traffic is accepted.");
+        console2.log("Production RGB settlement modules:");
+        console2.log("  42161 -> 96: RgbSettlementModule");
+        console2.log("  96 -> 42161: RgbSettlementModule");
+        console2.log("  42161 -> 97: RgbPoolSettlementModule");
+        console2.log("  97 -> 42161: RgbPoolSettlementModule");
+        console2.log("  96 -> 97: RgbOutboundSettlementModule");
+        console2.log("  97 -> 96: RgbSettlementModule");
         console2.log("For every additional fundsOut source chain, federation must also");
         console2.log("install setOutflowLimit(chainId, burstBps, refillBpsPerWindow)");
         console2.log("before enabling traffic for that chain.");

--- a/ethereum/script/deploy/DeployBridge.s.sol
+++ b/ethereum/script/deploy/DeployBridge.s.sol
@@ -35,6 +35,15 @@ import {Bridge} from "../../src/Bridge.sol";
 ///                               non-zero; retune later via federation
 ///                               governance with
 ///                               `Bridge.setMinFundsInAmount(newMinimum)`.
+///   MIN_FUNDS_OUT_AMOUNT      — Minimum accepted `fundsOut` release in token
+///                               smallest units. Required and must be non-zero;
+///                               retune later with
+///                               `Bridge.setMinFundsOutAmount(newMinimum)`.
+///                               Set it above the per-release settlement cost
+///                               (source-chain fee plus this chain's gas), and
+///                               at least above any flat `baseFee` the
+///                               CommissionManager charges on a release route —
+///                               `setCommissionRule` validates against it.
 ///
 /// Usage:
 ///   forge script script/deploy/DeployBridge.s.sol \
@@ -47,9 +56,12 @@ contract DeployBridge is Script {
         address commissionManager = vm.envAddress("COMMISSION_MANAGER");
         address lzAdapter = vm.envOr("LZ_ADAPTER", address(0));
         uint256 minFundsInAmount = vm.envUint("MIN_FUNDS_IN_AMOUNT");
+        uint256 minFundsOutAmount = vm.envUint("MIN_FUNDS_OUT_AMOUNT");
 
         vm.startBroadcast(pk);
-        bridge = new Bridge(usdt0, routeRegistry, payable(commissionManager), lzAdapter, minFundsInAmount);
+        bridge = new Bridge(
+            usdt0, routeRegistry, payable(commissionManager), lzAdapter, minFundsInAmount, minFundsOutAmount
+        );
         vm.stopBroadcast();
 
         console2.log("Bridge deployed at:  ", address(bridge));

--- a/ethereum/script/deploy/DeployBtcRelay.s.sol
+++ b/ethereum/script/deploy/DeployBtcRelay.s.sol
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import {Script, console2} from "forge-std/Script.sol";
+
+import {BtcRelay} from "../../src/btc_relay/BtcRelay.sol";
+import {BtcRelayTestnet} from "../../src/btc_relay/BtcRelayTestnet.sol";
+import {
+    StoredBlockHeader as MainnetHeader,
+    StoredBlockHeaderImpl as MainnetHeaderImpl,
+    StoredBlockHeaderByteLength as MAINNET_HEADER_BYTES
+} from "../../src/btc_relay/structs/StoredBlockHeader.sol";
+import {
+    StoredBlockHeader as TestnetHeader,
+    StoredBlockHeaderByteLength as TESTNET_HEADER_BYTES
+} from "../../src/btc_relay/structs/StoredBlockHeaderTestnet.sol";
+import {Endianness} from "../../src/btc_relay/btc_utils/Endianness.sol";
+import {IBtcRelayView} from "../../src/interfaces/IBtcRelayView.sol";
+
+/// @title DeployBtcRelay
+/// @notice Deploys the Atomiq Bitcoin SPV header relay at a fixed, pre-reviewed
+///         initialisation checkpoint, then hands its address to
+///         `DeployRGBVerifier` / `DeployAll` via `BTC_RELAY_ADDRESS`.
+///
+///      Choose the checkpoint DEEP. Six blocks is not enough: a reorg deeper
+///      than the checkpoint is unrecoverable, because all three header-submit
+///      paths can only extend a height already committed in `_mainChain`, so
+///      the relay would stay pinned to the orphaned branch forever and the fix
+///      is a new relay + a new (immutable) RGBVerifier + a route rotation.
+///      Depth is nearly free: catch-up costs 48 bytes of calldata per block, so
+///      a full day of margin (~144 blocks) is ~7 KB — one transaction.
+///
+/// Env (required):
+///   PRIVATE_KEY                — deployer private key
+///   BTC_CHECKPOINT_HEADER      — the 160-byte `StoredBlockHeader` blob, hex:
+///                                  [0..79]    raw 80-byte Bitcoin block header
+///                                  [80..111]  cumulative chainWork (big-endian uint256)
+///                                  [112..115] block height (uint32)
+///                                  [116..119] lastDiffAdjustment (uint32)
+///                                  [120..159] uint32[10] previous block timestamps
+///   BTC_CHECKPOINT_HEIGHT      — expected height, asserted against the blob
+///   BTC_CHECKPOINT_BLOCKHASH   — expected block hash in DISPLAY order, i.e. exactly
+///                                as a block explorer or `getblockhash` shows it
+///   BTC_CHECKPOINT_CHAINWORK   — expected cumulative chainwork, as the 32-byte
+///                                `chainwork` field of `getblockheader`
+///
+/// Env (optional, defaults in parens):
+///   BTC_CLAMP_BLOCK_TARGET (true)  — enforce the maximum PoW target; immutable after deploy
+///   BTC_RELAY_TESTNET      (false) — deploy `BtcRelayTestnet` instead of `BtcRelay`
+///
+/// Usage:
+///   forge script script/deploy/DeployBtcRelay.s.sol \
+///     --rpc-url $RPC_URL --broadcast --verify
+contract DeployBtcRelay is Script {
+    using MainnetHeaderImpl for MainnetHeader;
+
+    /// @dev Chainwork is masked to 224 bits by the relay constructor. Bitcoin is
+    ///      nowhere near this, so exceeding it means a malformed blob rather
+    ///      than a real chain — reject instead of silently truncating.
+    uint256 private constant MAX_CHAINWORK = type(uint224).max;
+
+    function run() external returns (address relay) {
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        bytes memory blob = vm.envBytes("BTC_CHECKPOINT_HEADER");
+        uint256 expectedHeight = vm.envUint("BTC_CHECKPOINT_HEIGHT");
+        bytes32 expectedBlockhash = vm.envBytes32("BTC_CHECKPOINT_BLOCKHASH");
+        uint256 expectedChainwork = uint256(vm.envBytes32("BTC_CHECKPOINT_CHAINWORK"));
+        bool clampBlockTarget = vm.envOr("BTC_CLAMP_BLOCK_TARGET", true);
+        bool testnet = vm.envOr("BTC_RELAY_TESTNET", false);
+
+        bytes32[5] memory words = _toWords(blob);
+
+        // Mainnet and testnet headers are the same 160-byte layout at the same
+        // offsets, so one decoder validates both. Guarded rather than assumed,
+        // in case the vendored copies ever diverge upstream.
+        require(MAINNET_HEADER_BYTES == TESTNET_HEADER_BYTES, "checkpoint: header layouts diverged");
+
+        MainnetHeader memory header;
+        header.data = words;
+
+        _reportAndVerifyHeader(header, expectedHeight, expectedBlockhash, expectedChainwork);
+
+        console2.log("");
+        console2.log("clampBlockTarget (immutable):", clampBlockTarget);
+        console2.log("network:                     ", testnet ? "testnet" : "mainnet");
+
+        vm.startBroadcast(pk);
+        if (testnet) {
+            TestnetHeader memory testnetHeader;
+            testnetHeader.data = words;
+            relay = address(new BtcRelayTestnet(testnetHeader, clampBlockTarget));
+        } else {
+            relay = address(new BtcRelay(header, clampBlockTarget));
+        }
+        vm.stopBroadcast();
+
+        _verifyDeployment(relay, expectedHeight, expectedChainwork);
+        _reportNextSteps(relay, expectedHeight);
+    }
+
+    // =========================================================================
+    // Header decoding
+    // =========================================================================
+
+    /// @dev Split the 160-byte blob into the five words of `bytes32[5]`. Written
+    ///      as plain loads rather than `mcopy` because the project targets the
+    ///      shanghai EVM.
+    function _toWords(bytes memory blob) private pure returns (bytes32[5] memory words) {
+        require(blob.length == MAINNET_HEADER_BYTES, "checkpoint: header must be exactly 160 bytes");
+
+        for (uint256 i = 0; i < 5; i++) {
+            bytes32 word;
+            assembly ("memory-safe") {
+                word := mload(add(add(blob, 32), mul(i, 32)))
+            }
+            words[i] = word;
+        }
+    }
+
+    /// @dev Re-derive every field from the blob, print it for a final human
+    ///      read, and assert the three independently supplied expectations.
+    ///      The three fields NOT asserted here — `lastDiffAdjustment` and the
+    ///      ten previous timestamps — cannot be checked from the blob alone;
+    ///      they are printed instead, and are the fields most worth verifying
+    ///      by hand, because a mistake in them surfaces weeks later in the
+    ///      retarget and median-time-past rules rather than at deploy.
+    function _reportAndVerifyHeader(
+        MainnetHeader memory header,
+        uint256 expectedHeight,
+        bytes32 expectedBlockhash,
+        uint256 expectedChainwork
+    ) private view {
+        uint256 height = uint256(header.blockHeight());
+        uint256 chainWork = header.chainWork();
+        // `header_blockhash` returns the raw double-SHA256 in Bitcoin's internal
+        // byte order; explorers show it reversed. Compare in display order so the
+        // configured value is a straight copy-paste.
+        bytes32 displayHash = Endianness.reverseBytes32(header.header_blockhash());
+
+        console2.log("=== Checkpoint header (decoded from BTC_CHECKPOINT_HEADER) ===");
+        console2.log("blockHeight:        ", height);
+        console2.log("blockhash (display):", vm.toString(displayHash));
+        console2.log("chainWork:          ", chainWork);
+        console2.log("version:            ", uint256(header.header_version()));
+        console2.log("previousBlockhash:  ", vm.toString(Endianness.reverseBytes32(header.header_previousBlockhash())));
+        console2.log("merkleRoot:         ", vm.toString(Endianness.reverseBytes32(header.header_merkleRoot())));
+        console2.log("timestamp:          ", uint256(header.header_timestamp()));
+        console2.log("nBits (LE):         ", uint256(header.header_nBitsLE()));
+        console2.log("nonce:              ", uint256(header.header_nonce()));
+        console2.log("lastDiffAdjustment: ", uint256(header.lastDiffAdjustment()));
+
+        uint32[10] memory prevTimestamps = header.previousBlockTimestamps();
+        console2.log("previousBlockTimestamps (oldest first):");
+        for (uint256 i = 0; i < 10; i++) {
+            console2.log("  -", uint256(prevTimestamps[i]));
+        }
+
+        require(height == expectedHeight, "checkpoint: height does not match BTC_CHECKPOINT_HEIGHT");
+        require(height <= type(uint32).max, "checkpoint: height overflows uint32");
+        require(displayHash == expectedBlockhash, "checkpoint: blockhash does not match BTC_CHECKPOINT_BLOCKHASH");
+        require(chainWork == expectedChainwork, "checkpoint: chainwork does not match BTC_CHECKPOINT_CHAINWORK");
+        require(chainWork <= MAX_CHAINWORK, "checkpoint: chainwork exceeds the relay's 224-bit field");
+        require(header.header_timestamp() != 0, "checkpoint: zero header timestamp");
+        require(header.header_nBitsLE() != 0, "checkpoint: zero nBits");
+    }
+
+    // =========================================================================
+    // Post-deploy verification
+    // =========================================================================
+
+    /// @dev Read the deployed relay back through the same interface `RGBVerifier`
+    ///      uses, so a mis-initialised relay fails here rather than silently
+    ///      serving a bogus chain.
+    function _verifyDeployment(address relay, uint256 expectedHeight, uint256 expectedChainwork) private view {
+        IBtcRelayView view_ = IBtcRelayView(relay);
+
+        require(uint256(view_.getBlockheight()) == expectedHeight, "deployed: tip height mismatch");
+
+        bytes32 tipCommit = view_.getTipCommitHash();
+        require(tipCommit != bytes32(0), "deployed: zero tip commitment");
+        require(view_.getCommitHash(expectedHeight) == tipCommit, "deployed: checkpoint is not the tip");
+        require(uint256(view_.getChainwork()) == expectedChainwork, "deployed: chainwork mismatch");
+
+        // End-to-end read on the exact call `RGBVerifier` makes.
+        require(view_.verifyBlockheaderHash(expectedHeight, tipCommit) == 1, "deployed: checkpoint does not verify");
+
+        console2.log("");
+        console2.log("=== Post-deploy verification ===");
+        console2.log("BtcRelay deployed at:", relay);
+        console2.log("tip height:          ", uint256(view_.getBlockheight()));
+        console2.log("tip commitment:      ", vm.toString(tipCommit));
+        console2.log("chainwork:           ", uint256(view_.getChainwork()));
+    }
+
+    function _reportNextSteps(address relay, uint256 expectedHeight) private pure {
+        console2.log("");
+        console2.log("=== Next steps ===");
+        console2.log("1. The relay sits at the checkpoint and is NOT usable yet. Submit headers");
+        console2.log("   from this height up to the Bitcoin tip via submitMainBlockheaders");
+        console2.log("   (160-byte stored header + 48 bytes per block, chunked across txs).");
+        console2.log("   RGBVerifier enforces maxLatestConfirmations, so it rejects everything");
+        console2.log("   until the relay reaches the chain head - and keeping it there is a");
+        console2.log("   standing operational duty, not a one-off.");
+        console2.log("2. Export BTC_RELAY_ADDRESS for DeployRGBVerifier / DeployAll:");
+        console2.log("   BTC_RELAY_ADDRESS=", relay);
+        console2.log("3. Checkpoint height, now the immutable floor of the finality gate:");
+        console2.log("   ", expectedHeight);
+    }
+}

--- a/ethereum/script/deploy/DeployRgbPoolSettlementModule.s.sol
+++ b/ethereum/script/deploy/DeployRgbPoolSettlementModule.s.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import {Script, console2} from "forge-std/Script.sol";
+
+import {RgbPoolSettlementModule} from "../../src/settlement/RgbPoolSettlementModule.sol";
+
+/// @title DeployRgbPoolSettlementModuleScript
+/// @notice Deploys the settlement adapter for the RGB liquidity-pool network.
+///         Pool credits create no canonical record; pool debits verify Bridge
+///         operation ids against the configured mint/burn ledger.
+///
+/// Env:
+///   PRIVATE_KEY
+///   ROUTE_REGISTRY_ADDRESS
+///   RGB_SETTLEMENT_MODULE_ADDRESS
+///   RGB_POOL_CHAIN_ID
+///   RGB_MINT_BURN_CHAIN_ID
+contract DeployRgbPoolSettlementModuleScript is Script {
+    function run() external returns (RgbPoolSettlementModule module) {
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address routeRegistry = vm.envAddress("ROUTE_REGISTRY_ADDRESS");
+        address rgbModule = vm.envAddress("RGB_SETTLEMENT_MODULE_ADDRESS");
+        uint256 poolChainId = vm.envUint("RGB_POOL_CHAIN_ID");
+        uint256 mintBurnChainId = vm.envUint("RGB_MINT_BURN_CHAIN_ID");
+
+        vm.startBroadcast(pk);
+        module = new RgbPoolSettlementModule(routeRegistry, rgbModule, poolChainId, mintBurnChainId);
+        vm.stopBroadcast();
+
+        console2.log("RgbPoolSettlementModule deployed at:", address(module));
+        console2.log("RouteRegistry (immutable):           ", module.routeRegistry());
+        console2.log("RgbSettlementModule (immutable):     ", address(module.rgbModule()));
+        console2.log("RGB pool chain id:                   ", module.poolChainId());
+        console2.log("Backing mint/burn chain id:          ", module.backingRecordChainId());
+    }
+}

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -157,8 +157,10 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         "UtexoRebalanceBurnId(address bridge,uint256 chainId,address token,uint256 amount,uint256 sourceChainId,uint256 destinationChainId,bytes32 sourceAddressHash,bytes32 destinationAddressHash,bytes32 proofHash,bytes32 settlementDataOutHash,bytes32 settlementDataInHash)"
     );
 
-    /// @notice CommissionManager that receives and custodies protocol fees.
-    ICommissionManager public immutable commissionManager;
+    /// @inheritdoc IBridge
+    /// @dev Mutable so federation can migrate to a redeployed manager through
+    ///      the typed, timelocked `UpdateCommissionManager` governance op.
+    ICommissionManager public override commissionManager;
 
     /// @inheritdoc IBridge
     /// @dev Mutable so federation can rotate registry deployments via
@@ -318,6 +320,16 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     }
 
     /// @inheritdoc IBridge
+    /// @dev Owner is `MultisigProxy`; its typed `UpdateCommissionManager`
+    ///      operation updates this pointer and the proxy's own target atomically.
+    function setCommissionManager(address newCommissionManager) external override onlyOwner {
+        if (newCommissionManager == address(0)) revert InvalidCommissionManagerAddress();
+        address old = address(commissionManager);
+        commissionManager = ICommissionManager(payable(newCommissionManager));
+        emit CommissionManagerUpdated(old, newCommissionManager);
+    }
+
+    /// @inheritdoc IBridge
     /// @dev Owner is `MultisigProxy`; federation gates this on its M-of-N
     ///      timelock flow (generic `proposeAdminExecute` -> execute). Must be
     ///      non-zero: a non-zero floor is what rejects zero-amount and dust
@@ -372,13 +384,13 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     /// @inheritdoc IBridge
     function availableOutflow(uint256 chainId) external view override returns (uint256) {
         uint256 shares = OutflowRateLimiter.currentState(chainBuckets[chainId]).tokens;
-        return _fromShares(shares, _chainReference(chainId));
+        return _fromShares(shares, lockedLiquidity[chainId]);
     }
 
     /// @inheritdoc IBridge
     function availableGlobalOutflow() external view override returns (uint256) {
         uint256 shares = OutflowRateLimiter.currentState(globalBucket).tokens;
-        return _fromShares(shares, _globalReference());
+        return _fromShares(shares, totalLockedLiquidity);
     }
 
     /// @inheritdoc IBridge
@@ -395,27 +407,30 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
 
     /// @inheritdoc IBridge
     function chainOutflowReference(uint256 chainId) external view override returns (uint256) {
-        return _chainReference(chainId);
+        return lockedLiquidity[chainId];
     }
 
     /// @inheritdoc IBridge
     function globalOutflowReference() external view override returns (uint256) {
-        return _globalReference();
+        return totalLockedLiquidity;
     }
 
     /// @inheritdoc IBridge
     function effectiveAvailableOutflow(uint256 chainId) external view override returns (uint256) {
         uint256 chainSpent = _chainSafetyWindows[chainId].current();
-        uint256 chainRef = lockedLiquidity[chainId] + chainSpent;
+        uint256 chainLiquidity = lockedLiquidity[chainId];
+        uint256 chainSafetyRef = chainLiquidity + chainSpent;
         uint256 globalSpent = _globalSafetyWindow.current();
-        uint256 globalRef = totalLockedLiquidity + globalSpent;
+        uint256 globalLiquidity = totalLockedLiquidity;
+        uint256 globalSafetyRef = globalLiquidity + globalSpent;
 
-        uint256 allowed = lockedLiquidity[chainId];
-        allowed =
-            Math.min(allowed, _fromShares(OutflowRateLimiter.currentState(chainBuckets[chainId]).tokens, chainRef));
-        allowed = Math.min(allowed, _fromShares(OutflowRateLimiter.currentState(globalBucket).tokens, globalRef));
-        allowed = Math.min(allowed, _remainingSafetyAllowance(chainRef, chainSpent, MAX_CHAIN_OUTFLOW_BPS));
-        allowed = Math.min(allowed, _remainingSafetyAllowance(globalRef, globalSpent, MAX_GLOBAL_OUTFLOW_BPS));
+        uint256 allowed = chainLiquidity;
+        allowed = Math.min(
+            allowed, _fromShares(OutflowRateLimiter.currentState(chainBuckets[chainId]).tokens, chainLiquidity)
+        );
+        allowed = Math.min(allowed, _fromShares(OutflowRateLimiter.currentState(globalBucket).tokens, globalLiquidity));
+        allowed = Math.min(allowed, _remainingSafetyAllowance(chainSafetyRef, chainSpent, MAX_CHAIN_OUTFLOW_BPS));
+        allowed = Math.min(allowed, _remainingSafetyAllowance(globalSafetyRef, globalSpent, MAX_GLOBAL_OUTFLOW_BPS));
         return allowed;
     }
 
@@ -508,17 +523,16 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         uint256 totalLiquidity = totalLockedLiquidity;
         totalLockedLiquidity = totalLiquidity - fundsOutParams.amount;
 
-        // Reference liquidity for both limiter layers: pre-debit liquidity plus
-        // usage already recorded in the rolling window. That sum is invariant as
-        // releases drain liquidity inside one window, so a sequence of small
-        // withdrawals cannot geometrically outpace the ceiling. Both the token
-        // buckets and the immutable safety limits below are denominated against
-        // the SAME reference, so the two layers never disagree about what a
-        // percentage means.
+        // Token buckets price this release against the actual pre-debit locked
+        // liquidity. Their reference therefore changes only when accounted
+        // liquidity changes, never merely because an old rolling slot expires.
+        // The immutable safety windows intentionally keep their own
+        // pre-window reference (`locked + spent`) so aggregate outflow remains
+        // capped across a sequence of transactions in the same rolling window.
         uint256 chainSpent = _chainSafetyWindows[fundsOutParams.sourceChainId].current();
-        uint256 chainReference = srcLiquidity + chainSpent;
+        uint256 chainSafetyReference = srcLiquidity + chainSpent;
         uint256 globalSpent = _globalSafetyWindow.current();
-        uint256 globalReference = totalLiquidity + globalSpent;
+        uint256 globalSafetyReference = totalLiquidity + globalSpent;
 
         // Outflow rate limit. Consume both the per-source-chain
         // bucket and the global aggregate bucket; either being short reverts the
@@ -530,8 +544,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // rejects the release instead of falling back to unlimited outflow.
         // Amounts are converted to shares of the reference, so a bucket keeps
         // its configured percentage meaning as liquidity moves.
-        chainBuckets[fundsOutParams.sourceChainId].spend(_toShares(fundsOutParams.amount, chainReference), TOKEN);
-        globalBucket.spend(_toShares(fundsOutParams.amount, globalReference), address(0));
+        chainBuckets[fundsOutParams.sourceChainId].spend(_toShares(fundsOutParams.amount, srcLiquidity), TOKEN);
+        globalBucket.spend(_toShares(fundsOutParams.amount, totalLiquidity), address(0));
 
         // Quote commission. NATIVE on fundsOut is unrepresentable: the
         // CommissionManager setters reject a (NATIVE, FUNDS_OUT) rule at config,
@@ -565,8 +579,10 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // They run after the existing bucket and route checks to preserve those
         // paths' fail-fast errors; any failure here still atomically rolls back
         // all earlier state and plugin calls.
-        _consumeChainSafetyOutflow(fundsOutParams.sourceChainId, chainSpent, chainReference, fundsOutParams.amount);
-        _consumeGlobalSafetyOutflow(globalSpent, globalReference, fundsOutParams.amount);
+        _consumeChainSafetyOutflow(
+            fundsOutParams.sourceChainId, chainSpent, chainSafetyReference, fundsOutParams.amount
+        );
+        _consumeGlobalSafetyOutflow(globalSpent, globalSafetyReference, fundsOutParams.amount);
 
         // Forward token commission to the CommissionManager pool.
         if (tokenCommission != 0) _forwardTokenCommission(tokenCommission);
@@ -644,11 +660,12 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // away from this chain, so it spends the chain bucket like a release.
         // The global bucket is intentionally NOT spent — it bounds physical
         // token egress, and no tokens leave here; the eventual exit pays the
-        // global bucket inside `fundsOut`. Same reference as the immutable
-        // per-chain safety limit consumed below.
+        // global bucket inside `fundsOut`. The bucket uses actual pre-debit
+        // source liquidity; the immutable safety window below separately keeps
+        // its rolling `locked + spent` reference.
         uint256 chainSpent = _chainSafetyWindows[params.sourceChainId].current();
-        uint256 chainReference = srcLiquidity + chainSpent;
-        chainBuckets[params.sourceChainId].spend(_toShares(params.amount, chainReference), TOKEN);
+        uint256 chainSafetyReference = srcLiquidity + chainSpent;
+        chainBuckets[params.sourceChainId].spend(_toShares(params.amount, srcLiquidity), TOKEN);
 
         // Debit-leg verification: route verifier (view-only source proof)
         // first, then the settlement module's release check. `recipient` is
@@ -698,7 +715,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         // no token leaves custody, and the eventual fundsOut will consume it.
         // Kept after route validation so route-specific errors retain priority;
         // a safety-limit revert rolls the complete rebalance back atomically.
-        _consumeChainSafetyOutflow(params.sourceChainId, chainSpent, chainReference, params.amount);
+        _consumeChainSafetyOutflow(params.sourceChainId, chainSpent, chainSafetyReference, params.amount);
 
         // RGB-only correlation event, same contract as `_fundsIn`: the RGB
         // listener authorises a mint against `FundsIn` and needs no awareness
@@ -1107,17 +1124,6 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     /// @dev Convert bucket shares back to token units for the public views.
     function _fromShares(uint256 shares, uint256 refLiquidity) private pure returns (uint256) {
         return Math.mulDiv(shares, refLiquidity, SHARE_UNIT);
-    }
-
-    /// @dev Reference liquidity for a source chain: accounted liquidity plus
-    ///      usage still counted in the rolling window.
-    function _chainReference(uint256 chainId) private view returns (uint256) {
-        return lockedLiquidity[chainId] + _chainSafetyWindows[chainId].current();
-    }
-
-    /// @dev Reference liquidity for the aggregate scope.
-    function _globalReference() private view returns (uint256) {
-        return totalLockedLiquidity + _globalSafetyWindow.current();
     }
 
     function _remainingSafetyAllowance(uint256 refLiquidity, uint256 spent, uint256 maxBps)

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -725,7 +725,7 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     // =========================================================================
 
     function _validateFundsOutParams(FundsOutParams calldata params) private view {
-        if (params.amount == 0) revert ZeroAmount();        
+        if (params.amount == 0) revert ZeroAmount();
         if (params.amount < minFundsOutAmount) revert AmountBelowMinimum(params.amount, minFundsOutAmount);
         if (params.recipient == address(0)) revert InvalidRecipientAddress();
         if (params.sourceChainId == 0) revert InvalidSourceChainId();

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -223,6 +223,14 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     ///      propose -> timelock -> execute flow without redeploying the Bridge.
     uint256 public override minFundsInAmount;
 
+    /// @inheritdoc IBridge
+    /// @dev Always non-zero (validated at the constructor and setter). The
+    ///      outbound mirror of `minFundsInAmount`, and the bound the
+    ///      CommissionManager validates a `FUNDS_OUT` flat `baseFee` against.
+    ///      Mutable through the same `MultisigProxy` propose -> timelock ->
+    ///      execute flow.
+    uint256 public override minFundsOutAmount;
+
     // =========================================================================
     // Modifiers
     // =========================================================================
@@ -250,21 +258,27 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     /// @param minFundsInAmount_  Initial minimum accepted `fundsIn` deposit in
     ///                           token smallest units. Must be non-zero; it can
     ///                           be retuned later via `setMinFundsInAmount`.
+    /// @param minFundsOutAmount_ Initial minimum accepted `fundsOut` release in
+    ///                           token smallest units. Must be non-zero; it can
+    ///                           be retuned later via `setMinFundsOutAmount`.
     constructor(
         address usdt0_,
         address routeRegistry_,
         address payable commissionManager_,
         address lzAdapter_,
-        uint256 minFundsInAmount_
+        uint256 minFundsInAmount_,
+        uint256 minFundsOutAmount_
     ) BridgeBase(usdt0_) {
         if (routeRegistry_ == address(0)) revert InvalidRouteRegistryAddress();
         if (commissionManager_ == address(0)) revert InvalidCommissionManagerAddress();
         if (minFundsInAmount_ == 0) revert InvalidMinFundsInAmount();
+        if (minFundsOutAmount_ == 0) revert InvalidMinFundsOutAmount();
 
         routeRegistry = routeRegistry_;
         commissionManager = ICommissionManager(commissionManager_);
         lzAdapter = lzAdapter_;
         minFundsInAmount = minFundsInAmount_;
+        minFundsOutAmount = minFundsOutAmount_;
     }
 
     // =========================================================================
@@ -313,6 +327,17 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         uint256 old = minFundsInAmount;
         minFundsInAmount = newMinimum;
         emit MinFundsInAmountUpdated(old, newMinimum);
+    }
+
+    /// @inheritdoc IBridge
+    /// @dev Owner is `MultisigProxy`; federation gates this on its M-of-N
+    ///      timelock flow (generic `proposeAdminExecute` -> execute). Must be
+    ///      non-zero
+    function setMinFundsOutAmount(uint256 newMinimum) external override onlyOwner {
+        if (newMinimum == 0) revert InvalidMinFundsOutAmount();
+        uint256 old = minFundsOutAmount;
+        minFundsOutAmount = newMinimum;
+        emit MinFundsOutAmountUpdated(old, newMinimum);
     }
 
     /// @inheritdoc IBridge
@@ -700,7 +725,8 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
     // =========================================================================
 
     function _validateFundsOutParams(FundsOutParams calldata params) private view {
-        if (params.amount == 0) revert ZeroAmount();
+        if (params.amount == 0) revert ZeroAmount();        
+        if (params.amount < minFundsOutAmount) revert AmountBelowMinimum(params.amount, minFundsOutAmount);
         if (params.recipient == address(0)) revert InvalidRecipientAddress();
         if (params.sourceChainId == 0) revert InvalidSourceChainId();
         if (params.destinationChainId == 0) revert InvalidDestinationChainId();

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -662,6 +662,7 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     /**
      * @notice Returns current global defaults (used when no per-route override exists).
      * @return stablePercent Global percent × 100.
+     * @return baseFee Global flat fee in token smallest units.
      * @return multiplier Global multiplier.
      * @return side Global `CommissionSide`.
      * @return currency Global `CommissionCurrency`.
@@ -669,9 +670,15 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     function getGlobalDefaults()
         external
         view
-        returns (uint256 stablePercent, uint8 multiplier, CommissionSide side, CommissionCurrency currency)
+        returns (
+            uint256 stablePercent,
+            uint256 baseFee,
+            uint8 multiplier,
+            CommissionSide side,
+            CommissionCurrency currency
+        )
     {
-        return (globalStablePercent, globalMultiplier, globalSide, globalCurrency);
+        return (globalStablePercent, globalBaseFee, globalMultiplier, globalSide, globalCurrency);
     }
 
     /**

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -17,6 +17,13 @@ import {
     ICommissionManager
 } from "./interfaces/ICommissionManager.sol";
 
+/// @notice Minimal view of the Bridge's inbound dust floor. Declared locally
+///         rather than importing the full `IBridge` so the commission layer
+///         depends on exactly the one value it needs.
+interface IBridgeDepositFloor {
+    function minFundsInAmount() external view returns (uint256);
+}
+
 /**
  * @title CommissionManager
  * @author UTEXO bridge stack
@@ -27,6 +34,14 @@ import {
  *      numeric ids by the Utexo backend in a namespace reserved above the EVM range (see README).
  *      Routes are **directional** (swapping source and destination yields a different key), so
  *      independent rules can apply to each leg of a round trip (e.g. ETH→RGB vs RGB→ETH).
+ *
+ *      **Fee shape:** `fee = amount * stablePercent / multiplier^2 + baseFee` — a proportional part
+ *      plus a flat part, both per-route configurable and either optionally zero. `baseFee` covers a
+ *      per-operation cost that does not scale with the amount (the Bitcoin transaction fee on the RGB
+ *      leg). It is expressed in the token's smallest units and is only accepted on the `FUNDS_IN`
+ *      side, where `Bridge.minFundsInAmount` bounds it: every configured rule must leave a positive
+ *      net for a deposit sitting exactly on that floor, re-verified against the live floor on every
+ *      quote (see `_requireFeeFitsDepositFloor`).
  *
  *      **Side (`CommissionSide`):** For a given route config, commission applies only to **either**
  *      `FUNDS_IN` **or** `FUNDS_OUT`, matching `calculateFundsInCommission` vs `calculateFundsOutCommission`.
@@ -57,6 +72,9 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
 
     /// @notice Default `stablePercent` when no per-route rule exists (×100; 0 = no % fee until configured).
     uint256 public globalStablePercent = 0;
+    /// @notice Default flat `baseFee` in token smallest units (0 = no flat fee
+    ///         until configured). Added on top of the proportional part.
+    uint256 public globalBaseFee = 0;
     /// @notice Default `multiplier` for `calculateStableFee` (typically 100).
     uint8 public globalMultiplier = 100;
     /// @notice Default `side` for routes without an override.
@@ -158,23 +176,29 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
             return (0, 0, amount);
         }
 
-        // Calculate stable fee in token units
-        uint256 stableFee = calculateStableFee(amount, config.stablePercent, config.multiplier);
-        _requireNonZeroConfiguredCommission(amount, stableFee, config);
+        // Total fee in token units: proportional part plus the flat `baseFee`.
+        uint256 totalFee = calculateStableFee(amount, config.stablePercent, config.multiplier) + config.baseFee;
+        _requireNonZeroConfiguredCommission(amount, totalFee, config);
+        // Live floor check. `baseFee` does not shrink with the amount, so a rule
+        // is only sound while it still leaves a positive net at the Bridge's
+        // current `minFundsInAmount`. Re-read on every quote rather than trusted
+        // from configuration time, because `Bridge.setMinFundsInAmount` can lower
+        // the floor after a rule was validated against a higher one.
+        _requireFeeFitsDepositFloor(config);
 
         if (config.currency == CommissionCurrency.TOKEN) {
             // TOKEN commission: deduct from amount
-            if (stableFee >= amount) revert ZeroNetAmount(amount, stableFee);
-            tokenCommission = stableFee;
+            if (totalFee >= amount) revert ZeroNetAmount(amount, totalFee);
+            tokenCommission = totalFee;
             nativeCommission = 0;
             netAmount = amount - tokenCommission;
         } else {
             // NATIVE commission: user pays in ETH/BNB via msg.value
             tokenCommission = 0;
-            if (stableFee == 0) {
+            if (totalFee == 0) {
                 nativeCommission = 0;
             } else {
-                nativeCommission = convertTokenFeeToNative(stableFee, _tokenDecimals(token));
+                nativeCommission = convertTokenFeeToNative(totalFee, _tokenDecimals(token));
                 if (nativeCommission == 0) {
                     revert CommissionRoundsToZero(amount, config.stablePercent, config.multiplier);
                 }
@@ -209,22 +233,27 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
             return (0, 0, amount);
         }
 
-        // Calculate stable fee
-        uint256 stableFee = calculateStableFee(amount, config.stablePercent, config.multiplier);
-        _requireNonZeroConfiguredCommission(amount, stableFee, config);
+        // Total fee. `baseFee` is rejected at configuration time on this side
+        // (`BaseFeeNotAllowedOnFundsOut`), so the flat term is always zero here;
+        // the expression is written uniformly with the inbound path so enabling
+        // outbound `baseFee` later is a validator change only. No deposit-floor
+        // check either: `minFundsInAmount` bounds deposits, and the release path
+        // has no equivalent floor to validate a flat fee against.
+        uint256 totalFee = calculateStableFee(amount, config.stablePercent, config.multiplier) + config.baseFee;
+        _requireNonZeroConfiguredCommission(amount, totalFee, config);
 
         if (config.currency == CommissionCurrency.TOKEN) {
-            if (stableFee >= amount) revert ZeroNetAmount(amount, stableFee);
-            tokenCommission = stableFee;
+            if (totalFee >= amount) revert ZeroNetAmount(amount, totalFee);
+            tokenCommission = totalFee;
             nativeCommission = 0;
             netAmount = amount - tokenCommission;
         } else {
             // NATIVE commission for fundsOut: user pays in native (per blueprint)
             tokenCommission = 0;
-            if (stableFee == 0) {
+            if (totalFee == 0) {
                 nativeCommission = 0;
             } else {
-                nativeCommission = convertTokenFeeToNative(stableFee, _tokenDecimals(token));
+                nativeCommission = convertTokenFeeToNative(totalFee, _tokenDecimals(token));
                 if (nativeCommission == 0) {
                     revert CommissionRoundsToZero(amount, config.stablePercent, config.multiplier);
                 }
@@ -246,6 +275,66 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         returns (uint256)
     {
         return (amount * stablePercent) / multiplier / multiplier;
+    }
+
+    /// @inheritdoc ICommissionManager
+    /// @dev Convenience view for the backend: resolves the effective rule and
+    ///      returns the full `proportional + flat` fee without the side/currency
+    ///      branching the `calculate*Commission` entrypoints apply.
+    function calculateTotalFee(uint256 sourceChainId, uint256 destChainId, address token, uint256 amount)
+        external
+        view
+        returns (uint256)
+    {
+        CommissionConfig memory config = getEffectiveConfig(buildRouteKey(sourceChainId, destChainId, token));
+        return calculateStableFee(amount, config.stablePercent, config.multiplier) + config.baseFee;
+    }
+
+    /// @inheritdoc ICommissionManager
+    function depositFloor() external view returns (uint256) {
+        return _depositFloor();
+    }
+
+    /// @dev Reads the Bridge's inbound dust floor. Fails closed: a
+    ///      `bridgeAddress` that is not a live Bridge, or a zero floor (which the
+    ///      Bridge itself rejects at construction and in `setMinFundsInAmount`),
+    ///      leaves no sound bound for a flat fee, so no quote may proceed.
+    function _depositFloor() internal view returns (uint256 floor) {
+        address bridge = bridgeAddress;
+        // Explicit code check first: Solidity's `extcodesize` guard on a
+        // high-level call to a codeless address reverts WITHOUT data and is not
+        // catchable by the `try/catch` below, which would surface as an opaque
+        // bare revert instead of a named error.
+        if (bridge.code.length == 0) revert DepositFloorUnavailable();
+        try IBridgeDepositFloor(bridge).minFundsInAmount() returns (uint256 value) {
+            floor = value;
+        } catch {
+            revert DepositFloorUnavailable();
+        }
+        if (floor == 0) revert DepositFloorUnavailable();
+    }
+
+    /// @dev Enforces that the effective rule still leaves a positive net for a
+    ///      deposit sitting exactly on the floor.
+    ///
+    ///      Checking at the floor is both necessary and sufficient: net is
+    ///      `amount * (1 - stablePercent/multiplier^2) - baseFee`, which is
+    ///      strictly increasing in `amount` because the configured proportional
+    ///      rate is below 100% (`InvalidFeeShape`). So if the floor clears, every
+    ///      larger deposit clears too — and `baseFee < depositFloor` alone would
+    ///      NOT be sufficient, since the proportional part also consumes part of
+    ///      that floor.
+    function _requireFeeFitsDepositFloor(CommissionConfig memory config) private view {
+        // Only a FLAT fee needs this bound. A purely proportional fee is already
+        // held below 100% by `InvalidFeeShape`, so it leaves a positive net at
+        // every amount on its own. Skipping the read here keeps the Bridge
+        // dependency — and its failure mode — off the quote path of every route
+        // that charges no flat fee, which is every route that exists today.
+        if (config.baseFee == 0) return;
+
+        uint256 floor = _depositFloor();
+        uint256 feeAtFloor = calculateStableFee(floor, config.stablePercent, config.multiplier) + config.baseFee;
+        if (feeAtFloor >= floor) revert FeeAboveDepositFloor(feeAtFloor, floor);
     }
 
     /// @inheritdoc ICommissionManager
@@ -324,10 +413,35 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
      */
     function setGlobalDefaults(
         uint256 stablePercent,
+        uint256 baseFee,
         uint8 multiplier,
         CommissionSide side,
         CommissionCurrency currency
     ) external onlyOwner {
+        _validateConfig(stablePercent, baseFee, multiplier, side, currency);
+
+        globalStablePercent = stablePercent;
+        globalBaseFee = baseFee;
+        globalMultiplier = multiplier;
+        globalSide = side;
+        globalCurrency = currency;
+
+        emit GlobalDefaultsUpdated(stablePercent, baseFee, multiplier, side, currency);
+    }
+
+    /// @dev Shared shape validation for both the global defaults and a per-route
+    ///      override. Fails fast at configuration time so a malformed rule
+    ///      reverts for governance here instead of silently bricking every quote
+    ///      on the route later. The deposit-floor part is re-checked on every
+    ///      quote (`_requireFeeFitsDepositFloor`), because the floor can move
+    ///      after a rule was accepted.
+    function _validateConfig(
+        uint256 stablePercent,
+        uint256 baseFee,
+        uint8 multiplier,
+        CommissionSide side,
+        CommissionCurrency currency
+    ) private view {
         if (stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
         if (multiplier == 0) revert MultiplierZero();
         // Joint invariant: the fee fraction is `stablePercent / multiplier^2`.
@@ -344,13 +458,25 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         if (currency == CommissionCurrency.NATIVE && side == CommissionSide.FUNDS_OUT) {
             revert NativeCommissionNotAllowedOnFundsOut();
         }
+        // A flat fee is only bounded on the inbound side, where
+        // `minFundsInAmount` guarantees a minimum amount to charge it against.
+        // The release path has no such floor: a `baseFee` exceeding a small
+        // release would revert its quote, and because `burnId` is derived from
+        // the release intent that exact release could then never execute.
+        if (baseFee != 0 && side == CommissionSide.FUNDS_OUT) revert BaseFeeNotAllowedOnFundsOut();
 
-        globalStablePercent = stablePercent;
-        globalMultiplier = multiplier;
-        globalSide = side;
-        globalCurrency = currency;
-
-        emit GlobalDefaultsUpdated(stablePercent, multiplier, side, currency);
+        if (side == CommissionSide.FUNDS_IN) {
+            _requireFeeFitsDepositFloor(
+                CommissionConfig({
+                    stablePercent: stablePercent,
+                    baseFee: baseFee,
+                    multiplier: multiplier,
+                    side: side,
+                    currency: currency,
+                    isSet: true
+                })
+            );
+        }
     }
 
     /// @inheritdoc ICommissionManager
@@ -414,23 +540,7 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         CommissionConfig calldata config
     ) external onlyOwner {
         if (token == address(0)) revert InvalidToken();
-        // Validate config
-        if (config.stablePercent > _MAX_STABLE_PERCENT) revert StablePercentTooHigh();
-        if (config.multiplier == 0) revert MultiplierZero();
-        // Joint invariant: the fee fraction is `stablePercent / multiplier^2`.
-        // The configured fee must be strictly below 100%. Equality would make
-        // TOKEN commission consume the entire amount and create a zero-net
-        // settlement; greater values would underflow. Widen to uint256 before
-        // squaring — `multiplier` is uint8 and the common `100 * 100` would
-        // itself overflow uint8.
-        if (config.stablePercent >= uint256(config.multiplier) * uint256(config.multiplier)) {
-            revert InvalidFeeShape(config.stablePercent, config.multiplier);
-        }
-        // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
-        // native fee
-        if (config.currency == CommissionCurrency.NATIVE && config.side == CommissionSide.FUNDS_OUT) {
-            revert NativeCommissionNotAllowedOnFundsOut();
-        }
+        _validateConfig(config.stablePercent, config.baseFee, config.multiplier, config.side, config.currency);
 
         // Build route key
         bytes32 key = buildRouteKey(sourceChainId, destChainId, token);
@@ -438,7 +548,10 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         commissionRules[key] = config;
         commissionRules[key].isSet = true;
 
-        emit CommissionRuleUpdated(sourceChainId, destChainId, token, config);
+        // Emit what was STORED, not the caller's struct: `isSet` is forced true
+        // above, so echoing the argument would let a rule written with
+        // `isSet: false` be logged as unset while storage says otherwise.
+        emit CommissionRuleUpdated(sourceChainId, destChainId, token, commissionRules[key]);
     }
 
     /**
@@ -481,6 +594,7 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         // Fall back to global defaults
         return CommissionConfig({
             stablePercent: globalStablePercent,
+            baseFee: globalBaseFee,
             multiplier: globalMultiplier,
             side: globalSide,
             currency: globalCurrency,
@@ -488,16 +602,18 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         });
     }
 
-    /// @dev A deliberately disabled fee (`stablePercent == 0`) is valid. Once
-    ///      governance enables a fee, however, every operation governed by that
-    ///      rule must pay at least one smallest unit. This runtime check couples
-    ///      the effective per-route/global rule to the actual transfer amount,
-    ///      so later configuration changes cannot reopen commission-free dust.
-    function _requireNonZeroConfiguredCommission(uint256 amount, uint256 stableFee, CommissionConfig memory config)
+    /// @dev A deliberately disabled fee (`stablePercent == 0 && baseFee == 0`) is
+    ///      valid. Once governance enables a fee, however, every operation
+    ///      governed by that rule must pay at least one smallest unit. This
+    ///      runtime check couples the effective per-route/global rule to the
+    ///      actual transfer amount, so later configuration changes cannot reopen
+    ///      commission-free dust. A non-zero `baseFee` satisfies it by
+    ///      construction — the flat term never rounds away.
+    function _requireNonZeroConfiguredCommission(uint256 amount, uint256 totalFee, CommissionConfig memory config)
         private
         pure
     {
-        if (config.stablePercent != 0 && stableFee == 0) {
+        if ((config.stablePercent != 0 || config.baseFee != 0) && totalFee == 0) {
             revert CommissionRoundsToZero(amount, config.stablePercent, config.multiplier);
         }
     }

--- a/ethereum/src/CommissionManager.sol
+++ b/ethereum/src/CommissionManager.sol
@@ -17,11 +17,12 @@ import {
     ICommissionManager
 } from "./interfaces/ICommissionManager.sol";
 
-/// @notice Minimal view of the Bridge's inbound dust floor. Declared locally
+/// @notice Minimal view of the Bridge's per-side dust floors. Declared locally
 ///         rather than importing the full `IBridge` so the commission layer
-///         depends on exactly the one value it needs.
-interface IBridgeDepositFloor {
+///         depends on exactly the two values it needs.
+interface IBridgeAmountFloors {
     function minFundsInAmount() external view returns (uint256);
+    function minFundsOutAmount() external view returns (uint256);
 }
 
 /**
@@ -38,10 +39,10 @@ interface IBridgeDepositFloor {
  *      **Fee shape:** `fee = amount * stablePercent / multiplier^2 + baseFee` — a proportional part
  *      plus a flat part, both per-route configurable and either optionally zero. `baseFee` covers a
  *      per-operation cost that does not scale with the amount (the Bitcoin transaction fee on the RGB
- *      leg). It is expressed in the token's smallest units and is only accepted on the `FUNDS_IN`
- *      side, where `Bridge.minFundsInAmount` bounds it: every configured rule must leave a positive
- *      net for a deposit sitting exactly on that floor, re-verified against the live floor on every
- *      quote (see `_requireFeeFitsDepositFloor`).
+ *      leg). It is expressed in the token's smallest units and is bounded by its side's Bridge dust
+ *      floor — `minFundsInAmount` for `FUNDS_IN`, `minFundsOutAmount` for `FUNDS_OUT`: every
+ *      configured rule must leave a positive net for an operation sitting exactly on that floor,
+ *      re-verified against the live floor on every quote (see `_requireFeeFitsAmountFloor`).
  *
  *      **Side (`CommissionSide`):** For a given route config, commission applies only to **either**
  *      `FUNDS_IN` **or** `FUNDS_OUT`, matching `calculateFundsInCommission` vs `calculateFundsOutCommission`.
@@ -82,8 +83,25 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
     /// @notice Default `currency` for routes without an override.
     CommissionCurrency public globalCurrency = CommissionCurrency.TOKEN;
 
-    /// @notice Maximum allowed `stablePercent` (9000 = 90%).
+    /// @notice Absolute bound on the raw `stablePercent` numerator. Kept as a
+    ///         sanity bound (and as the overflow guard for the rate comparison
+    ///         in `_validateConfig`); the ceiling that actually governs what a
+    ///         route can charge is `_MAX_FEE_BPS`.
     uint256 private constant _MAX_STABLE_PERCENT = 9000;
+
+    /// @notice Basis-point denominator for the effective-rate ceiling.
+    uint256 private constant _BPS_DENOMINATOR = 10_000;
+
+    /// @notice Hard ceiling on the EFFECTIVE proportional rate: 9000 bps = 90%.
+    /// @dev `stablePercent` alone does not express the rate — the charged
+    ///      fraction is `stablePercent / multiplier^2`. Bounding the numerator
+    ///      therefore caps the rate only at the conventional `multiplier == 100`;
+    ///      with any smaller multiplier the same numerator buys a far larger
+    ///      rate (`stablePercent = 99, multiplier = 10` is 99%, and
+    ///      `8999 / 95^2` is 99.7%), leaving only the `InvalidFeeShape` "below
+    ///      100%" bound in force. The ceiling is enforced on the rate itself so
+    ///      it holds for every representable `multiplier`.
+    uint256 private constant _MAX_FEE_BPS = 9_000;
 
     /// @notice Per-route overrides; key = `buildRouteKey(sourceChainId, destChainId, token)`.
     mapping(bytes32 => CommissionConfig) public commissionRules;
@@ -184,7 +202,7 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         // current `minFundsInAmount`. Re-read on every quote rather than trusted
         // from configuration time, because `Bridge.setMinFundsInAmount` can lower
         // the floor after a rule was validated against a higher one.
-        _requireFeeFitsDepositFloor(config);
+        _requireFeeFitsAmountFloor(config);
 
         if (config.currency == CommissionCurrency.TOKEN) {
             // TOKEN commission: deduct from amount
@@ -233,14 +251,14 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
             return (0, 0, amount);
         }
 
-        // Total fee. `baseFee` is rejected at configuration time on this side
-        // (`BaseFeeNotAllowedOnFundsOut`), so the flat term is always zero here;
-        // the expression is written uniformly with the inbound path so enabling
-        // outbound `baseFee` later is a validator change only. No deposit-floor
-        // check either: `minFundsInAmount` bounds deposits, and the release path
-        // has no equivalent floor to validate a flat fee against.
+        // Total fee: proportional part plus the flat `baseFee`, symmetric with
+        // the inbound path. The flat term is bounded here by
+        // `Bridge.minFundsOutAmount`, the release-side mirror of the deposit
+        // floor, and re-verified against the live value on every quote for the
+        // same reason: the floor can be lowered after a rule was accepted.
         uint256 totalFee = calculateStableFee(amount, config.stablePercent, config.multiplier) + config.baseFee;
         _requireNonZeroConfiguredCommission(amount, totalFee, config);
+        _requireFeeFitsAmountFloor(config);
 
         if (config.currency == CommissionCurrency.TOKEN) {
             if (totalFee >= amount) revert ZeroNetAmount(amount, totalFee);
@@ -292,49 +310,61 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
 
     /// @inheritdoc ICommissionManager
     function depositFloor() external view returns (uint256) {
-        return _depositFloor();
+        return _amountFloor(CommissionSide.FUNDS_IN);
     }
 
-    /// @dev Reads the Bridge's inbound dust floor. Fails closed: a
-    ///      `bridgeAddress` that is not a live Bridge, or a zero floor (which the
-    ///      Bridge itself rejects at construction and in `setMinFundsInAmount`),
-    ///      leaves no sound bound for a flat fee, so no quote may proceed.
-    function _depositFloor() internal view returns (uint256 floor) {
+    /// @inheritdoc ICommissionManager
+    function releaseFloor() external view returns (uint256) {
+        return _amountFloor(CommissionSide.FUNDS_OUT);
+    }
+
+    /// @dev Reads the Bridge dust floor governing `side`. Fails closed: a
+    ///      `bridgeAddress` that is not a live Bridge, or a zero floor .
+    function _amountFloor(CommissionSide side) internal view returns (uint256 floor) {
         address bridge = bridgeAddress;
         // Explicit code check first: Solidity's `extcodesize` guard on a
-        // high-level call to a codeless address reverts WITHOUT data and is not
-        // catchable by the `try/catch` below, which would surface as an opaque
-        // bare revert instead of a named error.
-        if (bridge.code.length == 0) revert DepositFloorUnavailable();
-        try IBridgeDepositFloor(bridge).minFundsInAmount() returns (uint256 value) {
-            floor = value;
-        } catch {
-            revert DepositFloorUnavailable();
+        // high-level call to a codeless address reverts WITHOUT data.
+        if (bridge.code.length == 0) revert AmountFloorUnavailable();
+
+        if (side == CommissionSide.FUNDS_IN) {
+            try IBridgeAmountFloors(bridge).minFundsInAmount() returns (uint256 value) {
+                floor = value;
+            } catch {
+                revert AmountFloorUnavailable();
+            }
+        } else {
+            try IBridgeAmountFloors(bridge).minFundsOutAmount() returns (uint256 value) {
+                floor = value;
+            } catch {
+                revert AmountFloorUnavailable();
+            }
         }
-        if (floor == 0) revert DepositFloorUnavailable();
+
+        if (floor == 0) revert AmountFloorUnavailable();
     }
 
-    /// @dev Enforces that the effective rule still leaves a positive net for a
-    ///      deposit sitting exactly on the floor.
+    /// @dev Enforces that the effective rule still leaves a positive net for an
+    ///      operation sitting exactly on its side's floor — `minFundsInAmount`
+    ///      for a deposit, `minFundsOutAmount` for a release.
     ///
     ///      Checking at the floor is both necessary and sufficient: net is
     ///      `amount * (1 - stablePercent/multiplier^2) - baseFee`, which is
     ///      strictly increasing in `amount` because the configured proportional
     ///      rate is below 100% (`InvalidFeeShape`). So if the floor clears, every
-    ///      larger deposit clears too — and `baseFee < depositFloor` alone would
-    ///      NOT be sufficient, since the proportional part also consumes part of
-    ///      that floor.
-    function _requireFeeFitsDepositFloor(CommissionConfig memory config) private view {
+    ///      larger operation clears too — and `baseFee < floor` alone would NOT
+    ///      be sufficient, since the proportional part also consumes part of that
+    ///      floor.
+    function _requireFeeFitsAmountFloor(CommissionConfig memory config) private view {
         // Only a FLAT fee needs this bound. A purely proportional fee is already
         // held below 100% by `InvalidFeeShape`, so it leaves a positive net at
         // every amount on its own. Skipping the read here keeps the Bridge
         // dependency — and its failure mode — off the quote path of every route
-        // that charges no flat fee, which is every route that exists today.
+        // that charges no flat fee.
         if (config.baseFee == 0) return;
 
-        uint256 floor = _depositFloor();
+        uint256 floor = _amountFloor(config.side);
         uint256 feeAtFloor = calculateStableFee(floor, config.stablePercent, config.multiplier) + config.baseFee;
-        if (feeAtFloor >= floor) revert FeeAboveDepositFloor(feeAtFloor, floor);
+        if (feeAtFloor >= floor) revert FeeAboveAmountFloor(feeAtFloor, floor);
     }
 
     /// @inheritdoc ICommissionManager
@@ -453,30 +483,41 @@ contract CommissionManager is Ownable2Step, ReentrancyGuard, ICommissionManager 
         if (stablePercent >= uint256(multiplier) * uint256(multiplier)) {
             revert InvalidFeeShape(stablePercent, multiplier);
         }
+        // Protocol ceiling on the EFFECTIVE rate, checked after the "below 100%"
+        // shape bound so that an over-100% configuration keeps reporting
+        // `InvalidFeeShape` rather than being reclassified here.
+        //
+        // Cross-multiplied instead of computing `stablePercent * 10_000 /
+        // multiplier^2`, so a rate just above the ceiling cannot be truncated
+        // down onto it. Overflow-free: `stablePercent` is already bounded by
+        // `_MAX_STABLE_PERCENT`, and `multiplier` is uint8.
+        //
+        // At the conventional `multiplier == 100` this reduces to exactly
+        // `stablePercent <= 9000`, so no existing rule shape changes meaning.
+        if (stablePercent * _BPS_DENOMINATOR > _MAX_FEE_BPS * uint256(multiplier) * uint256(multiplier)) {
+            revert FeeRateTooHigh(stablePercent, multiplier);
+        }
         // NATIVE on FUNDS_OUT is unrepresentable: a release has no payer for a
         // native fee
         if (currency == CommissionCurrency.NATIVE && side == CommissionSide.FUNDS_OUT) {
             revert NativeCommissionNotAllowedOnFundsOut();
         }
-        // A flat fee is only bounded on the inbound side, where
-        // `minFundsInAmount` guarantees a minimum amount to charge it against.
-        // The release path has no such floor: a `baseFee` exceeding a small
-        // release would revert its quote, and because `burnId` is derived from
-        // the release intent that exact release could then never execute.
-        if (baseFee != 0 && side == CommissionSide.FUNDS_OUT) revert BaseFeeNotAllowedOnFundsOut();
-
-        if (side == CommissionSide.FUNDS_IN) {
-            _requireFeeFitsDepositFloor(
-                CommissionConfig({
-                    stablePercent: stablePercent,
-                    baseFee: baseFee,
-                    multiplier: multiplier,
-                    side: side,
-                    currency: currency,
-                    isSet: true
-                })
-            );
-        }
+        // A flat fee is bounded by its side's Bridge floor — `minFundsInAmount`
+        // for deposits, `minFundsOutAmount` for releases — each of which
+        // guarantees a minimum amount to charge it against. Without that bound a
+        // `baseFee` exceeding a small operation would revert its quote, and on
+        // the release side, because `burnId` is derived from the release intent,
+        // that exact release could then never execute.
+        _requireFeeFitsAmountFloor(
+            CommissionConfig({
+                stablePercent: stablePercent,
+                baseFee: baseFee,
+                multiplier: multiplier,
+                side: side,
+                currency: currency,
+                isSet: true
+            })
+        );
     }
 
     /// @inheritdoc ICommissionManager

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -53,12 +53,17 @@ contract MultisigProxy is IMultisigProxy {
     ///         not registered — used as the existence guard on the release path.
     mapping(uint256 sourceChainId => uint256) public enclaveThreshold;
 
-    /// @notice Registered enclave source chains, for enumeration and the
-    ///         cross-set disjointness checks. Bounded by `MAX_ENCLAVE_SOURCE_CHAINS`.
+    /// @notice Registered enclave source chains, for enumeration and for
+    ///         checking federation candidates against every enclave set.
+    ///         Bounded by `MAX_ENCLAVE_SOURCE_CHAINS`.
     uint256[] private _enclaveSourceChains;
 
     address[] private _federationSigners;
     uint256 public federationThreshold;
+
+    /// @notice Monotonic version of the federation signer set. Every proposal
+    ///         snapshots this value and becomes unexecutable after a rotation.
+    uint256 public federationSignerSetVersion;
 
     /// @notice Per-source-chain nonce for the typed TEE methods (`fundsOutCall`
     ///         / `lzFundsOutCall`). Each source chain has its own lane, so the
@@ -70,8 +75,8 @@ contract MultisigProxy is IMultisigProxy {
     /// @notice Federation proposals.
     mapping(bytes32 => Proposal) private _proposals;
 
-    /// @notice Sequential nonce for the regular federation lane: `_propose`
-    ///         (all typed proposals) and `cancelProposal`.
+    /// @notice Sequential nonce for the regular federation proposal lane
+    ///         (`_propose` and all typed proposal entrypoints).
     uint256 public proposalNonce;
 
     /// @notice Sequential nonce for the emergency lane: `emergencyPause` /
@@ -112,8 +117,8 @@ contract MultisigProxy is IMultisigProxy {
     uint256 public constant MAX_SIGNERS = 20;
 
     /// @notice Hard upper bound on the number of registered enclave source
-    ///         chains. Bounds the cross-set disjointness loop (run on every
-    ///         signer rotation), keeping governance updates gas-predictable.
+    ///         chains. Bounds the disjointness loop run on federation signer
+    ///         rotations, keeping governance updates gas-predictable.
     uint256 public constant MAX_ENCLAVE_SOURCE_CHAINS = 32;
 
     /// @notice Length of a Solidity function selector (`bytes4`) in bytes. Used
@@ -139,6 +144,14 @@ contract MultisigProxy is IMultisigProxy {
     ///         bypass the federation restriction.
     bytes4 private constant _SEL_FUNDS_OUT = IBridge.fundsOut.selector;
     bytes4 private constant _SEL_REBALANCE_LIQUIDITY = IBridge.rebalanceLiquidity.selector;
+
+    /// @notice CommissionManager rotation is reserved for the typed operation,
+    ///         which keeps the Bridge and proxy targets synchronized atomically.
+    bytes4 private constant _SEL_SET_COMMISSION_MANAGER = IBridge.setCommissionManager.selector;
+
+    /// @notice Ownership transfer is reserved for the typed managed-target
+    ///         operation and rejected from every generic raw-call lane.
+    bytes4 private constant _SEL_TRANSFER_OWNERSHIP = bytes4(keccak256("transferOwnership(address)"));
 
     uint256 private immutable _cachedChainId;
     bytes32 private immutable _cachedDomainSeparator;
@@ -170,6 +183,8 @@ contract MultisigProxy is IMultisigProxy {
         keccak256("ProposeUpdateBridge(address newBridge,uint256 nonce,uint256 deadline)");
     bytes32 private constant _PROPOSE_SET_TIMELOCK_DURATION_TYPEHASH =
         keccak256("ProposeSetTimelockDuration(uint256 newDuration,uint256 nonce,uint256 deadline)");
+    bytes32 private constant _PROPOSE_TRANSFER_MANAGED_OWNERSHIP_TYPEHASH =
+        keccak256("ProposeTransferManagedOwnership(address target,address newOwner,uint256 nonce,uint256 deadline)");
 
     // Federation propose — CommissionManager side
     bytes32 private constant _PROPOSE_ADMIN_EXECUTE_CM_TYPEHASH = keccak256(
@@ -201,7 +216,7 @@ contract MultisigProxy is IMultisigProxy {
 
     // Cancel
     bytes32 private constant _CANCEL_PROPOSAL_TYPEHASH =
-        keccak256("CancelProposal(bytes32 proposalId,uint256 nonce,uint256 deadline)");
+        keccak256("CancelProposal(bytes32 proposalId,uint256 deadline)");
 
     // Emergency
     bytes32 private constant _EMERGENCY_PAUSE_TYPEHASH = keccak256("EmergencyPause(uint256 nonce,uint256 deadline)");
@@ -253,6 +268,7 @@ contract MultisigProxy is IMultisigProxy {
         _enclaveSourceChains.push(initialEnclaveSourceChain_);
         _federationSigners = federationSigners_;
         federationThreshold = federationThreshold_;
+        federationSignerSetVersion = 1;
         timelockDuration = timelockDuration_;
         MIN_TIMELOCK = minTimelock_;
 
@@ -563,9 +579,7 @@ contract MultisigProxy is IMultisigProxy {
     ) external returns (bytes32) {
         // Validate the proposed set up front so a malformed rotation reverts
         // here instead of consuming a nonce + timelock slot and failing only at
-        // execution. Disjointness is intentionally left to execute time: it
-        // depends on the live federation and other enclave sets, which may
-        // change before then.
+        // execution.
         if (sourceChainId == 0) revert UnknownSourceChain(0);
         if (newSigners.length == 0) revert NoSigners();
         _requireValidThreshold(newThreshold, newSigners.length);
@@ -897,6 +911,32 @@ contract MultisigProxy is IMultisigProxy {
     }
 
     /// @inheritdoc IMultisigProxy
+    function proposeTransferManagedOwnership(
+        address target,
+        address newOwner,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32) {
+        _requireManagedOwnershipTarget(target);
+        if (newOwner == address(0)) revert ZeroNewOwner();
+
+        bytes32 structHash =
+            keccak256(abi.encode(_PROPOSE_TRANSFER_MANAGED_OWNERSHIP_TYPEHASH, target, newOwner, nonce, deadline));
+
+        return _propose(
+            OperationType.TransferManagedOwnership,
+            abi.encode(target, newOwner),
+            nonce,
+            deadline,
+            structHash,
+            fedBitmap,
+            fedSigs
+        );
+    }
+
+    /// @inheritdoc IMultisigProxy
     /// @dev Planned inflow-only pause: freezes deposits while leaving
     ///      withdrawals open (e.g. to migrate liquidity during an upgrade).
     ///      Runs through the timelocked propose -> execute path, so the
@@ -927,23 +967,17 @@ contract MultisigProxy is IMultisigProxy {
     // =========================================================================
 
     /// @inheritdoc IMultisigProxy
-    function cancelProposal(
-        bytes32 proposalId,
-        uint256 nonce,
-        uint256 deadline,
-        uint256 fedBitmap,
-        bytes[] calldata fedSigs
-    ) external {
+    function cancelProposal(bytes32 proposalId, uint256 deadline, uint256 fedBitmap, bytes[] calldata fedSigs)
+        external
+    {
         if (block.timestamp > deadline) revert Expired();
-        if (nonce != proposalNonce) revert InvalidNonce();
 
         Proposal storage p = _proposals[proposalId];
         if (p.status != ProposalStatus.Pending) revert NotPending();
 
-        bytes32 digest = _hashTypedData(keccak256(abi.encode(_CANCEL_PROPOSAL_TYPEHASH, proposalId, nonce, deadline)));
+        bytes32 digest = _hashTypedData(keccak256(abi.encode(_CANCEL_PROPOSAL_TYPEHASH, proposalId, deadline)));
         _verifySignatures(digest, fedBitmap, fedSigs, _federationSigners, federationThreshold);
 
-        proposalNonce++;
         p.status = ProposalStatus.Cancelled;
 
         emit ProposalCancelled(proposalId);
@@ -957,6 +991,9 @@ contract MultisigProxy is IMultisigProxy {
     function executeProposal(bytes32 proposalId, bytes calldata opData) external {
         Proposal storage p = _proposals[proposalId];
         if (p.status != ProposalStatus.Pending) revert NotPending();
+        if (p.federationVersion != federationSignerSetVersion) {
+            revert StaleFederationProposal(p.federationVersion, federationSignerSetVersion);
+        }
         // Enforce the timelock that was in force when the proposal was created,
         // not the current one — a later SetTimelockDuration cannot reschedule.
         if (block.timestamp < p.proposedAt + p.timelockSnapshot) revert TimelockActive();
@@ -1046,6 +1083,7 @@ contract MultisigProxy is IMultisigProxy {
             proposedAt: block.timestamp,
             deadline: deadline,
             timelockSnapshot: timelockDuration,
+            federationVersion: federationSignerSetVersion,
             opType: opType,
             status: ProposalStatus.Pending
         });
@@ -1071,11 +1109,9 @@ contract MultisigProxy is IMultisigProxy {
             if (newSigners.length == 0) revert NoSigners();
             _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
-            // Keep every trust domain independent: disjoint from the federation
-            // and from every *other* enclave source chain (skip this chain, so a
-            // partial rotation that keeps some of its own keys is allowed).
+            // Enclave keys may be reused by different source chains, but the
+            // enclave and federation trust domains must remain disjoint.
             _requireDisjoint(newSigners, _federationSigners);
-            _requireDisjointFromAllEnclaveSets(newSigners, sourceChainId);
 
             // Register a brand-new source chain (bounded); existing ones just
             // overwrite their set/threshold.
@@ -1094,10 +1130,12 @@ contract MultisigProxy is IMultisigProxy {
             _requireValidThreshold(newThreshold, newSigners.length);
             _validateSigners(newSigners);
             // Federation must stay disjoint from every enclave source-chain set.
-            _requireDisjointFromAllEnclaveSets(newSigners, 0);
+            _requireDisjointFromAllEnclaveSets(newSigners);
             _federationSigners = newSigners;
             federationThreshold = newThreshold;
+            federationSignerSetVersion++;
             emit FederationSignersUpdated(newSigners, newThreshold);
+            emit FederationSignerSetVersionUpdated(federationSignerSetVersion);
         } else if (opType == OperationType.UpdateBridge) {
             address newBridge = abi.decode(opData, (address));
             if (newBridge == address(0)) revert ZeroBridge();
@@ -1120,9 +1158,9 @@ contract MultisigProxy is IMultisigProxy {
             _propagateRevert(ok, ret);
         } else if (opType == OperationType.AdminExecuteRouteRegistry) {
             // opData = raw RouteRegistry callData. Registry resolved from Bridge
-            // (single source of truth), same as SetRoute. Enables ownership
-            // migration (transferOwnership / acceptOwnership) for the Ownable2Step
-            // RouteRegistry.
+            // (single source of truth), same as SetRoute. `acceptOwnership`
+            // remains available for Ownable2Step handoffs; initiating a transfer
+            // is reserved for the typed managed-ownership operation.
             _requireAllowedGenericSelector(_firstSelector(opData));
             address registry = IBridge(bridge).routeRegistry();
             if (registry == address(0)) revert ZeroTarget();
@@ -1146,6 +1184,7 @@ contract MultisigProxy is IMultisigProxy {
             address newCm = abi.decode(opData, (address));
             if (newCm == address(0)) revert ZeroCommissionManager();
             address old = commissionManager;
+            IBridge(bridge).setCommissionManager(newCm);
             commissionManager = newCm;
             emit CommissionManagerUpdated(old, newCm);
         } else if (opType == OperationType.AdminExecuteAdapter) {
@@ -1193,6 +1232,13 @@ contract MultisigProxy is IMultisigProxy {
         } else if (opType == OperationType.UnpauseInflow) {
             (bool ok, bytes memory ret) = bridge.call(abi.encodeWithSignature("unpauseInflow()"));
             _propagateRevert(ok, ret);
+        } else if (opType == OperationType.TransferManagedOwnership) {
+            (address target, address newOwner) = abi.decode(opData, (address, address));
+            _requireManagedOwnershipTarget(target);
+            if (newOwner == address(0)) revert ZeroNewOwner();
+            (bool ok, bytes memory ret) = target.call(abi.encodeWithSelector(_SEL_TRANSFER_OWNERSHIP, newOwner));
+            _propagateRevert(ok, ret);
+            emit ManagedOwnershipTransferStarted(target, newOwner);
         } else {
             revert UnknownOperationType();
         }
@@ -1284,15 +1330,13 @@ contract MultisigProxy is IMultisigProxy {
         }
     }
 
-    /// @dev Reverts if `candidate` overlaps any registered enclave source-chain
-    ///      set, skipping `exceptSourceChain` (pass `0` to skip none). Used to
-    ///      keep every enclave set disjoint from the others and from the
-    ///      federation. Cost is bounded by `MAX_ENCLAVE_SOURCE_CHAINS` *
-    ///      `MAX_SIGNERS` * candidate length.
-    function _requireDisjointFromAllEnclaveSets(address[] memory candidate, uint256 exceptSourceChain) private view {
+    /// @dev Reverts if a federation candidate overlaps any registered enclave
+    ///      source-chain set. Enclave sets may reuse keys across chains, but no
+    ///      such key may enter the federation trust domain. Cost is bounded by
+    ///      `MAX_ENCLAVE_SOURCE_CHAINS` * `MAX_SIGNERS` * candidate length.
+    function _requireDisjointFromAllEnclaveSets(address[] memory candidate) private view {
         uint256[] memory chains = _enclaveSourceChains;
         for (uint256 i = 0; i < chains.length; i++) {
-            if (chains[i] == exceptSourceChain) continue;
             _requireDisjoint(candidate, _enclaveSigners[chains[i]]);
         }
     }
@@ -1373,5 +1417,20 @@ contract MultisigProxy is IMultisigProxy {
     function _requireAllowedGenericSelector(bytes4 selector) private pure {
         _requireNotCommissionWithdrawSelector(selector);
         _requireNotBridgeReleaseSelector(selector);
+        if (selector == _SEL_SET_COMMISSION_MANAGER) revert ForbiddenCommissionManagerSelector(selector);
+        if (selector == _SEL_TRANSFER_OWNERSHIP) revert ForbiddenOwnershipSelector(selector);
+    }
+
+    /// @dev Restricts typed ownership migration to the proxy's current managed
+    ///      targets. Rechecked at execution so a target rotation cannot redirect
+    ///      or preserve authority for an address no longer governed here.
+    function _requireManagedOwnershipTarget(address target) private view {
+        if (target == address(0)) revert InvalidManagedOwnershipTarget(target);
+        if (target == bridge || target == commissionManager || target == lzAdapter) return;
+
+        address registry = IBridge(bridge).routeRegistry();
+        if (target == registry && registry != address(0)) return;
+
+        revert InvalidManagedOwnershipTarget(target);
     }
 }

--- a/ethereum/src/btc_relay/BtcRelay.sol
+++ b/ethereum/src/btc_relay/BtcRelay.sol
@@ -38,6 +38,10 @@ contract BtcRelay is IBtcRelay, IBtcRelayView {
     // only used during testing
     bool immutable _clampBlockTarget;
 
+    // The trusted initialization height. Headers below this checkpoint are not
+    // stored by this relay and must never be treated as part of its main chain.
+    uint32 immutable _checkpointHeight;
+
     //Initialize the btc relay with the provided stored_header
     constructor(StoredBlockHeader memory storedHeader, bool clampBlockTarget) {
         _clampBlockTarget = clampBlockTarget;
@@ -45,6 +49,7 @@ contract BtcRelay is IBtcRelay, IBtcRelayView {
         //Save the initial stored header
         bytes32 commitHash = storedHeader.hash();
         uint32 blockHeight = storedHeader.blockHeight();
+        _checkpointHeight = blockHeight;
         _mainChain[blockHeight] = commitHash;
         _relayState.write(
             blockHeight, uint224(storedHeader.chainWork() & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
@@ -63,8 +68,12 @@ contract BtcRelay is IBtcRelay, IBtcRelayView {
         uint256 mainBlockheight = _relayState.blockHeight;
         //Check that the block height isn't past the tip, this can happen if there is a reorg, where a shorter
         // chain becomes the cannonical one, this can happen due to the heaviest work rule (and not lonest chain rule)
+        require(height >= _checkpointHeight, "verify: before checkpoint");
         require(height <= mainBlockheight, "verify: future block");
 
+        // An unwritten mapping entry has the default zero value. Reject zero
+        // explicitly so it can never be presented as a real block commitment.
+        require(commitmentHash != bytes32(0), "verify: zero commitment");
         require(_mainChain[height] == commitmentHash, "verify: block commitment");
 
         confirmations = mainBlockheight - height + 1;

--- a/ethereum/src/btc_relay/BtcRelayTestnet.sol
+++ b/ethereum/src/btc_relay/BtcRelayTestnet.sol
@@ -42,6 +42,10 @@ contract BtcRelayTestnet is IBtcRelay, IBtcRelayView {
     // only used during testing
     bool immutable _clampBlockTarget;
 
+    // The trusted initialization height. Headers below this checkpoint are not
+    // stored by this relay and must never be treated as part of its main chain.
+    uint32 immutable _checkpointHeight;
+
     //Initialize the btc relay with the provided stored_header
     constructor(StoredBlockHeader memory storedHeader, bool clampBlockTarget) {
         _clampBlockTarget = clampBlockTarget;
@@ -49,6 +53,7 @@ contract BtcRelayTestnet is IBtcRelay, IBtcRelayView {
         //Save the initial stored header
         bytes32 commitHash = storedHeader.hash();
         uint32 blockHeight = storedHeader.blockHeight();
+        _checkpointHeight = blockHeight;
         _mainChain[blockHeight] = commitHash;
         _relayState.write(
             blockHeight, uint224(storedHeader.chainWork() & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
@@ -67,8 +72,12 @@ contract BtcRelayTestnet is IBtcRelay, IBtcRelayView {
         uint256 mainBlockheight = _relayState.blockHeight;
         //Check that the block height isn't past the tip, this can happen if there is a reorg, where a shorter
         // chain becomes the cannonical one, this can happen due to the heaviest work rule (and not lonest chain rule)
+        require(height >= _checkpointHeight, "verify: before checkpoint");
         require(height <= mainBlockheight, "verify: future block");
 
+        // An unwritten mapping entry has the default zero value. Reject zero
+        // explicitly so it can never be presented as a real block commitment.
+        require(commitmentHash != bytes32(0), "verify: zero commitment");
         require(_mainChain[height] == commitmentHash, "verify: block commitment");
 
         confirmations = mainBlockheight - height + 1;

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -13,6 +13,7 @@ interface IBridge {
     error AmountBelowMinimum(uint256 amount, uint256 minimum);
     error InsufficientReceived(uint256 received, uint256 tokenCommission);
     error InvalidMinFundsInAmount();
+    error InvalidMinFundsOutAmount();
     error AddressTooLong(uint256 length, uint256 maxLength);
     error ProofTooLong(uint256 length, uint256 maxLength);
     error SettlementDataTooLong(uint256 length, uint256 maxLength);
@@ -58,6 +59,11 @@ interface IBridge {
     /// @param oldMinimum Previous minimum (constructor value before first update).
     /// @param newMinimum New minimum (in token smallest units; always non-zero).
     event MinFundsInAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
+
+    /// @notice Emitted on every successful `setMinFundsOutAmount`.
+    /// @param oldMinimum Previous minimum (constructor value before first update).
+    /// @param newMinimum New minimum (in token smallest units; always non-zero).
+    event MinFundsOutAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
 
     /// @notice Emitted on `setOutflowLimit` (per-chain outflow token bucket).
     /// @param chainId             Source chain the limit applies to.
@@ -345,6 +351,21 @@ interface IBridge {
     /// @notice Current minimum accepted `fundsIn` deposit in token smallest
     ///         units. Always non-zero.
     function minFundsInAmount() external view returns (uint256);
+
+    /// @notice Updates the minimum accepted `fundsOut` release (token smallest
+    ///         units). Owner-only (MultisigProxy via the federation
+    ///         propose -> timelock -> execute flow). Must be non-zero; reverts
+    ///         `InvalidMinFundsOutAmount` otherwise.
+    function setMinFundsOutAmount(uint256 newMinimum) external;
+
+    /// @notice Current minimum accepted `fundsOut` release in token smallest
+    ///         units. Always non-zero.
+    /// @dev The outbound counterpart of `minFundsInAmount`. It bounds the flat
+    ///      `baseFee` a release route may charge, and independently caps how
+    ///      cheap an individual release can be — a swarm of dust releases costs
+    ///      the bridge Arbitrum gas and a per-operation source-chain fee that the
+    ///      released amount would not cover.
+    function minFundsOutAmount() external view returns (uint256);
 
     /// @notice Configure (or reconfigure) the per-chain outflow token bucket for
     ///         `chainId`. Owner-only (MultisigProxy timelock flow).

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.35;
 
+import {ICommissionManager} from "./ICommissionManager.sol";
+
 interface IBridge {
     // =========================================================================
     // Errors
@@ -55,6 +57,11 @@ interface IBridge {
     /// @param newRegistry New registry (non-zero by `setRouteRegistry` guard).
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
 
+    /// @notice Emitted on every successful `setCommissionManager`.
+    /// @param oldCommissionManager Previous CommissionManager address.
+    /// @param newCommissionManager New non-zero CommissionManager address.
+    event CommissionManagerUpdated(address indexed oldCommissionManager, address indexed newCommissionManager);
+
     /// @notice Emitted on every successful `setMinFundsInAmount`.
     /// @param oldMinimum Previous minimum (constructor value before first update).
     /// @param newMinimum New minimum (in token smallest units; always non-zero).
@@ -100,7 +107,7 @@ interface IBridge {
     /// @param rgbOpId RGB operation id, decoded by the route module from its
     ///                `settlementData`. Not an on-chain dedup key.
     /// @param amount  Net amount bridged (post-commission).
-    event FundsIn(address indexed sender, uint256 indexed rgbOpId, uint256 amount);
+    event FundsIn(address indexed sender, uint256 rgbOpId, uint256 amount);
 
     /// @param operationId        Canonical bridge-side operation id, derived
     ///                           on-chain by Bridge and unpredictable by third
@@ -342,6 +349,11 @@ interface IBridge {
     ///         `onFundsIn` / `beforeFundsOut` through. Owner-only.
     function setRouteRegistry(address newRouteRegistry) external;
 
+    /// @notice Updates the `CommissionManager` used for fee quotes and custody.
+    ///         Owner-only (MultisigProxy via the typed, timelocked
+    ///         `UpdateCommissionManager` operation). Must be non-zero.
+    function setCommissionManager(address newCommissionManager) external;
+
     /// @notice Updates the minimum accepted `fundsIn` deposit (token smallest
     ///         units). Owner-only (MultisigProxy via the federation
     ///         propose -> timelock -> execute flow). Must be non-zero; reverts
@@ -418,16 +430,15 @@ interface IBridge {
     ///         rolling window. Independent of the configurable token bucket.
     function availableGlobalSafetyOutflow() external view returns (uint256);
 
-    /// @notice Reference liquidity every percentage in this contract is measured
-    ///         against for `chainId`: accounted liquidity plus usage still
-    ///         counted in the rolling window. Constant while releases drain
-    ///         liquidity inside one window — each release moves the same amount
-    ///         from one term to the other — and it steps down to plain
-    ///         `lockedLiquidity` once that usage expires. Both the configurable
-    ///         bucket and the immutable safety limit are denominated against it.
+    /// @notice Current token-bucket reference for `chainId`, equal to its
+    ///         accounted locked liquidity. Rolling-window expiry cannot change
+    ///         this value by itself; only an actual liquidity debit, credit, or
+    ///         rebalance can do so. The immutable safety limiter separately uses
+    ///         `lockedLiquidity + rollingSpent` as its rolling reference.
     function chainOutflowReference(uint256 chainId) external view returns (uint256);
 
-    /// @notice Aggregate counterpart of `chainOutflowReference`.
+    /// @notice Aggregate token-bucket reference, equal to total accounted
+    ///         locked liquidity across all source chains.
     function globalOutflowReference() external view returns (uint256);
 
     /// @notice The amount `fundsOut` would actually permit for `chainId` right
@@ -443,6 +454,9 @@ interface IBridge {
 
     /// @notice Current `RouteRegistry` Bridge uses for route dispatch.
     function routeRegistry() external view returns (address);
+
+    /// @notice Current `CommissionManager` Bridge uses for fee quotes and custody.
+    function commissionManager() external view returns (ICommissionManager);
 
     /// @notice Permanently blocked — ownership cannot be renounced.
     function renounceOwnership() external view;

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -25,8 +25,15 @@ enum CommissionCurrency {
 }
 
 /// @notice Commission parameters for one directional route (keyed by `buildRouteKey`).
+/// @dev The effective fee is `amount * stablePercent / multiplier^2 + baseFee`:
+///      a proportional part plus a flat part. `baseFee` is denominated in the
+///      token's smallest units (the bridged token is a USD-pegged stablecoin, so
+///      it doubles as a USD figure) and exists to cover a per-operation cost that
+///      does not scale with the amount — notably the Bitcoin transaction fee on
+///      the RGB leg. Either part may be zero; both zero disables the route's fee.
 struct CommissionConfig {
     uint256 stablePercent;
+    uint256 baseFee;
     uint8 multiplier;
     CommissionSide side;
     CommissionCurrency currency;
@@ -50,6 +57,19 @@ interface ICommissionManager {
     error CommissionRoundsToZero(uint256 amount, uint256 stablePercent, uint8 multiplier);
     error ZeroNetAmount(uint256 amount, uint256 commission);
     error NativeCommissionNotAllowedOnFundsOut();
+
+    /// @notice The configured fee would consume a deposit sitting exactly on the
+    ///         Bridge's `minFundsInAmount` floor. Carries the total fee charged at
+    ///         the floor and the floor itself.
+    error FeeAboveDepositFloor(uint256 feeAtFloor, uint256 depositFloor);
+
+    /// @notice `baseFee` is currently only representable on the `FUNDS_IN` side —
+    ///         the release path has no minimum-amount floor to bound it against.
+    error BaseFeeNotAllowedOnFundsOut();
+
+    /// @notice The Bridge's `minFundsInAmount` could not be read (unset or
+    ///         non-contract `bridgeAddress`), so no fee can be validated or quoted.
+    error DepositFloorUnavailable();
     error TokenDecimalsUnavailable();
     error BalanceBelowRecordedPool();
     error NothingReceived();
@@ -77,7 +97,7 @@ interface ICommissionManager {
     event BridgeAddressUpdated(address indexed newBridge);
 
     event GlobalDefaultsUpdated(
-        uint256 stablePercent, uint8 multiplier, CommissionSide side, CommissionCurrency currency
+        uint256 stablePercent, uint256 baseFee, uint8 multiplier, CommissionSide side, CommissionCurrency currency
     );
 
     event CommissionRuleUpdated(
@@ -107,6 +127,8 @@ interface ICommissionManager {
     function commissionRecipient() external view returns (address);
 
     function globalStablePercent() external view returns (uint256);
+
+    function globalBaseFee() external view returns (uint256);
 
     function globalMultiplier() external view returns (uint8);
 
@@ -147,6 +169,18 @@ interface ICommissionManager {
         pure
         returns (uint256);
 
+    /// @notice Total fee for `amount` under the route's effective rule:
+    ///         `calculateStableFee(...) + baseFee`, in token smallest units.
+    function calculateTotalFee(uint256 sourceChainId, uint256 destChainId, address token, uint256 amount)
+        external
+        view
+        returns (uint256);
+
+    /// @notice The Bridge's current `minFundsInAmount`. Every configured fee must
+    ///         leave a positive net for a deposit sitting exactly on this floor;
+    ///         it is the bound `baseFee` is validated and quoted against.
+    function depositFloor() external view returns (uint256);
+
     /// @notice Convert a USD-denominated token fee (stablecoin, 1 token ≈ $1) to
     ///         native wei using the configured ETH/USD Chainlink feed. Reverts
     ///         `EthUsdFeedNotSet` when the price feed is unconfigured,
@@ -160,6 +194,7 @@ interface ICommissionManager {
 
     function setGlobalDefaults(
         uint256 stablePercent,
+        uint256 baseFee,
         uint8 multiplier,
         CommissionSide side,
         CommissionCurrency currency

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -228,7 +228,13 @@ interface ICommissionManager {
     function getGlobalDefaults()
         external
         view
-        returns (uint256 stablePercent, uint8 multiplier, CommissionSide side, CommissionCurrency currency);
+        returns (
+            uint256 stablePercent,
+            uint256 baseFee,
+            uint8 multiplier,
+            CommissionSide side,
+            CommissionCurrency currency
+        );
 
     function getCommissionRule(uint256 sourceChainId, uint256 destChainId, address token)
         external

--- a/ethereum/src/interfaces/ICommissionManager.sol
+++ b/ethereum/src/interfaces/ICommissionManager.sol
@@ -54,22 +54,12 @@ interface ICommissionManager {
     error StablePercentTooHigh();
     error MultiplierZero();
     error InvalidFeeShape(uint256 stablePercent, uint8 multiplier);
+    error FeeRateTooHigh(uint256 stablePercent, uint8 multiplier);
     error CommissionRoundsToZero(uint256 amount, uint256 stablePercent, uint8 multiplier);
     error ZeroNetAmount(uint256 amount, uint256 commission);
     error NativeCommissionNotAllowedOnFundsOut();
-
-    /// @notice The configured fee would consume a deposit sitting exactly on the
-    ///         Bridge's `minFundsInAmount` floor. Carries the total fee charged at
-    ///         the floor and the floor itself.
-    error FeeAboveDepositFloor(uint256 feeAtFloor, uint256 depositFloor);
-
-    /// @notice `baseFee` is currently only representable on the `FUNDS_IN` side —
-    ///         the release path has no minimum-amount floor to bound it against.
-    error BaseFeeNotAllowedOnFundsOut();
-
-    /// @notice The Bridge's `minFundsInAmount` could not be read (unset or
-    ///         non-contract `bridgeAddress`), so no fee can be validated or quoted.
-    error DepositFloorUnavailable();
+    error FeeAboveAmountFloor(uint256 feeAtFloor, uint256 amountFloor);
+    error AmountFloorUnavailable();
     error TokenDecimalsUnavailable();
     error BalanceBelowRecordedPool();
     error NothingReceived();
@@ -176,10 +166,15 @@ interface ICommissionManager {
         view
         returns (uint256);
 
-    /// @notice The Bridge's current `minFundsInAmount`. Every configured fee must
-    ///         leave a positive net for a deposit sitting exactly on this floor;
-    ///         it is the bound `baseFee` is validated and quoted against.
+    /// @notice The Bridge's current `minFundsInAmount`. Every configured
+    ///         `FUNDS_IN` fee must leave a positive net for a deposit sitting
+    ///         exactly on this floor; it is the bound an inbound `baseFee` is
+    ///         validated and quoted against.
     function depositFloor() external view returns (uint256);
+
+    /// @notice The Bridge's current `minFundsOutAmount` — the same bound for the
+    ///         release side.
+    function releaseFloor() external view returns (uint256);
 
     /// @notice Convert a USD-denominated token fee (stablecoin, 1 token ≈ $1) to
     ///         native wei using the configured ETH/USD Chainlink feed. Reverts

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -74,6 +74,10 @@ interface IMultisigProxy {
     error ZeroTarget();
     error ForbiddenCommissionManagerSelector(bytes4 selector);
     error ForbiddenBridgeReleaseSelector(bytes4 selector);
+    error ForbiddenOwnershipSelector(bytes4 selector);
+    error InvalidManagedOwnershipTarget(address target);
+    error ZeroNewOwner();
+    error StaleFederationProposal(uint256 proposalVersion, uint256 currentVersion);
     error LZAdapterNotSet();
     error InvalidLZAdapter();
 
@@ -98,7 +102,8 @@ interface IMultisigProxy {
         PauseInflow, // 13 — Bridge.pauseInflow()  (planned inflow-only freeze, timelocked)
         UnpauseInflow, // 14 — Bridge.unpauseInflow()
         DisableLZAdapter, // 15 — clear the routing target (explicit disable, distinct from UpdateLZAdapter rotation)
-        AdminExecuteRouteRegistry // 16 — generic call into RouteRegistry (transferOwnership/acceptOwnership, setRoute, …)
+        AdminExecuteRouteRegistry, // 16 — generic call into RouteRegistry (acceptOwnership, config, …)
+        TransferManagedOwnership // 17 — typed Ownable2Step transfer for an allowlisted governance target
     }
 
     enum ProposalStatus {
@@ -130,6 +135,7 @@ interface IMultisigProxy {
         uint256 proposedAt;
         uint256 deadline;
         uint256 timelockSnapshot;
+        uint256 federationVersion;
         OperationType opType;
         ProposalStatus status;
     }
@@ -171,6 +177,8 @@ interface IMultisigProxy {
     // Emitted when proposals are executed
     event EnclaveSignersUpdated(uint256 indexed sourceChainId, address[] newSigners, uint256 newThreshold);
     event FederationSignersUpdated(address[] newSigners, uint256 newThreshold);
+    event FederationSignerSetVersionUpdated(uint256 indexed newVersion);
+    event ManagedOwnershipTransferStarted(address indexed target, address indexed newOwner);
     event BridgeAddressUpdated(address indexed oldBridge, address indexed newBridge);
     event CommissionManagerUpdated(address indexed oldCm, address indexed newCm);
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
@@ -299,8 +307,8 @@ interface IMultisigProxy {
 
     /// @notice Propose a permitted generic call into the CommissionManager.
     /// @dev Used for rare configuration: setCommissionRule, setGlobalDefaults,
-    ///      setMockTokenToNativeRate, setBridgeAddress, transferOwnership, …
-    ///      Withdrawal selectors are reserved for the typed operations.
+    ///      setMockTokenToNativeRate, setBridgeAddress, … Withdrawal and
+    ///      ownership-transfer selectors are reserved for typed operations.
     /// @dev opData = raw ABI-encoded CommissionManager callData (selector + args).
     function proposeAdminExecuteCommissionManager(
         bytes calldata callData,
@@ -312,10 +320,10 @@ interface IMultisigProxy {
 
     // --- RouteRegistry-targeted operations ---
 
-    /// @notice Propose an arbitrary call into the RouteRegistry (resolved from
-    ///         Bridge). Enables ownership migration (`transferOwnership` /
-    ///         `acceptOwnership`) now that RouteRegistry is `Ownable2Step`,
-    ///         alongside the dedicated `SetRoute` op.
+    /// @notice Propose an arbitrary permitted call into the RouteRegistry
+    ///         (resolved from Bridge), alongside the dedicated `SetRoute` op.
+    ///         `acceptOwnership` remains available here; `transferOwnership`
+    ///         must use `proposeTransferManagedOwnership`.
     /// @dev opData = raw ABI-encoded RouteRegistry callData (selector + args).
     function proposeAdminExecuteRouteRegistry(
         bytes calldata callData,
@@ -348,7 +356,8 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose migrating to a new CommissionManager address.
+    /// @notice Propose migrating Bridge and this proxy to a new
+    ///         CommissionManager address atomically.
     /// @dev opData = abi.encode(address newCommissionManager)
     function proposeUpdateCommissionManager(
         address newCommissionManager,
@@ -427,6 +436,21 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
+    /// @notice Propose an Ownable2Step ownership transfer for a contract under
+    ///         this proxy's governance.
+    /// @dev `target` must be the current Bridge, CommissionManager, LZAdapter,
+    ///      or Bridge RouteRegistry both when proposed and when executed. The
+    ///      exact target and new owner are bound into the EIP-712 signature.
+    ///      opData = abi.encode(address target, address newOwner).
+    function proposeTransferManagedOwnership(
+        address target,
+        address newOwner,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 fedBitmap,
+        bytes[] calldata fedSigs
+    ) external returns (bytes32);
+
     /// @notice Propose a planned inflow-only pause on Bridge (`pauseInflow`).
     /// @dev Freezes deposits while leaving withdrawals open — intended for a
     ///      bridge upgrade / liquidity migration. Runs through the timelocked
@@ -447,13 +471,8 @@ interface IMultisigProxy {
     // =========================================================================
 
     /// @notice Cancel a pending proposal. Requires M-of-N federation signatures.
-    function cancelProposal(
-        bytes32 proposalId,
-        uint256 nonce,
-        uint256 deadline,
-        uint256 fedBitmap,
-        bytes[] calldata fedSigs
-    ) external;
+    /// @dev The authorization is bound directly to `proposalId`;
+    function cancelProposal(bytes32 proposalId, uint256 deadline, uint256 fedBitmap, bytes[] calldata fedSigs) external;
 
     /// @notice Execute a proposal after the timelock has elapsed. Permissionless.
     /// @param proposalId The proposal to execute.
@@ -482,7 +501,7 @@ interface IMultisigProxy {
     function enclaveThreshold(uint256 sourceChainId) external view returns (uint256);
     function getFederationSigners() external view returns (address[] memory);
     function federationThreshold() external view returns (uint256);
-    /// @notice Immutable recipient reported by the current CommissionManager.
+    function federationSignerSetVersion() external view returns (uint256);
     function commissionRecipient() external view returns (address);
     function DOMAIN_SEPARATOR() external view returns (bytes32);
     function proposalNonce() external view returns (uint256);

--- a/ethereum/src/settlement/RgbOutboundSettlementModule.sol
+++ b/ethereum/src/settlement/RgbOutboundSettlementModule.sol
@@ -8,15 +8,10 @@ import {RgbSettlementModule} from "./RgbSettlementModule.sol";
 /// @title RgbOutboundSettlementModule
 /// @notice `ISettlementModule` for rebalance routes whose DEBIT side is an RGB
 ///         network but whose CREDIT side is NOT an RGB network, so no RGB
-///         bookkeeping is needed on credit — e.g. `(RGB, Arch)`: liquidity
-///         migrates toward Arch, nothing is minted on an RGB network, so the
-///         credit writes no record and emits no `FundsIn`.
-///
-///         Routes where BOTH sides are RGB networks (e.g. mint/burn ↔ pool) do
-///         NOT use this module: they use the canonical `RgbSettlementModule`,
-///         whose credit hook writes the destination-network record (tagged via
-///         `fundsInRecordChainIds`) so a later release from that network can
-///         reference it.
+///         bookkeeping is needed on credit — e.g. `(RGB, Arch)` or
+///         `(RGB mint/burn, RGB pool)`: liquidity migrates to a destination
+///         which must not create a mint/burn ledger record, so the credit writes
+///         nothing and emits no RGB-specific `FundsIn`.
 ///
 /// @dev The debit-side check must read the SAME `fundsInRecords` ledger the
 ///      canonical `RgbSettlementModule` of that RGB network writes — a burn

--- a/ethereum/src/settlement/RgbPoolSettlementModule.sol
+++ b/ethereum/src/settlement/RgbPoolSettlementModule.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import {ISettlementModule} from "../interfaces/ISettlementModule.sol";
+import {FundsInContext, FundsOutContext} from "../interfaces/RouteTypes.sol";
+import {RgbSettlementModule} from "./RgbSettlementModule.sol";
+
+/// @title RgbPoolSettlementModule
+/// @notice Settlement adapter for an RGB liquidity-pool network whose backing
+///         records live in a separate RGB mint/burn network's canonical
+///         `RgbSettlementModule` ledger.
+///
+/// @dev The pool network deliberately has asymmetric settlement semantics:
+///
+///      - credit (`onFundsIn`, e.g. Arbitrum -> Pool): write no canonical
+///        record and return no RGB OpId. Bridge therefore emits only its
+///        route-agnostic `BridgeFundsIn` event, not the RGB mint/burn `FundsIn`
+///        event;
+///      - debit (`beforeFundsOut`, e.g. Pool -> Arbitrum): verify every supplied
+///        Bridge operation id against the canonical mint/burn ledger. Records
+///        must exist, match the supplied amount exactly, and be tagged with the
+///        immutable backing mint/burn chain id.
+///
+///      Both chain ids are immutable to make an accidental route wiring error
+///      fail closed. This module is intended for the physical public-chain <->
+///      pool routes. MintBurn -> Pool rebalances use
+///      `RgbOutboundSettlementModule` (canonical debit check, no pool credit
+///      write); Pool -> MintBurn rebalances use `RgbSettlementModule` so the
+///      mint/burn credit leg creates its canonical record.
+contract RgbPoolSettlementModule is ISettlementModule {
+    // =========================================================================
+    // Errors
+    // =========================================================================
+
+    error InvalidRouteRegistry();
+    error InvalidRgbModule();
+    error InvalidPoolChainId();
+    error InvalidBackingRecordChainId();
+    error IdenticalChainIds();
+    error NotRouteRegistry();
+    error UnexpectedPoolDestination(uint256 expected, uint256 actual);
+    error UnexpectedPoolSource(uint256 expected, uint256 actual);
+    error FundsInNotFound(bytes32 operationId);
+    error AmountMismatch(bytes32 operationId, uint256 provided, uint256 recorded);
+    error FundsInRecordChainMismatch(bytes32 operationId, uint256 expected, uint256 recorded);
+    error SettlementDataLengthMismatch();
+    error EmptySettlementRecords();
+
+    // =========================================================================
+    // Immutables
+    // =========================================================================
+
+    /// @notice The only RouteRegistry authorised to invoke either hook.
+    address public immutable routeRegistry;
+
+    /// @notice Canonical ledger written by the RGB mint/burn routes.
+    RgbSettlementModule public immutable rgbModule;
+
+    /// @notice Backend-assigned chain id of the RGB liquidity-pool network.
+    uint256 public immutable poolChainId;
+
+    /// @notice RGB mint/burn chain id whose records back pool withdrawals.
+    uint256 public immutable backingRecordChainId;
+
+    modifier onlyRouteRegistry() {
+        if (msg.sender != routeRegistry) revert NotRouteRegistry();
+        _;
+    }
+
+    constructor(address routeRegistry_, address rgbModule_, uint256 poolChainId_, uint256 backingRecordChainId_) {
+        if (routeRegistry_ == address(0)) revert InvalidRouteRegistry();
+        if (rgbModule_ == address(0)) revert InvalidRgbModule();
+        if (poolChainId_ == 0) revert InvalidPoolChainId();
+        if (backingRecordChainId_ == 0) revert InvalidBackingRecordChainId();
+        if (poolChainId_ == backingRecordChainId_) revert IdenticalChainIds();
+
+        routeRegistry = routeRegistry_;
+        rgbModule = RgbSettlementModule(rgbModule_);
+        poolChainId = poolChainId_;
+        backingRecordChainId = backingRecordChainId_;
+    }
+
+    /// @inheritdoc ISettlementModule
+    /// @dev Pool credits have no mint/burn bookkeeping. Returning zero is what
+    ///      suppresses Bridge's RGB-specific `FundsIn` event.
+    function onFundsIn(FundsInContext calldata ctx, bytes calldata)
+        external
+        view
+        override
+        onlyRouteRegistry
+        returns (uint256)
+    {
+        if (ctx.destChainId != poolChainId) {
+            revert UnexpectedPoolDestination(poolChainId, ctx.destChainId);
+        }
+        return 0;
+    }
+
+    /// @inheritdoc ISettlementModule
+    /// @dev `settlementData = abi.encode(bytes32[] operationIds, uint256[] amounts)`.
+    ///      The operation ids are the canonical Bridge ids, not RGB OpIds.
+    function beforeFundsOut(FundsOutContext calldata ctx, bytes calldata settlementData)
+        external
+        view
+        override
+        onlyRouteRegistry
+    {
+        if (ctx.sourceChainId != poolChainId) {
+            revert UnexpectedPoolSource(poolChainId, ctx.sourceChainId);
+        }
+
+        (bytes32[] memory operationIds, uint256[] memory amounts) = abi.decode(settlementData, (bytes32[], uint256[]));
+
+        if (operationIds.length != amounts.length) revert SettlementDataLengthMismatch();
+        if (operationIds.length == 0) revert EmptySettlementRecords();
+
+        for (uint256 i = 0; i < operationIds.length; i++) {
+            uint256 recorded = rgbModule.fundsInRecords(operationIds[i]);
+            if (recorded == 0) revert FundsInNotFound(operationIds[i]);
+            if (recorded != amounts[i]) revert AmountMismatch(operationIds[i], amounts[i], recorded);
+
+            uint256 recordChainId = rgbModule.fundsInRecordChainIds(operationIds[i]);
+            if (recordChainId != backingRecordChainId) {
+                revert FundsInRecordChainMismatch(operationIds[i], backingRecordChainId, recordChainId);
+            }
+        }
+    }
+}

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -24,6 +24,7 @@ import {FeeOnTransferERC20} from "./mocks/FeeOnTransferERC20.sol";
 import {MockBtcRelay} from "./mocks/MockBtcRelay.sol";
 import {MockAggregatorV3} from "./mocks/MockAggregatorV3.sol";
 import {MockSettlementModule} from "./mocks/MockSettlementModule.sol";
+import {MockDepositFloor} from "./mocks/MockDepositFloor.sol";
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
@@ -59,6 +60,7 @@ contract BridgeTest is Test {
     event LZAdapterDisabled(address indexed oldAdapter);
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
     event MinFundsInAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
+    event MinFundsOutAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
     event OutflowLimitUpdated(uint256 indexed chainId, uint256 capacity, uint256 refillRate, uint256 available);
     event GlobalOutflowLimitUpdated(uint256 capacity, uint256 refillRate, uint256 available);
 
@@ -129,7 +131,8 @@ contract BridgeTest is Test {
             address(routeRegistry),
             payable(address(cm)),
             address(0),
-            1 // minFundsInAmount: smallest non-zero floor; cases that need a higher floor deploy their own Bridge
+            1, // minFundsInAmount: smallest non-zero floor; cases that need a higher floor deploy their own Bridge
+            1 // minFundsOutAmount: smallest non-zero floor for tests
         );
 
         rgbVerifier = new RGBVerifier(address(btcRelay), 6, 1, 5);
@@ -343,6 +346,7 @@ contract BridgeTest is Test {
             address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_IN,
                 currency: CommissionCurrency.TOKEN,
@@ -359,6 +363,7 @@ contract BridgeTest is Test {
             address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_IN,
                 currency: CommissionCurrency.NATIVE,
@@ -375,6 +380,7 @@ contract BridgeTest is Test {
             address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_OUT,
                 currency: CommissionCurrency.TOKEN,
@@ -391,6 +397,7 @@ contract BridgeTest is Test {
             address(usdt0),
             CommissionConfig({
                 stablePercent: percent,
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_OUT,
                 currency: CommissionCurrency.NATIVE,
@@ -475,23 +482,23 @@ contract BridgeTest is Test {
 
     function test_constructor_revertsOnZeroToken() public {
         vm.expectRevert(BridgeBase.InvalidTokenAddress.selector);
-        new Bridge(address(0), address(routeRegistry), payable(address(cm)), address(0), 1);
+        new Bridge(address(0), address(routeRegistry), payable(address(cm)), address(0), 1, 1);
     }
 
     function test_constructor_revertsOnZeroRouteRegistry() public {
         vm.expectRevert(IBridge.InvalidRouteRegistryAddress.selector);
-        new Bridge(address(usdt0), address(0), payable(address(cm)), address(0), 1);
+        new Bridge(address(usdt0), address(0), payable(address(cm)), address(0), 1, 1);
     }
 
     function test_constructor_revertsOnZeroCommissionManager() public {
         vm.expectRevert(IBridge.InvalidCommissionManagerAddress.selector);
-        new Bridge(address(usdt0), address(routeRegistry), payable(address(0)), address(0), 1);
+        new Bridge(address(usdt0), address(routeRegistry), payable(address(0)), address(0), 1, 1);
     }
 
     function test_constructor_storesInitialLZAdapter() public {
         address initialAdapter = makeAddr("initial-adapter");
         vm.prank(deployer);
-        Bridge b = new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), initialAdapter, 1);
+        Bridge b = new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), initialAdapter, 1, 1);
         assertEq(b.lzAdapter(), initialAdapter, "lzAdapter set in constructor");
     }
 
@@ -583,13 +590,13 @@ contract BridgeTest is Test {
 
     function test_constructor_storesMinFundsInAmount() public {
         vm.prank(deployer);
-        Bridge b = new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 1234);
+        Bridge b = new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 1234, 1);
         assertEq(b.minFundsInAmount(), 1234, "minFundsInAmount stored from constructor");
     }
 
     function test_constructor_revertsOnZeroMinFundsInAmount() public {
         vm.expectRevert(IBridge.InvalidMinFundsInAmount.selector);
-        new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 0);
+        new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 0, 1);
     }
 
     function test_setMinFundsInAmount_updatesAndEmits() public {
@@ -611,6 +618,106 @@ contract BridgeTest is Test {
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         bridge.setMinFundsInAmount(1000);
+    }
+
+    // --- Minimum fundsOut amount (outbound mirror) ---
+
+    function test_constructor_storesMinFundsOutAmount() public {
+        vm.prank(deployer);
+        Bridge b = new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 1, 4321);
+        assertEq(b.minFundsOutAmount(), 4321, "minFundsOutAmount stored from constructor");
+    }
+
+    function test_constructor_revertsOnZeroMinFundsOutAmount() public {
+        vm.expectRevert(IBridge.InvalidMinFundsOutAmount.selector);
+        new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 1, 0);
+    }
+
+    function test_setMinFundsOutAmount_updatesAndEmits() public {
+        vm.expectEmit(false, false, false, true, address(bridge));
+        emit MinFundsOutAmountUpdated(1, 2000);
+
+        vm.prank(multisig);
+        bridge.setMinFundsOutAmount(2000);
+        assertEq(bridge.minFundsOutAmount(), 2000);
+    }
+
+    function test_setMinFundsOutAmount_revertsOnZero() public {
+        vm.prank(multisig);
+        vm.expectRevert(IBridge.InvalidMinFundsOutAmount.selector);
+        bridge.setMinFundsOutAmount(0);
+    }
+
+    function test_setMinFundsOutAmount_revertsIfNotOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.setMinFundsOutAmount(2000);
+    }
+
+    /// @dev The floor is an on-chain backstop for a limit the TEE is not known
+    ///      to enforce: a dust release costs the bridge more to settle than it
+    ///      moves.
+    function test_fundsOut_revertsBelowMinFundsOutAmount() public {
+        _seedRGB(1000 ether);
+
+        vm.prank(multisig);
+        bridge.setMinFundsOutAmount(1 ether);
+
+        vm.expectRevert(abi.encodeWithSelector(IBridge.AmountBelowMinimum.selector, 1 ether - 1, 1 ether));
+        _releaseRGB(1 ether - 1, BURN_ID);
+    }
+
+    function test_fundsOut_acceptsExactlyMinFundsOutAmount() public {
+        _seedRGB(1000 ether);
+
+        vm.prank(multisig);
+        bridge.setMinFundsOutAmount(1 ether);
+
+        uint256 before = usdt0.balanceOf(recipient);
+        _releaseRGB(1 ether, BURN_ID);
+        assertEq(usdt0.balanceOf(recipient) - before, 1 ether, "release at the floor goes through");
+    }
+
+    /// @dev End-to-end mirror of the inbound flat-fee case: a `FUNDS_OUT` rule
+    ///      with a `baseFee` deducts percentage + flat from the release and
+    ///      forwards both to the CommissionManager pool.
+    function test_fundsOut_baseFeeRoutesToCMOnTopOfPercentage() public {
+        _seedRGB(1000 ether);
+
+        uint256 percent = 400; // 4%
+        uint256 baseFee = 1 ether;
+
+        // The flat fee must fit under the release floor.
+        vm.prank(multisig);
+        bridge.setMinFundsOutAmount(10 ether);
+
+        vm.prank(deployer);
+        cm.setCommissionRule(
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            address(usdt0),
+            CommissionConfig({
+                stablePercent: percent,
+                baseFee: baseFee,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_OUT,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        uint256 release = 100 ether;
+        uint256 expectedCommission = (release * percent) / 100 / 100 + baseFee;
+
+        uint256 recipientBefore = usdt0.balanceOf(recipient);
+        uint256 poolBefore = cm.tokenCommissionPool(address(usdt0));
+
+        _releaseRGB(release, BURN_ID);
+
+        assertEq(usdt0.balanceOf(recipient) - recipientBefore, release - expectedCommission, "recipient gets net");
+        assertEq(
+            cm.tokenCommissionPool(address(usdt0)) - poolBefore, expectedCommission, "pool holds percentage + flat"
+        );
     }
 
     // --- Zero amount ---
@@ -2209,6 +2316,47 @@ contract BridgeTest is Test {
         assertEq(rgbModule.fundsInRecords(opId), expectedNet, "record = net");
     }
 
+    // The flat `baseFee` rides the same path as the proportional part: it is
+    // deducted from the deposit, forwarded to the CommissionManager pool, and
+    // the settlement record is written against the resulting net.
+    function test_fundsIn_baseFeeRoutesToCMOnTopOfPercentage() public {
+        uint256 percent = 400; // 4%
+        uint256 baseFee = 1e18;
+
+        // The harness floor is 1 wei-unit, which no flat fee can sit under.
+        // Raise it to a realistic value first: at a 10e18 floor the combined fee
+        // is 0.4e18 + 1e18, comfortably below it.
+        vm.prank(bridge.owner());
+        bridge.setMinFundsInAmount(10e18);
+
+        vm.prank(deployer);
+        cm.setCommissionRule(
+            SOURCE_CHAIN_ID,
+            RGB_CHAIN_ID,
+            address(usdt0),
+            CommissionConfig({
+                stablePercent: percent,
+                baseFee: baseFee,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_IN,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        uint256 expectedCommission = (AMOUNT * percent) / 100 / 100 + baseFee;
+        uint256 expectedNet = AMOUNT - expectedCommission;
+
+        vm.prank(user);
+        bytes32 opId = bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        assertEq(usdt0.balanceOf(address(bridge)), expectedNet, "bridge net");
+        assertEq(usdt0.balanceOf(address(cm)), expectedCommission, "cm pool holds percentage + flat");
+        assertEq(cm.tokenCommissionPool(address(usdt0)), expectedCommission, "cm recorded");
+        assertEq(rgbModule.fundsInRecords(opId), expectedNet, "record = net");
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), expectedNet, "liquidity credited net");
+    }
+
     // A token already donated directly to the CommissionManager is NOT absorbed
     // as commission. Bridge measures the delta of its own transfer,
     // so the pool grows by exactly the real fee; the donation stays a stray balance.
@@ -2884,8 +3032,10 @@ contract BridgeTest is Test {
 
         // Misconfigure only the CM bridge guard so the route/RGB write happens
         // before commission forwarding fails in receiveTokenCommission().
+        // Deploy the stub BEFORE the prank — as a call argument it would consume it.
+        address wrongBridge = _wrongBridgeWithFloor();
         vm.prank(deployer);
-        cm.setBridgeAddress(makeAddr("wrong-bridge"));
+        cm.setBridgeAddress(wrongBridge);
 
         uint256 userBefore = usdt0.balanceOf(user);
         uint256 bridgeBefore = usdt0.balanceOf(address(bridge));
@@ -3314,6 +3464,17 @@ contract BridgeTest is Test {
         }
     }
 
+    /// @dev A contract that is NOT the Bridge but still answers the deposit-floor
+    ///      query the CommissionManager makes while quoting. Pointing CM's
+    ///      `bridgeAddress` here isolates the failure to `receiveTokenCommission`
+    ///      (`OnlyBridge`) — a codeless address would instead fail earlier, at the
+    ///      quote, with `AmountFloorUnavailable`.
+    function _wrongBridgeWithFloor() internal returns (address) {
+        MockDepositFloor stub = new MockDepositFloor();
+        stub.setMinFundsInAmount(bridge.minFundsInAmount());
+        return address(stub);
+    }
+
     function _assertFundsInRevertPathLeavesStateUnchanged(uint256 amount, uint8 failureMode) internal {
         bytes memory expectedRevert;
         MockSettlementModule revertingModule;
@@ -3332,8 +3493,10 @@ contract BridgeTest is Test {
             expectedRevert = abi.encodeWithSelector(MockSettlementModule.MockModuleForcedRevert.selector);
         } else if (failureMode == 2) {
             _setFundsInTokenRule(400); // 4%, positive for the fuzzed amount range.
+            // Deploy the stub BEFORE the prank — as a call argument it would consume it.
+            address wrongBridge = _wrongBridgeWithFloor();
             vm.prank(deployer);
-            cm.setBridgeAddress(makeAddr("wrong-bridge-for-fuzz"));
+            cm.setBridgeAddress(wrongBridge);
             expectedRevert = abi.encodeWithSelector(ICommissionManager.OnlyBridge.selector);
         } else if (failureMode == 3) {
             _setFundsInNativeRule(100); // Positive native quote for the fuzzed amount range.
@@ -3456,6 +3619,7 @@ contract BridgeTest is Test {
     function test_hundredPercentRouteRuleCannotBeConfigured() public {
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 8_100,
+            baseFee: 0,
             multiplier: 90,
             side: CommissionSide.FUNDS_IN,
             currency: CommissionCurrency.TOKEN,
@@ -3614,7 +3778,7 @@ contract BridgeTest is Test {
 
         s.cm = new CommissionManager(predictedBridge, recipient);
         RouteRegistry feeRouteRegistry = new RouteRegistry(predictedBridge, deployer);
-        s.bridge = new Bridge(address(s.token), address(feeRouteRegistry), payable(address(s.cm)), address(0), 1);
+        s.bridge = new Bridge(address(s.token), address(feeRouteRegistry), payable(address(s.cm)), address(0), 1, 1);
 
         // Reuse the suite's RGB verifier (shares `btcRelay` + `_proof()`); a
         // fresh module is bound to this stack's route registry.
@@ -3651,6 +3815,7 @@ contract BridgeTest is Test {
                 address(s.token),
                 CommissionConfig({
                     stablePercent: stablePercent,
+                    baseFee: 0,
                     multiplier: multiplier,
                     side: CommissionSide.FUNDS_IN,
                     currency: CommissionCurrency.TOKEN,
@@ -3811,19 +3976,16 @@ contract BridgeTest is Test {
 
     // --- Received <= tokenCommission reverts InsufficientReceived ---
     //
-    // Fee = 9000 bps (90%) → received = 10% of AMOUNT = 10e18. The fee-shape
-    // guard caps the commission fraction at `stablePercent / multiplier^2`
-    // (stablePercent ≤ 9000, stablePercent < multiplier^2). Choosing
-    // multiplier = 95, stablePercent = 9000 yields a fraction 9000/9025 ≈ 99.7%,
-    // so the commission quote on the NOMINAL AMOUNT (~99.7e18) far exceeds the
-    // actual received (10e18) — configurable within the guard, so no boundary
-    // compromise is needed.
+    // Token transfer fee = 9000 bps (90%) → received = 10% of AMOUNT = 10e18.
+    // The commission is quoted on the NOMINAL amount, so the protocol maximum
+    // rate of 90% (`_MAX_FEE_BPS`) already puts the quote at 90e18 — far above
+    // the 10e18 that actually arrived, which is what this path must reject.
     function test_fundsIn_feeToken_revertsWhenFeeExceedsCommission() public {
         FeeStack memory s = _deployFeeStack(9000); // 90% transfer fee
-        _setFeeStackFundsInTokenRule(s, 9000, 95); // ~99.7% commission on nominal
+        _setFeeStackFundsInTokenRule(s, 9000, 100); // 90% commission on nominal — the ceiling
 
         uint256 received = AMOUNT - s.token.feeOn(AMOUNT);
-        uint256 tokenCommission = s.cm.calculateStableFee(AMOUNT, 9000, 95);
+        uint256 tokenCommission = s.cm.calculateStableFee(AMOUNT, 9000, 100);
 
         assertEq(received, AMOUNT / 10, "sanity: received == 10% of nominal");
         assertGt(tokenCommission, received, "sanity: commission exceeds actual received");

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.35;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 
 import {Bridge} from "../src/Bridge.sol";
 import {IBridge} from "../src/interfaces/IBridge.sol";
@@ -32,7 +32,7 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract BridgeTest is Test {
     // Events re-declared locally for vm.expectEmit
-    event FundsIn(address indexed sender, uint256 indexed rgbOpId, uint256 amount);
+    event FundsIn(address indexed sender, uint256 rgbOpId, uint256 amount);
     event BridgeFundsIn(
         bytes32 indexed operationId,
         bytes32 indexed sourceSender,
@@ -59,6 +59,7 @@ contract BridgeTest is Test {
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event LZAdapterDisabled(address indexed oldAdapter);
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+    event CommissionManagerUpdated(address indexed oldCommissionManager, address indexed newCommissionManager);
     event MinFundsInAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
     event MinFundsOutAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
     event OutflowLimitUpdated(uint256 indexed chainId, uint256 capacity, uint256 refillRate, uint256 available);
@@ -109,6 +110,10 @@ contract BridgeTest is Test {
 
         usdt0 = new MockERC20("Mock USDT0", "USDT0");
         btcRelay = new MockBtcRelay();
+        // The real relay never stores a header below its initialisation
+        // checkpoint; mirror that here so a proof this suite accepts is one
+        // the deployed relay would also accept.
+        btcRelay.setCheckpointHeight(BLOCK_HEIGHT);
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, CONFIRMATIONS);
         btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONFIRMATIONS);
 
@@ -576,6 +581,62 @@ contract BridgeTest is Test {
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
         bridge.setRouteRegistry(makeAddr("newReg"));
+    }
+
+    // ========================================================================
+    // setCommissionManager
+    // ========================================================================
+
+    function test_setCommissionManager_ownerCanRotate() public {
+        CommissionManager newCm = new CommissionManager(address(bridge), recipient);
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit CommissionManagerUpdated(address(cm), address(newCm));
+
+        vm.prank(multisig);
+        bridge.setCommissionManager(address(newCm));
+        assertEq(address(bridge.commissionManager()), address(newCm));
+    }
+
+    function test_setCommissionManager_revertsOnZero() public {
+        vm.prank(multisig);
+        vm.expectRevert(IBridge.InvalidCommissionManagerAddress.selector);
+        bridge.setCommissionManager(address(0));
+    }
+
+    function test_setCommissionManager_revertsIfNotOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.setCommissionManager(makeAddr("newCm"));
+    }
+
+    function test_setCommissionManager_routesNewFeesToReplacement() public {
+        CommissionManager newCm = new CommissionManager(address(bridge), recipient);
+        uint256 percent = 400; // 4%
+        newCm.setCommissionRule(
+            SOURCE_CHAIN_ID,
+            RGB_CHAIN_ID,
+            address(usdt0),
+            CommissionConfig({
+                stablePercent: percent,
+                baseFee: 0,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_IN,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        vm.prank(multisig);
+        bridge.setCommissionManager(address(newCm));
+
+        uint256 oldPoolBefore = cm.tokenCommissionPool(address(usdt0));
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        uint256 expectedCommission = AMOUNT * percent / 100 / 100;
+        assertEq(newCm.tokenCommissionPool(address(usdt0)), expectedCommission, "replacement receives fees");
+        assertEq(cm.tokenCommissionPool(address(usdt0)), oldPoolBefore, "old manager receives nothing");
     }
 
     // ========================================================================
@@ -1047,7 +1108,7 @@ contract BridgeTest is Test {
         // Drop the emitter filter so Forge's expectEmit scans past the token's
         // Transfer event (emitter = usdt0) and matches BridgeFundsIn by topic0.
         // FundsIn (RGB route) carries the rgbOpId; sender = the adapter.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(mockAdapter, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -1086,7 +1147,7 @@ contract BridgeTest is Test {
         bytes32 sourceSender = bytes32(uint256(uint160(user)));
         bytes32 expectedOpId = _deriveOpId(SOURCE_CHAIN_ID, sourceSender, 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -1421,21 +1482,38 @@ contract BridgeTest is Test {
         bytes memory altProof = abi.encode(BLOCK_HEIGHT, COMMITMENT_HASH, LATEST_HEIGHT + 1, altLatestCommit);
 
         vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
+        uint256 secondAmount = 90 ether; // 10% of the current 900 liquidity
         vm.prank(multisig);
         _fundsOut(
-            recipient, AMOUNT, BURN_ID + 1, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, altProof, _settlement(_ids(opId))
+            recipient,
+            secondAmount,
+            BURN_ID + 1,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            altProof,
+            _settlement(_ids(opId))
         );
 
-        // Two 10% bucket bursts have now consumed the immutable 20% allowance.
-        // A third distinct intent cannot reuse the permanent proof to move more.
+        // The bucket reprices the second burst against current liquidity, while
+        // the immutable limiter still counts both releases against the original
+        // 1,000 reference. No split can exceed its remaining 10-token allowance.
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 10 ether);
+        assertEq(bridge.availableGlobalSafetyOutflow(), 10 ether);
         vm.warp(block.timestamp + 1);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IBridge.ChainSafetyLimitExceeded.selector, RGB_CHAIN_ID, uint256(1), AMOUNT * 2, AMOUNT * 2
-            )
-        );
+        assertLe(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), 10 ether, "rolling ceiling remains authoritative");
+        vm.expectPartialRevert(OutflowRateLimiter.TokenOutflowThrottled.selector);
         vm.prank(multisig);
-        _fundsOut(recipient, 1, BURN_ID + 1, RGB_CHAIN_ID, SOURCE_CHAIN_ID, SRC_ADDR, altProof, _settlement(_ids(opId)));
+        _fundsOut(
+            recipient,
+            10 ether + 1,
+            BURN_ID + 2,
+            RGB_CHAIN_ID,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            altProof,
+            _settlement(_ids(opId))
+        );
     }
 
     // ========================================================================
@@ -1691,11 +1769,12 @@ contract BridgeTest is Test {
         _releaseRGB(cap, BURN_ID);
         assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 0, "drained");
 
-        // `cap` is restored over one full BUCKET_REFILL_WINDOW, so half a window
-        // accrues half of it (to within the per-second share truncation).
+        // Half the share capacity is restored. Its token value is calculated
+        // against the current 9,900 liquidity after the first release.
         vm.warp(block.timestamp + 12 hours);
         uint256 refilled = bridge.availableOutflow(RGB_CHAIN_ID);
-        assertApproxEqRel(refilled, cap / 2, 1e12, "partial linear refill"); // 1e-6 relative
+        uint256 expectedRefill = bridge.lockedLiquidity(RGB_CHAIN_ID) * 50 / bridge.BPS_DENOMINATOR();
+        assertApproxEqRel(refilled, expectedRefill, 1e12, "partial linear refill"); // 1e-6 relative
 
         _releaseRGB(refilled - 1, BURN_ID + 1); // the refilled allowance is spendable
     }
@@ -1709,7 +1788,8 @@ contract BridgeTest is Test {
         vm.warp(block.timestamp + 1); // one second later
 
         uint256 accrued = bridge.availableOutflow(RGB_CHAIN_ID);
-        assertApproxEqRel(accrued, cap / (24 hours), 1e12, "only one second of refill accrued");
+        uint256 expectedAccrued = bridge.lockedLiquidity(RGB_CHAIN_ID) * 100 / bridge.BPS_DENOMINATOR() / (24 hours);
+        assertApproxEqRel(accrued, expectedAccrued, 1e12, "only one second of refill accrued");
         assertLt(accrued, cap, "not a fresh cap");
         bytes32 altLatestCommit = keccak256("test-btc-short-gap-latest-commitment");
         btcRelay.setBlock(LATEST_HEIGHT + 1, altLatestCommit, LATEST_CONFIRMATIONS);
@@ -1717,11 +1797,12 @@ contract BridgeTest is Test {
         bytes32[] memory ids = new bytes32[](1);
         ids[0] = _seedOpId;
 
+        uint256 currentCapacity = bridge.lockedLiquidity(RGB_CHAIN_ID) * 100 / bridge.BPS_DENOMINATOR();
         vm.expectPartialRevert(OutflowRateLimiter.TokenOutflowThrottled.selector);
         vm.prank(multisig);
         _fundsOut(
             recipient,
-            cap,
+            currentCapacity,
             BURN_ID + 1,
             RGB_CHAIN_ID,
             SOURCE_CHAIN_ID,
@@ -1772,12 +1853,13 @@ contract BridgeTest is Test {
     function test_outflow_reconfigPreservesAvailableNoGift() public {
         _seedRGB(1000 ether);
         _setRGBBucket(100 ether, 100 ether);
-        _releaseRGB(60 ether, BURN_ID); // available 40 ether
-        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 40 ether, "pre");
+        _releaseRGB(60 ether, BURN_ID); // 4,000 bps of shares remain
+        uint256 availableBefore = bridge.availableOutflow(RGB_CHAIN_ID);
+        assertEq(availableBefore, 39.76 ether, "pre");
 
         // Raising capacity must NOT gift a fresh full bucket.
         _setRGBBucket(200 ether, 200 ether);
-        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 40 ether, "available preserved, not gifted");
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), availableBefore, "available preserved, not gifted");
     }
 
     function test_outflow_reconfigClampsOnDecrease() public {
@@ -1866,27 +1948,66 @@ contract BridgeTest is Test {
 
         // One extra second fully restores the slightly conservative, integer-
         // rounded bucket refill while the first rolling-window spend remains.
+        // The bucket is now 10% of the actual 900 liquidity, so the next tranche
+        // is 90 rather than 100; rolling usage affects only the safety limiter.
         vm.warp(block.timestamp + 1);
-        _releaseRGBTo(makeAddr("rolling-window-second"), bucketBurst, BURN_ID + 1);
-        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 0);
-        assertEq(bridge.availableGlobalSafetyOutflow(), 0);
+        uint256 secondTranche = 90 ether;
+        _releaseRGBTo(makeAddr("rolling-window-second"), secondTranche, BURN_ID + 1);
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 10 ether);
+        assertEq(bridge.availableGlobalSafetyOutflow(), 10 ether);
 
-        // At H+25 the first spend expires but the second remains. Reference is
-        // remaining liquidity (800) plus still-counted spend (100) = 900, so the
-        // new 20% limit is 180 with 100 already consumed: 80 remains.
+        // At H+25 the first spend expires but the second remains. The bucket
+        // reference stays at actual locked liquidity (810). The independent
+        // safety reference is 810 + 90 = 900, so its 20% limit is 180 with 90
+        // still consumed: 90 remains.
         vm.warp(block.timestamp + 1 hours - 1);
-        uint256 nextWindowLimit = 80 ether;
-        assertEq(bridge.chainOutflowReference(RGB_CHAIN_ID), 900 ether, "reference follows rolling lower TVL");
-        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), nextWindowLimit);
-        assertEq(bridge.availableGlobalSafetyOutflow(), nextWindowLimit);
+        uint256 nextWindowSafetyLimit = 90 ether;
+        assertEq(bridge.chainOutflowReference(RGB_CHAIN_ID), 810 ether, "bucket reference is actual liquidity");
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), nextWindowSafetyLimit);
+        assertEq(bridge.availableGlobalSafetyOutflow(), nextWindowSafetyLimit);
 
         // Liveness: after the second spend also expires, the bucket has refilled
         // and a new 10%-of-current-liquidity tranche can leave.
         vm.warp(block.timestamp + bridge.OUTFLOW_SAFETY_WINDOW());
-        assertEq(bridge.chainOutflowReference(RGB_CHAIN_ID), 800 ether);
-        assertEq(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), nextWindowLimit);
-        _releaseRGBTo(makeAddr("rolling-window-third"), nextWindowLimit, BURN_ID + 2);
-        assertEq(bridge.totalLockedLiquidity(), 720 ether);
+        uint256 thirdTranche = 81 ether;
+        assertEq(bridge.chainOutflowReference(RGB_CHAIN_ID), 810 ether);
+        assertEq(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), thirdTranche);
+        _releaseRGBTo(makeAddr("rolling-window-third"), thirdTranche, BURN_ID + 2);
+        assertEq(bridge.totalLockedLiquidity(), 729 ether);
+    }
+
+    /// @dev Regression for the reported capacity-ceiling liveness issue. Once
+    ///      an earlier release has reduced actual liquidity, the bucket prices
+    ///      every later request against that lower liquidity immediately. The
+    ///      rolling slot can expire and change the safety allowance, but cannot
+    ///      make the bucket's reference or full allowance step down again.
+    function test_bucketCapacityDoesNotDecayWhenRollingUsageExpires() public {
+        vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
+        uint256 startedAt = block.timestamp;
+        _seedRGB(100 ether); // 1,000 liquidity, 10% bucket
+
+        _releaseRGBTo(makeAddr("first"), 100 ether, BURN_ID);
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), 900 ether);
+
+        vm.warp(startedAt + 24 hours + 1 minutes);
+        assertEq(bridge.chainOutflowReference(RGB_CHAIN_ID), 900 ether, "pre-expiry bucket reference");
+        assertEq(bridge.globalOutflowReference(), 900 ether, "pre-expiry global reference");
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 90 ether, "pre-expiry chain capacity");
+        assertEq(bridge.availableGlobalOutflow(), 90 ether, "pre-expiry global capacity");
+
+        uint256 snapshot = vm.snapshotState();
+        _releaseRGBTo(makeAddr("before-expiry"), 90 ether, BURN_ID + 1);
+        assertTrue(vm.revertToState(snapshot));
+
+        vm.warp(startedAt + 25 hours);
+        assertEq(bridge.chainOutflowReference(RGB_CHAIN_ID), 900 ether, "post-expiry bucket reference");
+        assertEq(bridge.globalOutflowReference(), 900 ether, "post-expiry global reference");
+        assertEq(bridge.availableOutflow(RGB_CHAIN_ID), 90 ether, "post-expiry chain capacity");
+        assertEq(bridge.availableGlobalOutflow(), 90 ether, "post-expiry global capacity");
+        assertEq(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), 90 ether, "effective allowance is stable");
+
+        _releaseRGBTo(makeAddr("after-expiry"), 90 ether, BURN_ID + 1);
+        assertEq(bridge.lockedLiquidity(RGB_CHAIN_ID), 810 ether, "same tranche remains executable");
     }
 
     function test_directTokenDonationCannotInflateGlobalSafetyAllowance() public {
@@ -1971,11 +2092,13 @@ contract BridgeTest is Test {
         bytes32[] memory otherIds = _ids(otherOpId);
         bytes memory otherSettlement = _settlementWithAmounts(otherIds, _one(1_000 ether));
 
-        _releaseRGBTo(makeAddr("aggregate-rgb-1"), 100 ether, BURN_ID);
+        uint256 firstRgb = 100 ether;
+        uint256 firstOther = 95 ether;
+        _releaseRGBTo(makeAddr("aggregate-rgb-1"), firstRgb, BURN_ID);
         vm.prank(multisig);
         _fundsOut(
             makeAddr("aggregate-other-1"),
-            100 ether,
+            firstOther,
             BURN_ID + 1,
             otherChain,
             SOURCE_CHAIN_ID,
@@ -1985,17 +2108,20 @@ contract BridgeTest is Test {
         );
 
         assertEq(bridge.availableGlobalOutflow(), 0, "both chains consume one global bucket");
-        assertEq(bridge.availableGlobalSafetyOutflow(), 200 ether, "aggregate hard allowance tracks both chains");
+        assertEq(bridge.availableGlobalSafetyOutflow(), 400 ether - firstRgb - firstOther, "hard allowance aggregates");
 
         // Buckets refill after 24h, but the aligned rolling window retains both
-        // first releases until H+25. A second 100 from each chain exhausts the
-        // immutable aggregate and per-chain allowances without exceeding them.
+        // first releases until H+25. Current-liquidity pricing makes each later
+        // tranche slightly smaller; rolling safety accounting still aggregates
+        // both source chains independently of that pricing.
         vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
-        _releaseRGBTo(makeAddr("aggregate-rgb-2"), 100 ether, BURN_ID + 2);
+        uint256 secondRgb = 90 ether;
+        _releaseRGBTo(makeAddr("aggregate-rgb-2"), secondRgb, BURN_ID + 2);
+        uint256 secondOther = bridge.effectiveAvailableOutflow(otherChain) - 1;
         vm.prank(multisig);
         _fundsOut(
             makeAddr("aggregate-other-2"),
-            100 ether,
+            secondOther,
             BURN_ID + 3,
             otherChain,
             SOURCE_CHAIN_ID,
@@ -2004,22 +2130,95 @@ contract BridgeTest is Test {
             otherSettlement
         );
 
-        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 0, "RGB rolling allowance exhausted");
-        assertEq(bridge.availableChainSafetyOutflow(otherChain), 0, "other rolling allowance exhausted");
-        assertEq(bridge.availableGlobalSafetyOutflow(), 0, "aggregate rolling allowance exhausted");
-        assertEq(bridge.totalLockedLiquidity(), 1_600 ether, "at most 20% of aggregate reference left the bridge");
+        uint256 totalReleased = firstRgb + firstOther + secondRgb + secondOther;
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 200 ether - firstRgb - secondRgb);
+        assertEq(bridge.availableChainSafetyOutflow(otherChain), 200 ether - firstOther - secondOther);
+        assertEq(
+            bridge.availableGlobalSafetyOutflow(), 400 ether - totalReleased, "aggregate usage includes both chains"
+        );
+        assertEq(bridge.totalLockedLiquidity(), 2_000 ether - totalReleased);
 
         vm.warp(block.timestamp + 1);
+        assertLe(
+            bridge.effectiveAvailableOutflow(RGB_CHAIN_ID),
+            bridge.availableGlobalSafetyOutflow(),
+            "global rolling ceiling cannot be bypassed by chain splitting"
+        );
+    }
+
+    function test_crossChainOutflowRepricesGlobalAllowanceAgainstCurrentLiquidity() public {
+        vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
+
+        uint256 otherChain = 888;
+        vm.startPrank(deployer);
+        routeRegistry.setRoute(SOURCE_CHAIN_ID, otherChain, true, address(rgbVerifier), address(rgbModule));
+        routeRegistry.setRoute(otherChain, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(rgbModule));
+        vm.stopPrank();
+
+        usdt0.mint(user, 1_000 ether);
+        vm.prank(user);
+        bytes32 otherOpId = bridge.fundsIn(1_000 ether, otherChain, DST_ADDR, _rgbData(RGB_OP_ID + otherChain));
+
+        _seedRGB(100 ether); // 1,000 RGB + 1,000 other
+        vm.startPrank(multisig);
+        bridge.setOutflowLimit(otherChain, 1_000, 1_000); // 10% chain burst
+        bridge.setGlobalOutflowLimit(500, 1_500); // intentionally stricter 5% global burst
+        vm.stopPrank();
+
+        uint256 quotedForOther = bridge.effectiveAvailableOutflow(otherChain);
+        assertEq(quotedForOther, 100 ether, "initial global capacity is 5% of 2,000");
+
+        // A release from RGB consumes the global bucket and reduces actual
+        // aggregate liquidity, without changing the other chain's liquidity.
+        _releaseRGBTo(makeAddr("cross-chain-rgb"), 100 ether, BURN_ID);
+        assertEq(bridge.lockedLiquidity(otherChain), 1_000 ether, "other chain liquidity unchanged");
+        assertEq(bridge.globalOutflowReference(), 1_900 ether, "real outflow reprices global reference");
+        assertEq(bridge.effectiveAvailableOutflow(otherChain), 0, "spent global bucket blocks other chain");
+
+        // Once the bucket refills, the old 100-token quote is above the new 5%
+        // capacity. This is expected stale-state handling: the current getter
+        // reports 95, which remains executable and respects aggregate policy.
+        vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
+        uint256 currentAllowance = bridge.effectiveAvailableOutflow(otherChain);
+        assertEq(currentAllowance, 95 ether, "fresh quote follows current aggregate liquidity");
+
+        uint256 capacityShares = 500 * bridge.SHARE_UNIT() / bridge.BPS_DENOMINATOR();
+        uint256 requestedShares = (quotedForOther * bridge.SHARE_UNIT() + bridge.globalOutflowReference() - 1)
+            / bridge.globalOutflowReference();
+        bytes memory otherSettlement = _settlementWithAmounts(_ids(otherOpId), _one(1_000 ether));
+
         vm.expectRevert(
             abi.encodeWithSelector(
-                IBridge.ChainSafetyLimitExceeded.selector,
-                RGB_CHAIN_ID,
-                uint256(1),
-                uint256(200 ether),
-                uint256(200 ether)
+                OutflowRateLimiter.AggregateRequestAboveCapacity.selector, capacityShares, requestedShares
             )
         );
-        _releaseRGBTo(makeAddr("aggregate-rgb-blocked"), 1, BURN_ID + 4);
+        vm.prank(multisig);
+        _fundsOut(
+            makeAddr("stale-other"),
+            quotedForOther,
+            BURN_ID + 1,
+            otherChain,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            _proof(),
+            otherSettlement
+        );
+
+        vm.prank(multisig);
+        _fundsOut(
+            makeAddr("fresh-other"),
+            currentAllowance,
+            BURN_ID + 2,
+            otherChain,
+            SOURCE_CHAIN_ID,
+            SRC_ADDR,
+            _proof(),
+            otherSettlement
+        );
+
+        assertEq(bridge.totalLockedLiquidity(), 1_805 ether, "aggregate accounting includes both releases");
+        assertEq(bridge.availableGlobalOutflow(), 0, "fresh release consumes the refilled global burst");
+        assertEq(bridge.availableGlobalSafetyOutflow(), 205 ether, "immutable aggregate safety remains enforced");
     }
 
     function test_setOutflowLimit_revertsOnZeroChainId() public {
@@ -2208,9 +2407,8 @@ contract BridgeTest is Test {
 
         vm.warp(block.timestamp + elapsed);
 
-        // Read the reference AFTER the warp: it is invariant while the release is
-        // still counted in the window, then steps down to plain `lockedLiquidity`
-        // once the window expires. The view converts against the live value.
+        // The bucket reference is always actual locked liquidity. A rolling
+        // safety-slot expiry cannot change it by itself.
         uint256 refLiquidity = bridge.chainOutflowReference(RGB_CHAIN_ID);
 
         (uint128 tokens,,, uint128 capacity, uint128 rate) = bridge.chainBuckets(RGB_CHAIN_ID);
@@ -2238,7 +2436,7 @@ contract BridgeTest is Test {
         amountBps = bound(amountBps, 1, burstBps);
 
         _seedRGB(1_000 ether);
-        // No warp in this test, so the reference stays constant across the release.
+        // Capture the pre-debit reference used to price the release.
         uint256 refLiquidity = bridge.chainOutflowReference(RGB_CHAIN_ID);
 
         vm.prank(multisig);
@@ -2247,16 +2445,20 @@ contract BridgeTest is Test {
         uint256 amount = refLiquidity * amountBps / bridge.BPS_DENOMINATOR();
         vm.assume(amount > 0);
 
-        uint256 available = bridge.availableOutflow(RGB_CHAIN_ID);
+        (uint128 sharesBefore,,,,) = bridge.chainBuckets(RGB_CHAIN_ID);
         _releaseRGB(amount, BURN_ID);
 
-        // One share is worth `refLiquidity / SHARE_UNIT` tokens; the ceiling can
-        // debit at most that much more than the nominal amount.
-        uint256 oneShare = refLiquidity / bridge.SHARE_UNIT() + 1;
-        assertApproxEqAbs(
-            bridge.availableOutflow(RGB_CHAIN_ID), available - amount, oneShare, "debited to within one share"
+        uint256 shareUnit = bridge.SHARE_UNIT();
+        uint256 spentShares = (amount * shareUnit + refLiquidity - 1) / refLiquidity;
+        (uint128 sharesAfter,,,,) = bridge.chainBuckets(RGB_CHAIN_ID);
+        assertEq(uint256(sharesAfter), uint256(sharesBefore) - spentShares, "share debit uses pre-debit liquidity");
+
+        uint256 remainingLiquidity = refLiquidity - amount;
+        assertEq(
+            bridge.availableOutflow(RGB_CHAIN_ID),
+            uint256(sharesAfter) * remainingLiquidity / shareUnit,
+            "token preview uses post-debit actual liquidity"
         );
-        assertLe(bridge.availableOutflow(RGB_CHAIN_ID), available - amount, "never debits less than the amount");
     }
 
     // ========================================================================
@@ -2798,7 +3000,7 @@ contract BridgeTest is Test {
         assertEq(nativePoolBefore, 0, "pre native pool");
         assertEq(recordBefore, 0, "pre record");
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -2870,7 +3072,7 @@ contract BridgeTest is Test {
         assertEq(nativePoolBefore, 0, "pre native pool");
         assertEq(recordBefore, 0, "pre record");
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -3310,7 +3512,7 @@ contract BridgeTest is Test {
         assertEq(cm.nativeCommissionPool(), nativePoolBefore, "native pool unchanged");
         assertEq(rgbModule.fundsInRecords(expectedOpId), recordBefore, "record not created");
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3354,7 +3556,7 @@ contract BridgeTest is Test {
         assertEq(bridgeBefore, 0, "pre bridge token");
         assertEq(recordBefore, 0, "pre record");
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3411,7 +3613,7 @@ contract BridgeTest is Test {
             SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
         );
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3571,7 +3773,7 @@ contract BridgeTest is Test {
             SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, amount, RGB_CHAIN_ID, DST_ADDR, _rgbData()
         );
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3715,10 +3917,30 @@ contract BridgeTest is Test {
 
     /// @dev The RGB route emits FundsIn carrying the rgbOpId and net amount.
     function test_fundsIn_rgbRouteEmitsFundsInWithRgbOpId() public {
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, AMOUNT); // no commission → net == gross == AMOUNT
         vm.prank(user);
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+    }
+
+    function test_fundsIn_rgbOpIdIsNonIndexedEventData() public {
+        bytes32 fundsInTopic = keccak256("FundsIn(address,uint256,uint256)");
+        vm.recordLogs();
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter == address(bridge) && logs[i].topics[0] == fundsInTopic) {
+                assertEq(logs[i].topics.length, 2, "only signature and sender are indexed");
+                assertEq(address(uint160(uint256(logs[i].topics[1]))), user, "sender topic");
+                (uint256 rgbOpId, uint256 amount) = abi.decode(logs[i].data, (uint256, uint256));
+                assertEq(rgbOpId, RGB_OP_ID, "rgb op id is event data");
+                assertEq(amount, AMOUNT, "amount is event data");
+                return;
+            }
+        }
+        fail("FundsIn event not found");
     }
 
     /// @dev The returned bytes32 is the key under which the module records net.
@@ -3866,7 +4088,7 @@ contract BridgeTest is Test {
         bytes32 sourceSender = bytes32(uint256(uint160(user)));
 
         // BridgeFundsIn must carry gross `amount == AMOUNT` and `netAmount == received`.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, received);
         vm.expectEmit(false, true, true, true);
         emit BridgeFundsIn(

--- a/ethereum/test/BridgeRebalance.t.sol
+++ b/ethereum/test/BridgeRebalance.t.sol
@@ -12,6 +12,7 @@ import {RGBVerifier} from "../src/verifiers/RGBVerifier.sol";
 import {NullVerifier} from "../src/verifiers/NullVerifier.sol";
 import {RgbSettlementModule} from "../src/settlement/RgbSettlementModule.sol";
 import {RgbOutboundSettlementModule} from "../src/settlement/RgbOutboundSettlementModule.sol";
+import {RgbPoolSettlementModule} from "../src/settlement/RgbPoolSettlementModule.sol";
 import {NullSettlementModule} from "../src/settlement/NullSettlementModule.sol";
 import {BridgeBase} from "../src/BridgeBase.sol";
 import {OutflowRateLimiter} from "../src/libraries/OutflowRateLimiter.sol";
@@ -36,7 +37,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 ///                    (burn-backed: BtcRelay proof + record check; credit leg
 ///                     writes nothing and emits no FundsIn)
 contract BridgeRebalanceTest is Test {
-    event FundsIn(address indexed sender, uint256 indexed rgbOpId, uint256 amount);
+    event FundsIn(address indexed sender, uint256 rgbOpId, uint256 amount);
     event BridgeRebalance(
         bytes32 indexed operationId,
         uint256 indexed burnId,
@@ -56,16 +57,20 @@ contract BridgeRebalanceTest is Test {
     NullVerifier nullVerifier;
     RgbSettlementModule rgbModule;
     RgbOutboundSettlementModule outboundModule;
+    RgbPoolSettlementModule poolModule;
     NullSettlementModule nullModule;
 
     address deployer = makeAddr("deployer");
     address user = makeAddr("user");
+    address recipient = makeAddr("recipient");
     address multisig = makeAddr("multisig");
 
     uint256 constant SOURCE_CHAIN_ID = 31337; // foundry block.chainid
     uint256 constant RGB_CHAIN_ID = 1_000_001; // RGB pool network
     uint256 constant ARCH_CHAIN_ID = 1_000_002; // backend-assigned for Arch
     uint256 constant RGB_MINTBURN_CHAIN_ID = 1_000_003; // RGB mint/burn network (variant C: same module)
+    uint256 constant PRODUCTION_RGB_MINT_BURN_CHAIN_ID = 96;
+    uint256 constant PRODUCTION_RGB_POOL_CHAIN_ID = 97;
     string constant RGB_DST_ADDR = "rgb:asset1qp0y3mq6h5k8d9f2e4j7n6c3w/utxo1abc123";
     string constant ARCH_DST_ADDR = "arch:bridge-wallet";
     string constant RGB_SRC_ADDR = "rgb:burner/utxo1burn";
@@ -85,6 +90,9 @@ contract BridgeRebalanceTest is Test {
     uint256 constant LATEST_HEIGHT = 850_005;
     bytes32 constant LATEST_COMMIT = keccak256("test-btc-latest-commitment");
     uint256 constant LATEST_CONFIRMATIONS = 1;
+    bytes32 constant FUNDS_OUT_BURN_ID_TYPEHASH = keccak256(
+        "UtexoFundsOutBurnId(address bridge,uint256 chainId,address token,address recipient,uint256 amount,uint256 sourceChainId,uint256 destinationChainId,bytes32 sourceAddressHash,bytes32 proofHash,bytes32 settlementDataHash)"
+    );
 
     // Seed deposit ids (captured in setUp): RGB-pool and RGB-mint/burn deposits.
     bytes32 rgbSeedOpId;
@@ -93,6 +101,10 @@ contract BridgeRebalanceTest is Test {
     function setUp() public {
         usdt0 = new MockERC20("Mock USDT0", "USDT0");
         btcRelay = new MockBtcRelay();
+        // The real relay never stores a header below its initialisation
+        // checkpoint; mirror that here so a proof this suite accepts is one
+        // the deployed relay would also accept.
+        btcRelay.setCheckpointHeight(BLOCK_HEIGHT);
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, CONFIRMATIONS);
         btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONFIRMATIONS);
 
@@ -109,6 +121,9 @@ contract BridgeRebalanceTest is Test {
         nullVerifier = new NullVerifier();
         rgbModule = new RgbSettlementModule(address(routeRegistry));
         outboundModule = new RgbOutboundSettlementModule(address(routeRegistry), address(rgbModule));
+        poolModule = new RgbPoolSettlementModule(
+            address(routeRegistry), address(rgbModule), PRODUCTION_RGB_POOL_CHAIN_ID, PRODUCTION_RGB_MINT_BURN_CHAIN_ID
+        );
         nullModule = new NullSettlementModule();
 
         // Deposit routes.
@@ -127,6 +142,40 @@ contract BridgeRebalanceTest is Test {
         // Pool → MintBurn (scenario A): operational, no external burn → NullVerifier.
         routeRegistry.setRoute(RGB_CHAIN_ID, RGB_MINTBURN_CHAIN_ID, true, address(nullVerifier), address(rgbModule));
 
+        // Production topology:
+        //   42161-like EVM <-> 96 (mint/burn) — canonical ledger + RGB event
+        //   42161-like EVM <-> 97 (pool)      — no pool record / RGB event;
+        //                                      pool releases read 96's ledger
+        //   96 -> 97 rebalance               — check 96, write nothing for 97
+        //   97 -> 96 rebalance               — accounting-only pool debit,
+        //                                      canonical write + RGB event for 96
+        routeRegistry.setRoute(
+            SOURCE_CHAIN_ID, PRODUCTION_RGB_MINT_BURN_CHAIN_ID, true, address(rgbVerifier), address(rgbModule)
+        );
+        routeRegistry.setRoute(
+            PRODUCTION_RGB_MINT_BURN_CHAIN_ID, SOURCE_CHAIN_ID, true, address(rgbVerifier), address(rgbModule)
+        );
+        routeRegistry.setRoute(
+            SOURCE_CHAIN_ID, PRODUCTION_RGB_POOL_CHAIN_ID, true, address(nullVerifier), address(poolModule)
+        );
+        routeRegistry.setRoute(
+            PRODUCTION_RGB_POOL_CHAIN_ID, SOURCE_CHAIN_ID, true, address(nullVerifier), address(poolModule)
+        );
+        routeRegistry.setRoute(
+            PRODUCTION_RGB_MINT_BURN_CHAIN_ID,
+            PRODUCTION_RGB_POOL_CHAIN_ID,
+            true,
+            address(rgbVerifier),
+            address(outboundModule)
+        );
+        routeRegistry.setRoute(
+            PRODUCTION_RGB_POOL_CHAIN_ID,
+            PRODUCTION_RGB_MINT_BURN_CHAIN_ID,
+            true,
+            address(nullVerifier),
+            address(rgbModule)
+        );
+
         bridge.transferOwnership(multisig);
         vm.stopPrank();
 
@@ -140,6 +189,8 @@ contract BridgeRebalanceTest is Test {
         bridge.setOutflowLimit(RGB_CHAIN_ID, MAX_BURST_BPS, MAX_REFILL_BPS);
         bridge.setOutflowLimit(ARCH_CHAIN_ID, MAX_BURST_BPS, MAX_REFILL_BPS);
         bridge.setOutflowLimit(RGB_MINTBURN_CHAIN_ID, MAX_BURST_BPS, MAX_REFILL_BPS);
+        bridge.setOutflowLimit(PRODUCTION_RGB_MINT_BURN_CHAIN_ID, MAX_BURST_BPS, MAX_REFILL_BPS);
+        bridge.setOutflowLimit(PRODUCTION_RGB_POOL_CHAIN_ID, MAX_BURST_BPS, MAX_REFILL_BPS);
         bridge.setGlobalOutflowLimit(MAX_BURST_BPS, MAX_REFILL_BPS);
         vm.stopPrank();
 
@@ -320,9 +371,178 @@ contract BridgeRebalanceTest is Test {
         bridge.rebalanceLiquidity(p);
     }
 
+    function _productionMintBurnToPoolParams(uint256 amount, bytes32 referencedOpId)
+        internal
+        view
+        returns (IBridge.RebalanceParams memory p)
+    {
+        p = IBridge.RebalanceParams({
+            amount: amount,
+            burnId: 0,
+            sourceChainId: PRODUCTION_RGB_MINT_BURN_CHAIN_ID,
+            destinationChainId: PRODUCTION_RGB_POOL_CHAIN_ID,
+            sourceAddress: RGB_SRC_ADDR,
+            destinationAddress: RGB_DST_ADDR,
+            proof: _proof(),
+            settlementDataOut: _settlement(referencedOpId),
+            settlementDataIn: ""
+        });
+        p.burnId = _deriveRebalanceBurnId(p);
+    }
+
+    function _productionPoolToMintBurnParams(uint256 amount, uint256 rgbOpId)
+        internal
+        view
+        returns (IBridge.RebalanceParams memory p)
+    {
+        p = IBridge.RebalanceParams({
+            amount: amount,
+            burnId: 0,
+            sourceChainId: PRODUCTION_RGB_POOL_CHAIN_ID,
+            destinationChainId: PRODUCTION_RGB_MINT_BURN_CHAIN_ID,
+            sourceAddress: RGB_SRC_ADDR,
+            destinationAddress: RGB_DST_ADDR,
+            proof: "",
+            settlementDataOut: _emptySettlement(),
+            settlementDataIn: abi.encode(rgbOpId)
+        });
+        p.burnId = _deriveRebalanceBurnId(p);
+    }
+
+    function _deriveFundsOutBurnId(
+        address recipient_,
+        uint256 amount,
+        uint256 sourceChainId,
+        bytes memory proof,
+        bytes memory settlementData
+    ) internal view returns (uint256) {
+        return uint256(
+            keccak256(
+                abi.encode(
+                    FUNDS_OUT_BURN_ID_TYPEHASH,
+                    address(bridge),
+                    block.chainid,
+                    address(usdt0),
+                    recipient_,
+                    amount,
+                    sourceChainId,
+                    SOURCE_CHAIN_ID,
+                    keccak256(bytes(RGB_SRC_ADDR)),
+                    keccak256(proof),
+                    keccak256(settlementData)
+                )
+            )
+        );
+    }
+
+    function _countBridgeLogs(Vm.Log[] memory logs, bytes32 topic0) internal view returns (uint256 count) {
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter == address(bridge) && logs[i].topics[0] == topic0) count++;
+        }
+    }
+
     // ========================================================================
     // Success paths
     // ========================================================================
+
+    function test_productionTopology_poolFundsInEmitsOnlyBridgeFundsInAndWritesNoRecord() public {
+        usdt0.mint(user, AMOUNT);
+
+        vm.recordLogs();
+        vm.prank(user);
+        bytes32 operationId = bridge.fundsIn(AMOUNT, PRODUCTION_RGB_POOL_CHAIN_ID, RGB_DST_ADDR, "");
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(rgbModule.fundsInRecords(operationId), 0, "pool deposit creates no mint/burn record");
+        assertEq(
+            _countBridgeLogs(logs, keccak256("FundsIn(address,uint256,uint256)")),
+            0,
+            "pool deposit emits no RGB FundsIn"
+        );
+        assertEq(
+            _countBridgeLogs(
+                logs,
+                keccak256(
+                    "BridgeFundsIn(bytes32,bytes32,address,uint256,uint256,uint256,uint256,uint256,uint256,uint256,string)"
+                )
+            ),
+            1,
+            "pool deposit emits one canonical BridgeFundsIn"
+        );
+    }
+
+    function test_productionTopology_poolFundsOutReadsMintBurnLedger() public {
+        usdt0.mint(user, AMOUNT * 11);
+
+        vm.prank(user);
+        bytes32 backingOperationId =
+            bridge.fundsIn(AMOUNT, PRODUCTION_RGB_MINT_BURN_CHAIN_ID, RGB_DST_ADDR, abi.encode(RGB_OP_ID + 1_000));
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT * 10, PRODUCTION_RGB_POOL_CHAIN_ID, RGB_DST_ADDR, "");
+
+        bytes memory settlementData = _settlement(backingOperationId);
+        bytes memory proof = "";
+        uint256 burnId = _deriveFundsOutBurnId(recipient, AMOUNT, PRODUCTION_RGB_POOL_CHAIN_ID, proof, settlementData);
+
+        vm.prank(multisig);
+        bridge.fundsOut(
+            IBridge.FundsOutParams({
+                recipient: recipient,
+                amount: AMOUNT,
+                burnId: burnId,
+                sourceChainId: PRODUCTION_RGB_POOL_CHAIN_ID,
+                destinationChainId: SOURCE_CHAIN_ID,
+                sourceAddress: RGB_SRC_ADDR,
+                proof: proof,
+                settlementData: settlementData
+            })
+        );
+
+        assertEq(usdt0.balanceOf(recipient), AMOUNT, "pool-backed fundsOut releases tokens");
+        assertEq(rgbModule.fundsInRecords(backingOperationId), AMOUNT, "backing record remains permanent");
+    }
+
+    function test_productionTopology_mintBurnToPoolRebalanceWritesNoPoolRecordOrFundsInEvent() public {
+        usdt0.mint(user, AMOUNT * 10);
+        vm.prank(user);
+        bytes32 backingOperationId =
+            bridge.fundsIn(AMOUNT, PRODUCTION_RGB_MINT_BURN_CHAIN_ID, RGB_DST_ADDR, abi.encode(RGB_OP_ID + 2_000));
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT * 9, PRODUCTION_RGB_MINT_BURN_CHAIN_ID, RGB_DST_ADDR, abi.encode(RGB_OP_ID + 2_001));
+
+        IBridge.RebalanceParams memory p = _productionMintBurnToPoolParams(AMOUNT, backingOperationId);
+        bytes32 rebalanceOperationId = _deriveRebalanceOpId(p);
+
+        vm.recordLogs();
+        _rebalance(p);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(rgbModule.fundsInRecords(rebalanceOperationId), 0, "pool credit writes no canonical record");
+        assertEq(
+            _countBridgeLogs(logs, keccak256("FundsIn(address,uint256,uint256)")), 0, "pool credit emits no RGB FundsIn"
+        );
+    }
+
+    function test_productionTopology_poolToMintBurnRebalanceWritesCanonicalRecordAndFundsInEvent() public {
+        usdt0.mint(user, AMOUNT * 10);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT * 10, PRODUCTION_RGB_POOL_CHAIN_ID, RGB_DST_ADDR, "");
+
+        uint256 rgbOpId = RGB_OP_ID + 3_000;
+        IBridge.RebalanceParams memory p = _productionPoolToMintBurnParams(AMOUNT, rgbOpId);
+        bytes32 rebalanceOperationId = _deriveRebalanceOpId(p);
+
+        vm.expectEmit(true, false, false, true);
+        emit FundsIn(multisig, rgbOpId, AMOUNT);
+        _rebalance(p);
+
+        assertEq(rgbModule.fundsInRecords(rebalanceOperationId), AMOUNT, "mint/burn credit creates record");
+        assertEq(
+            rgbModule.fundsInRecordChainIds(rebalanceOperationId),
+            PRODUCTION_RGB_MINT_BURN_CHAIN_ID,
+            "mint/burn record has network 96 tag"
+        );
+    }
 
     function test_rebalance_archToRgb_movesBucketsAndWritesRecord() public {
         uint256 srcBefore = bridge.lockedLiquidity(ARCH_CHAIN_ID);
@@ -334,7 +554,7 @@ contract BridgeRebalanceTest is Test {
 
         // Credit-RGB rebalance emits the standard FundsIn (the RGB side needs
         // no rebalance awareness) plus the canonical BridgeRebalance.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(multisig, mintOpId, AMOUNT);
         vm.expectEmit(true, true, false, true);
         emit BridgeRebalance(expectedOpId, p.burnId, ARCH_CHAIN_ID, RGB_CHAIN_ID, AMOUNT, ARCH_SRC_ADDR, RGB_DST_ADDR);
@@ -389,7 +609,7 @@ contract BridgeRebalanceTest is Test {
         // Both sides are RGB: the debit leg verifies the mint/burn record and the
         // credit leg writes a NEW pool record + emits FundsIn — all on the one
         // shared module, no composite module or privileged writer.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(multisig, poolOpId, AMOUNT);
         _rebalance(p);
 
@@ -410,7 +630,7 @@ contract BridgeRebalanceTest is Test {
         // Scenario A: operational, no external burn → NullVerifier, empty proof
         // and empty debit settlement. The credit leg writes the mint/burn record
         // (tagged with the mint/burn network) and emits the inflate FundsIn.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(multisig, inflateOpId, AMOUNT);
         _rebalance(p);
 
@@ -484,6 +704,40 @@ contract BridgeRebalanceTest is Test {
         assertEq(bridge.availableGlobalOutflow(), globalBefore, "global bucket untouched (no token egress)");
     }
 
+    function test_rebalanceBucketCapacityDoesNotDecayWhenRollingUsageExpires() public {
+        vm.warp((block.timestamp / 1 hours + 1) * 1 hours);
+        uint256 startedAt = block.timestamp;
+
+        _rebalance(_archToRgbParams(AMOUNT, RGB_OP_ID + 1));
+        assertEq(bridge.lockedLiquidity(ARCH_CHAIN_ID), AMOUNT * 9, "actual source liquidity debited");
+
+        vm.warp(startedAt + 24 hours + 1 minutes);
+        assertEq(bridge.chainOutflowReference(ARCH_CHAIN_ID), AMOUNT * 9, "pre-expiry bucket reference");
+        assertEq(bridge.availableOutflow(ARCH_CHAIN_ID), AMOUNT * 9 / 10, "pre-expiry full bucket");
+
+        // The old rolling-inclusive reference incorrectly exposed AMOUNT here,
+        // allowing an intent that became permanently above-capacity at expiry.
+        // With the actual-liquidity reference it is rejected immediately.
+        IBridge.RebalanceParams memory oversized = _archToRgbParams(AMOUNT, RGB_OP_ID + 2);
+        uint256 capacityShares = MAX_BURST_BPS * bridge.SHARE_UNIT() / bridge.BPS_DENOMINATOR();
+        uint256 requestedShares = (AMOUNT * bridge.SHARE_UNIT() + AMOUNT * 9 - 1) / (AMOUNT * 9);
+        vm.prank(multisig);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OutflowRateLimiter.TokenRequestAboveCapacity.selector, capacityShares, requestedShares, address(usdt0)
+            )
+        );
+        bridge.rebalanceLiquidity(oversized);
+
+        vm.warp(startedAt + 25 hours);
+        uint256 validAmount = AMOUNT * 9 / 10;
+        assertEq(bridge.chainOutflowReference(ARCH_CHAIN_ID), AMOUNT * 9, "post-expiry bucket reference");
+        assertEq(bridge.availableOutflow(ARCH_CHAIN_ID), validAmount, "post-expiry full bucket unchanged");
+
+        _rebalance(_archToRgbParams(validAmount, RGB_OP_ID + 3));
+        assertEq(bridge.lockedLiquidity(ARCH_CHAIN_ID), AMOUNT * 81 / 10, "valid tranche executes after expiry");
+    }
+
     function test_rebalance_distinctMints_differInDestinationOpId() public {
         // Legitimately distinct credit-side rebalances differ in the destination
         // RGB OpId (settlementDataIn), which alone makes their canonical ids
@@ -496,6 +750,14 @@ contract BridgeRebalanceTest is Test {
         bytes32 secondOpId = _deriveRebalanceOpId(second);
         assertTrue(first.burnId != second.burnId, "distinct burnId per destination OpId");
         assertTrue(firstOpId != secondOpId, "distinct operationId per destination OpId");
+
+        // Restore the source liquidity so the same absolute amount remains 10%
+        // of the live bucket reference. This test isolates destination OpId as
+        // the only intent difference rather than relying on rolling usage to
+        // preserve a stale, higher reference.
+        usdt0.mint(user, AMOUNT);
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, ARCH_CHAIN_ID, ARCH_DST_ADDR, "");
         vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
         _rebalance(second);
 

--- a/ethereum/test/BridgeRebalance.t.sol
+++ b/ethereum/test/BridgeRebalance.t.sol
@@ -103,7 +103,7 @@ contract BridgeRebalanceTest is Test {
 
         cm = new CommissionManager(predictedBridge, deployer);
         routeRegistry = new RouteRegistry(predictedBridge, deployer);
-        bridge = new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 1);
+        bridge = new Bridge(address(usdt0), address(routeRegistry), payable(address(cm)), address(0), 1, 1);
 
         rgbVerifier = new RGBVerifier(address(btcRelay), 6, 1, 5);
         nullVerifier = new NullVerifier();

--- a/ethereum/test/BtcRelayCheckpoint.t.sol
+++ b/ethereum/test/BtcRelayCheckpoint.t.sol
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import {Test} from "forge-std/Test.sol";
+
+import {BtcRelay} from "../src/btc_relay/BtcRelay.sol";
+import {BtcRelayTestnet} from "../src/btc_relay/BtcRelayTestnet.sol";
+import {StoredBlockHeader as MainnetStoredBlockHeader} from "../src/btc_relay/structs/StoredBlockHeader.sol";
+import {StoredBlockHeader as TestnetStoredBlockHeader} from "../src/btc_relay/structs/StoredBlockHeaderTestnet.sol";
+import {RGBVerifier} from "../src/verifiers/RGBVerifier.sol";
+import {MockBtcRelay} from "./mocks/MockBtcRelay.sol";
+import {FundsOutContext} from "../src/interfaces/RouteTypes.sol";
+
+contract BtcRelayCheckpointTest is Test {
+    uint32 internal constant CHECKPOINT_HEIGHT = 850_000;
+    uint32 internal constant BELOW_CHECKPOINT_HEIGHT = 849_000;
+
+    BtcRelay internal relay;
+    RGBVerifier internal verifier;
+    bytes32 internal checkpointCommitment;
+
+    function setUp() public {
+        relay = new BtcRelay(_headerAtHeight(CHECKPOINT_HEIGHT), true);
+        checkpointCommitment = relay.getTipCommitHash();
+        verifier = new RGBVerifier(address(relay), 6, 1, 5);
+    }
+
+    function test_verifyBlockheaderHash_rejectsZeroCommitmentBelowCheckpoint() public {
+        assertEq(relay.getCommitHash(BELOW_CHECKPOINT_HEIGHT), bytes32(0));
+
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    function test_verifyBlockheaderHash_rejectsNonZeroCommitmentBelowCheckpoint() public {
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, keccak256("phantom-block"));
+    }
+
+    function test_verifyBlockheaderHash_rejectsZeroCommitmentAtCheckpoint() public {
+        vm.expectRevert(bytes("verify: zero commitment"));
+        relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    function test_verifyBlockheaderHash_acceptsStoredCheckpointCommitment() public view {
+        assertTrue(checkpointCommitment != bytes32(0));
+        assertEq(relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, checkpointCommitment), 1);
+    }
+
+    function test_verifyBlockheaderHash_preservesFutureHeightRevert() public {
+        vm.expectRevert(bytes("verify: future block"));
+        relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT + 1, bytes32(0));
+    }
+
+    function test_rgbVerifier_rejectsPhantomSourceBelowCheckpoint() public {
+        bytes memory proof = abi.encode(BELOW_CHECKPOINT_HEIGHT, bytes32(0), CHECKPOINT_HEIGHT, checkpointCommitment);
+        FundsOutContext memory context;
+
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        verifier.verify(context, proof);
+    }
+
+    function _headerAtHeight(uint32 height) private pure returns (MainnetStoredBlockHeader memory header) {
+        // blockHeight() reads a big-endian uint32 at byte offset 112, i.e.
+        // bytes 16..19 of data[3].
+        header.data[3] = bytes32(uint256(height) << 96);
+    }
+}
+
+contract BtcRelayTestnetCheckpointTest is Test {
+    uint32 internal constant CHECKPOINT_HEIGHT = 2_500_000;
+    uint32 internal constant BELOW_CHECKPOINT_HEIGHT = 2_499_000;
+
+    BtcRelayTestnet internal relay;
+    bytes32 internal checkpointCommitment;
+
+    function setUp() public {
+        relay = new BtcRelayTestnet(_headerAtHeight(CHECKPOINT_HEIGHT), true);
+        checkpointCommitment = relay.getTipCommitHash();
+    }
+
+    function test_verifyBlockheaderHash_rejectsZeroCommitmentBelowCheckpoint() public {
+        assertEq(relay.getCommitHash(BELOW_CHECKPOINT_HEIGHT), bytes32(0));
+
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    function test_verifyBlockheaderHash_rejectsZeroCommitmentAtCheckpoint() public {
+        vm.expectRevert(bytes("verify: zero commitment"));
+        relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    function test_verifyBlockheaderHash_acceptsStoredCheckpointCommitment() public view {
+        assertTrue(checkpointCommitment != bytes32(0));
+        assertEq(relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, checkpointCommitment), 1);
+    }
+
+    function test_verifyBlockheaderHash_preservesFutureHeightRevert() public {
+        vm.expectRevert(bytes("verify: future block"));
+        relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT + 1, bytes32(0));
+    }
+
+    function _headerAtHeight(uint32 height) private pure returns (TestnetStoredBlockHeader memory header) {
+        header.data[3] = bytes32(uint256(height) << 96);
+    }
+}
+
+/// @notice `MockBtcRelay` stands in for the relay across the Bridge, MultisigProxy
+///         and RGBVerifier suites. It must reject exactly what the real relay
+///         rejects, otherwise an integration test could accept a proof the
+///         deployed relay would refuse.
+contract MockBtcRelayCheckpointTest is Test {
+    uint256 internal constant CHECKPOINT_HEIGHT = 850_000;
+    uint256 internal constant BELOW_CHECKPOINT_HEIGHT = 849_000;
+    uint256 internal constant LATEST_HEIGHT = 850_005;
+
+    bytes32 internal constant SOURCE_COMMIT = keccak256("mock-source-block");
+    bytes32 internal constant LATEST_COMMIT = keccak256("mock-latest-block");
+
+    MockBtcRelay internal relay;
+    RGBVerifier internal verifier;
+
+    function setUp() public {
+        relay = new MockBtcRelay();
+        relay.setCheckpointHeight(CHECKPOINT_HEIGHT);
+        relay.setBlock(CHECKPOINT_HEIGHT, SOURCE_COMMIT, 6);
+        relay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, 1);
+        verifier = new RGBVerifier(address(relay), 6, 1, 5);
+    }
+
+    /// Contrast: with no checkpoint configured (the previous mock behaviour) a
+    /// block registered below the real relay's checkpoint is served happily.
+    /// Setting the checkpoint is what closes that divergence.
+    function test_withoutCheckpointBelowHeightIsServed() public {
+        MockBtcRelay fresh = new MockBtcRelay();
+        assertEq(fresh.checkpointHeight(), 0, "default keeps the pre-existing behaviour");
+
+        bytes32 belowCommit = keccak256("registered-below-checkpoint");
+        fresh.setBlock(BELOW_CHECKPOINT_HEIGHT, belowCommit, 1000);
+        assertEq(
+            fresh.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, belowCommit),
+            1000,
+            "un-checkpointed mock serves a height the real relay rejects"
+        );
+
+        fresh.setCheckpointHeight(CHECKPOINT_HEIGHT);
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        fresh.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, belowCommit);
+    }
+
+    function test_rejectsZeroCommitmentBelowCheckpoint() public {
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    /// The divergence that actually mattered: before the checkpoint existed the
+    /// mock happily served a block registered below it, which the real relay
+    /// rejects outright. A suite could therefore green-light a proof the
+    /// deployed relay would refuse.
+    function test_rejectsRegisteredBlockBelowCheckpoint() public {
+        bytes32 belowCommit = keccak256("registered-below-checkpoint");
+        relay.setBlock(BELOW_CHECKPOINT_HEIGHT, belowCommit, 1000);
+
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, belowCommit);
+    }
+
+    function test_rejectsUnregisteredCommitmentBelowCheckpoint() public {
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, keccak256("phantom-block"));
+    }
+
+    function test_rejectsZeroCommitmentAtRegisteredHeight() public {
+        vm.expectRevert(bytes("verify: zero commitment"));
+        relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    function test_preservesUnknownBlockRevert() public {
+        vm.expectRevert(bytes("verify: block commitment"));
+        relay.verifyBlockheaderHash(LATEST_HEIGHT + 999, keccak256("unknown"));
+    }
+
+    function test_acceptsRegisteredBlock() public view {
+        assertEq(relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, SOURCE_COMMIT), 6);
+    }
+
+    /// The exact proof shape from the audit finding, driven through the mock the
+    /// integration suites use.
+    function test_rgbVerifier_rejectsPhantomSourceOverMock() public {
+        bytes memory proof = abi.encode(BELOW_CHECKPOINT_HEIGHT, bytes32(0), LATEST_HEIGHT, LATEST_COMMIT);
+        FundsOutContext memory context;
+
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        verifier.verify(context, proof);
+    }
+}

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.35;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {CommissionManager} from "../src/CommissionManager.sol";
 import {
@@ -12,6 +12,7 @@ import {
 } from "../src/interfaces/ICommissionManager.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
 import {MockAggregatorV3} from "./mocks/MockAggregatorV3.sol";
+import {MockDepositFloor} from "./mocks/MockDepositFloor.sol";
 
 contract CommissionManagerTest is Test {
     CommissionManager internal cm;
@@ -39,9 +40,15 @@ contract CommissionManagerTest is Test {
     uint256 internal constant MIN_ETH_USD = 100e8;
     uint256 internal constant MAX_ETH_USD = 100_000e8;
 
+    /// @dev Bridge dust floors the manager reads to bound a flat `baseFee` on
+    ///      each side. 1 USDT0 / 2 USDT0 at 6 decimals — deliberately different
+    ///      so a test that reads the wrong one fails.
+    uint256 internal constant DEPOSIT_FLOOR = 1_000_000;
+    uint256 internal constant RELEASE_FLOOR = 2_000_000;
+
     event BridgeAddressUpdated(address indexed newBridge);
     event GlobalDefaultsUpdated(
-        uint256 stablePercent, uint8 multiplier, CommissionSide side, CommissionCurrency currency
+        uint256 stablePercent, uint256 baseFee, uint8 multiplier, CommissionSide side, CommissionCurrency currency
     );
     event EthUsdFeedUpdated(address indexed feed, uint256 heartbeat);
     event TokenCommissionReceived(address indexed token, uint256 amount);
@@ -54,11 +61,17 @@ contract CommissionManagerTest is Test {
         // underflowing.
         vm.warp(HEARTBEAT * 10);
 
+        // `BRIDGE` is a bare address in these unit tests, but the manager reads
+        // the Bridge dust floors off it to bound a flat `baseFee`. Install the
+        // getters there so the existing `vm.prank(BRIDGE)` call sites are
+        // unaffected.
+        _installFloors(BRIDGE, DEPOSIT_FLOOR, RELEASE_FLOOR);
+
         vm.prank(owner);
         cm = new CommissionManager(BRIDGE, recipient);
         token = new MockERC20("Test", "TST");
         vm.prank(owner);
-        cm.setGlobalDefaults(0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(0, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
 
         // Install a complete healthy Arbitrum oracle config. The sequencer feed
         // and price band are mandatory whenever a non-zero NATIVE
@@ -70,6 +83,14 @@ contract CommissionManagerTest is Test {
         cm.setEthUsdPriceBounds(MIN_ETH_USD, MAX_ETH_USD);
         cm.setEthUsdFeed(address(ethUsdFeed), HEARTBEAT);
         vm.stopPrank();
+    }
+
+    /// @dev Put the Bridge dust-floor getters at `where`, reporting `inFloor`
+    ///      for deposits and `outFloor` for releases.
+    function _installFloors(address where, uint256 inFloor, uint256 outFloor) internal {
+        vm.etch(where, address(new MockDepositFloor()).code);
+        MockDepositFloor(where).setMinFundsInAmount(inFloor);
+        MockDepositFloor(where).setMinFundsOutAmount(outFloor);
     }
 
     // --- Constructor ---
@@ -187,9 +208,9 @@ contract CommissionManagerTest is Test {
         // deposit). NATIVE + FUNDS_OUT is rejected by the setter and is covered
         // by a dedicated revert test.
         vm.expectEmit(true, true, true, true);
-        emit GlobalDefaultsUpdated(200, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
+        emit GlobalDefaultsUpdated(200, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
         vm.prank(owner);
-        cm.setGlobalDefaults(200, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
+        cm.setGlobalDefaults(200, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
         (uint256 sp, uint8 m, CommissionSide side, CommissionCurrency cur) = cm.getGlobalDefaults();
         assertEq(sp, 200);
         assertEq(m, 100);
@@ -200,21 +221,21 @@ contract CommissionManagerTest is Test {
     function test_setGlobalDefaults_onlyOwner() public {
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
-        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
     function test_setGlobalDefaults_revertsPercentTooHigh() public {
         vm.prank(owner);
         vm.expectRevert(ICommissionManager.StablePercentTooHigh.selector);
-        cm.setGlobalDefaults(9001, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(9001, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
     function test_setGlobalDefaults_acceptsZeroPercent() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(100, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(100, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
         assertEq(cm.globalStablePercent(), 100);
         vm.prank(owner);
-        cm.setGlobalDefaults(0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(0, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
         (uint256 sp,,,) = cm.getGlobalDefaults();
         assertEq(sp, 0);
     }
@@ -222,20 +243,20 @@ contract CommissionManagerTest is Test {
     function test_setGlobalDefaults_revertsZeroMultiplier() public {
         vm.prank(owner);
         vm.expectRevert(ICommissionManager.MultiplierZero.selector);
-        cm.setGlobalDefaults(400, 0, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(400, 0, 0, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
     /// @dev setGlobalDefaults rejects the NATIVE + FUNDS_OUT shape.
     function test_setGlobalDefaults_revertsNativeFundsOut() public {
         vm.prank(owner);
         vm.expectRevert(ICommissionManager.NativeCommissionNotAllowedOnFundsOut.selector);
-        cm.setGlobalDefaults(100, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.NATIVE);
+        cm.setGlobalDefaults(100, 0, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.NATIVE);
     }
 
     /// @dev FUNDS_IN + NATIVE stays valid — the user funds the native fee on deposit.
     function test_setGlobalDefaults_acceptsNativeFundsIn() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(100, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
+        cm.setGlobalDefaults(100, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
         (,, CommissionSide side, CommissionCurrency cur) = cm.getGlobalDefaults();
         assertEq(uint8(side), uint8(CommissionSide.FUNDS_IN));
         assertEq(uint8(cur), uint8(CommissionCurrency.NATIVE));
@@ -245,7 +266,7 @@ contract CommissionManagerTest is Test {
 
     function test_calculateFundsInCommission_token_deductsFromAmount() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
         address t = address(token);
         uint256 amount = 100_000;
         (uint256 tok, uint256 nat, uint256 net) = cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, amount);
@@ -265,7 +286,7 @@ contract CommissionManagerTest is Test {
 
     function test_calculateFundsInCommission_zeroStablePercent_native_skipsFeedCheck() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
+        cm.setGlobalDefaults(0, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
         // Make the feed unhealthy: if the contract still hit it the call would
         // revert. A zero stable percent must short-circuit before the read.
         ethUsdFeed.setAnswer(0);
@@ -279,7 +300,7 @@ contract CommissionManagerTest is Test {
 
     function test_calculateFundsInCommission_native_fullAmount_bridged() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
         address t = address(token);
         uint256 amount = 100_000 ether;
         (uint256 tok, uint256 nat, uint256 net) = cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, amount);
@@ -295,7 +316,7 @@ contract CommissionManagerTest is Test {
 
     function test_calculateFundsInCommission_skipsWhenSideIsFundsOut() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.TOKEN);
         address t = address(token);
         (uint256 tok, uint256 nat, uint256 net) = cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, 50_000);
         assertEq(tok, 0);
@@ -310,7 +331,7 @@ contract CommissionManagerTest is Test {
         vm.prank(owner);
         cm.setEthUsdFeed(address(0), 0);
         vm.prank(owner);
-        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
         address t = address(token);
         vm.expectRevert(ICommissionManager.EthUsdFeedNotSet.selector);
         cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, 1000);
@@ -318,7 +339,7 @@ contract CommissionManagerTest is Test {
 
     function test_calculateFundsInCommission_native_revertsWhenPriceStale() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
         ethUsdFeed.setUpdatedAt(block.timestamp - HEARTBEAT - 1);
         vm.expectRevert(ICommissionManager.StalePrice.selector);
         cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 1000);
@@ -365,7 +386,7 @@ contract CommissionManagerTest is Test {
 
     function test_calculateFundsOutCommission_token() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.TOKEN);
         address t = address(token);
         uint256 amount = 80_000;
         (uint256 tok, uint256 nat, uint256 net) = cm.calculateFundsOutCommission(SRC_CHAIN_ID, DST_CHAIN_ID, t, amount);
@@ -388,6 +409,7 @@ contract CommissionManagerTest is Test {
         address t = address(token);
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 1000,
+            baseFee: 0,
             multiplier: 100,
             side: CommissionSide.FUNDS_IN,
             currency: CommissionCurrency.TOKEN,
@@ -407,10 +429,11 @@ contract CommissionManagerTest is Test {
 
     function test_clearCommissionRule_fallsBackToGlobal() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
         address t = address(token);
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 1000,
+            baseFee: 0,
             multiplier: 100,
             side: CommissionSide.FUNDS_IN,
             currency: CommissionCurrency.TOKEN,
@@ -432,6 +455,7 @@ contract CommissionManagerTest is Test {
         address t = address(token);
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 9001,
+            baseFee: 0,
             multiplier: 100,
             side: CommissionSide.FUNDS_IN,
             currency: CommissionCurrency.TOKEN,
@@ -447,6 +471,7 @@ contract CommissionManagerTest is Test {
         address t = address(token);
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 100,
+            baseFee: 0,
             multiplier: 100,
             side: CommissionSide.FUNDS_OUT,
             currency: CommissionCurrency.NATIVE,
@@ -462,6 +487,7 @@ contract CommissionManagerTest is Test {
         address t = address(token);
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 100,
+            baseFee: 0,
             multiplier: 100,
             side: CommissionSide.FUNDS_OUT,
             currency: CommissionCurrency.TOKEN,
@@ -485,7 +511,7 @@ contract CommissionManagerTest is Test {
     function test_setGlobalDefaults_revertsWhenStablePercentExceedsMultiplierSquared() public {
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(9000), uint8(1)));
-        cm.setGlobalDefaults(9000, 1, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(9000, 0, 1, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
     /// @dev Boundary just above the invariant: `multiplier = 10` → `multiplier^2 = 100`,
@@ -493,14 +519,14 @@ contract CommissionManagerTest is Test {
     function test_setGlobalDefaults_revertsJustAboveFeeShapeBoundary() public {
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(101), uint8(10)));
-        cm.setGlobalDefaults(101, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(101, 0, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
     /// @dev The exact boundary is a 100% fee and must be rejected too.
     function test_setGlobalDefaults_revertsFeeShapeAtExactBoundary() public {
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(100), uint8(10)));
-        cm.setGlobalDefaults(100, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(100, 0, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
     /// @dev Regression for the uint8 widening in the fix. With the default
@@ -511,7 +537,7 @@ contract CommissionManagerTest is Test {
     ///      the fix widens to uint256 before squaring.
     function test_setGlobalDefaults_acceptsHighPercentWithDefaultMultiplier() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(9000, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(9000, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
         (uint256 sp, uint8 m,,) = cm.getGlobalDefaults();
         assertEq(sp, 9000);
         assertEq(m, 100);
@@ -521,6 +547,7 @@ contract CommissionManagerTest is Test {
     function test_setCommissionRule_revertsWhenStablePercentExceedsMultiplierSquared() public {
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 9000,
+            baseFee: 0,
             multiplier: 1,
             side: CommissionSide.FUNDS_IN,
             currency: CommissionCurrency.TOKEN,
@@ -535,6 +562,7 @@ contract CommissionManagerTest is Test {
     function test_setCommissionRule_revertsFeeShapeAtExactBoundary() public {
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 100,
+            baseFee: 0,
             multiplier: 10,
             side: CommissionSide.FUNDS_IN,
             currency: CommissionCurrency.TOKEN,
@@ -549,6 +577,7 @@ contract CommissionManagerTest is Test {
     function test_setCommissionRule_acceptsHighPercentWithDefaultMultiplier() public {
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 9000,
+            baseFee: 0,
             multiplier: 100,
             side: CommissionSide.FUNDS_IN,
             currency: CommissionCurrency.TOKEN,
@@ -565,13 +594,13 @@ contract CommissionManagerTest is Test {
     function test_rejectsHundredPercentFeeConfiguration() public {
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, uint256(8100), uint8(90)));
-        cm.setGlobalDefaults(8100, 90, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(8100, 0, 90, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
     }
 
     /// @dev A non-zero inbound fee policy cannot silently round to zero.
     function test_fundsInActiveFeeRejectsCommissionFreeDust() public {
         vm.prank(owner);
-        cm.setGlobalDefaults(400, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -585,6 +614,7 @@ contract CommissionManagerTest is Test {
     function test_fundsOutActiveFeeRejectsCommissionFreeDust() public {
         CommissionConfig memory cfg = CommissionConfig({
             stablePercent: 400,
+            baseFee: 0,
             multiplier: 100,
             side: CommissionSide.FUNDS_OUT,
             currency: CommissionCurrency.TOKEN,
@@ -1001,5 +1031,425 @@ contract CommissionManagerTest is Test {
         vm.prank(user);
         vm.expectRevert();
         cm.setEthUsdPriceBounds(1_000e8, 100_000e8);
+    }
+
+    // =========================================================================
+    // Effective-rate ceiling (90%)
+    //
+    // The charged fraction is `stablePercent / multiplier^2`, so bounding
+    // `stablePercent` alone only caps the rate at `multiplier == 100`. These
+    // cover the ceiling on the rate itself.
+    // =========================================================================
+
+    /// @dev The canonical bypass: 99 / 10^2 = 99%, with both `stablePercent` and
+    ///      the "below 100%" shape bound individually satisfied.
+    function test_feeRate_rejectsSmallMultiplierBypass() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.FeeRateTooHigh.selector, 99, uint8(10)));
+        cm.setGlobalDefaults(99, 0, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    /// @dev The worst case reachable under the old bounds: 8999 / 95^2 ≈ 99.7%.
+    function test_feeRate_rejectsNearHundredPercentBypass() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.FeeRateTooHigh.selector, 8999, uint8(95)));
+        cm.setGlobalDefaults(8999, 0, 95, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    function test_feeRate_acceptsExactlyNinetyPercentAtSmallMultiplier() public {
+        // 90 / 10^2 = 90% — exactly the ceiling.
+        vm.prank(owner);
+        cm.setGlobalDefaults(90, 0, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+
+        (uint256 tok,,) = cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 1_000_000);
+        assertEq(tok, 900_000, "90% charged");
+    }
+
+    function test_feeRate_rejectsOneUnitAboveCeilingAtSmallMultiplier() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.FeeRateTooHigh.selector, 91, uint8(10)));
+        cm.setGlobalDefaults(91, 0, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    /// @dev At the conventional multiplier the ceiling reduces to the old raw
+    ///      bound, so no existing rule shape changes meaning.
+    function test_feeRate_unchangedAtDefaultMultiplier() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(9000, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        assertEq(cm.globalStablePercent(), 9000);
+
+        // 9001 still trips the raw numerator bound first, as before.
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.StablePercentTooHigh.selector);
+        cm.setGlobalDefaults(9001, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    /// @dev An over-100% shape keeps reporting `InvalidFeeShape`, not the new
+    ///      rate error — the checks are ordered so that diagnosis is preserved.
+    function test_feeRate_overHundredPercentStillReportsInvalidFeeShape() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.InvalidFeeShape.selector, 101, uint8(10)));
+        cm.setGlobalDefaults(101, 0, 10, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    function test_feeRate_ceilingAppliesToPerRouteRuleToo() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.FeeRateTooHigh.selector, 99, uint8(10)));
+        cm.setCommissionRule(
+            SRC_CHAIN_ID,
+            DST_CHAIN_ID,
+            address(token),
+            CommissionConfig({
+                stablePercent: 99,
+                baseFee: 0,
+                multiplier: 10,
+                side: CommissionSide.FUNDS_IN,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+    }
+
+    /// @dev The invariant itself: for ANY `(stablePercent, multiplier)` the
+    ///      setter accepts, the charged fee never exceeds 90% of the amount.
+    function testFuzz_feeRate_acceptedConfigNeverChargesAboveCeiling(
+        uint256 stablePercent,
+        uint8 multiplier,
+        uint256 amount
+    ) public {
+        stablePercent = bound(stablePercent, 0, 20_000);
+        amount = bound(amount, 1, 1e30);
+
+        vm.prank(owner);
+        try cm.setGlobalDefaults(stablePercent, 0, multiplier, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN) {
+            // Accepted — the resulting fee must respect the ceiling.
+            uint256 fee = cm.calculateStableFee(amount, stablePercent, multiplier);
+            assertLe(fee * 10_000, amount * 9_000, "accepted config charges at most 90%");
+            assertLt(fee, amount == 0 ? 1 : amount + 1, "fee never exceeds the amount");
+        } catch {
+            // Rejected — nothing to assert.
+        }
+    }
+
+    // =========================================================================
+    // Flat `baseFee`
+    // =========================================================================
+
+    function _cfg(uint256 stablePercent, uint256 baseFee, CommissionSide side, CommissionCurrency currency)
+        internal
+        pure
+        returns (CommissionConfig memory)
+    {
+        return CommissionConfig({
+            stablePercent: stablePercent, baseFee: baseFee, multiplier: 100, side: side, currency: currency, isSet: true
+        });
+    }
+
+    /// @dev The flat part is ADDED to the proportional one, not multiplied into it.
+    function test_baseFee_addsOnTopOfPercentage() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(200, 50_000, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+
+        // 2% of 10_000_000 = 200_000, plus the flat 50_000.
+        (uint256 tok,, uint256 net) =
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 10_000_000);
+        assertEq(tok, 250_000, "percentage + flat");
+        assertEq(net, 9_750_000, "net is gross minus total");
+    }
+
+    /// @dev A route may charge a flat fee only, with no proportional part.
+    function test_baseFee_aloneWithZeroPercent() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(0, 50_000, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+
+        (uint256 tok,, uint256 net) =
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 10_000_000);
+        assertEq(tok, 50_000);
+        assertEq(net, 9_950_000);
+    }
+
+    /// @dev Both parts zero still means "fee disabled for this route".
+    function test_baseFee_zeroBothKeepsFeeDisabled() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(0, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+
+        (uint256 tok,, uint256 net) = cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 1234);
+        assertEq(tok, 0);
+        assertEq(net, 1234);
+    }
+
+    /// @dev A flat fee never rounds away, so it also removes the
+    ///      `CommissionRoundsToZero` dust revert an amount-only fee has.
+    function test_baseFee_preventsCommissionRoundingToZero() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(400, 10, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+
+        // 4% of 24 rounds to 0, but the flat 10 keeps the total non-zero.
+        (uint256 tok,, uint256 net) = cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 24);
+        assertEq(tok, 10);
+        assertEq(net, 14);
+    }
+
+    /// @dev The NATIVE path converts the FULL fee (proportional + flat).
+    function test_baseFee_includedInNativeConversion() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(200, 50_000, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
+
+        (uint256 tok, uint256 nativeFee, uint256 net) =
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 10_000_000);
+        assertEq(tok, 0, "native route takes no token fee");
+        assertEq(net, 10_000_000, "full amount bridges");
+        // 250_000 token units at 18 decimals, $2000/ETH.
+        assertEq(nativeFee, cm.convertTokenFeeToNative(250_000, 18));
+    }
+
+    /// @dev Per-route override carries its own flat fee.
+    function test_baseFee_perRouteOverride() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(0, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        vm.prank(owner);
+        cm.setCommissionRule(
+            SRC_CHAIN_ID,
+            DST_CHAIN_ID,
+            address(token),
+            _cfg(100, 7_000, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN)
+        );
+
+        (uint256 tok,,) = cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 1_000_000);
+        assertEq(tok, 10_000 + 7_000);
+
+        // Clearing it falls back to the (fee-free) globals.
+        vm.prank(owner);
+        cm.clearCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token));
+        (uint256 tokAfter,,) = cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 1_000_000);
+        assertEq(tokAfter, 0);
+    }
+
+    /// @dev Global fallback carries `globalBaseFee` into the effective config.
+    function test_baseFee_globalFallbackCarriesBaseFee() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(0, 12_345, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        assertEq(cm.globalBaseFee(), 12_345);
+        assertEq(cm.globalStablePercent(), 0);
+
+        // No per-route override exists, so the quote resolves through the
+        // global fallback and must include the flat part.
+        assertEq(cm.calculateTotalFee(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 1_000_000), 12_345);
+    }
+
+    // --- FUNDS_OUT: symmetric, bounded by the release floor ---
+
+    function test_baseFee_appliesOnFundsOut() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(400, 50_000, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.TOKEN);
+
+        (uint256 tok,, uint256 net) =
+            cm.calculateFundsOutCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 10_000_000);
+        assertEq(tok, 400_000 + 50_000, "percentage + flat on release");
+        assertEq(net, 9_550_000);
+    }
+
+    function test_baseFee_zeroStillAllowedOnFundsOut() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.TOKEN);
+        (uint256 tok,,) = cm.calculateFundsOutCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 1_000_000);
+        assertEq(tok, 40_000);
+    }
+
+    /// @dev The release side is bounded by `minFundsOutAmount`, NOT by the
+    ///      deposit floor. A flat fee between the two floors proves which one is
+    ///      actually consulted.
+    function test_baseFee_fundsOutBoundedByReleaseFloorNotDepositFloor() public {
+        // 1_500_000 sits above DEPOSIT_FLOOR (1e6) but below RELEASE_FLOOR (2e6),
+        // so it is valid on the release side and invalid on the deposit side.
+        vm.prank(owner);
+        cm.setGlobalDefaults(0, 1_500_000, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.TOKEN);
+        assertEq(cm.globalBaseFee(), 1_500_000);
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(ICommissionManager.FeeAboveAmountFloor.selector, 1_500_000, DEPOSIT_FLOOR)
+        );
+        cm.setGlobalDefaults(0, 1_500_000, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    function test_baseFee_rejectedWhenItConsumesTheWholeReleaseFloor() public {
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(ICommissionManager.FeeAboveAmountFloor.selector, RELEASE_FLOOR, RELEASE_FLOOR)
+        );
+        cm.setGlobalDefaults(0, RELEASE_FLOOR, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.TOKEN);
+    }
+
+    /// @dev Same live re-check as the deposit side: lowering `minFundsOutAmount`
+    ///      under a stored rule must stop it quoting.
+    function test_baseFee_fundsOutQuoteRevertsAfterReleaseFloorLowered() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(0, 1_800_000, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.TOKEN);
+
+        (uint256 tok,,) = cm.calculateFundsOutCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 5_000_000);
+        assertEq(tok, 1_800_000);
+
+        MockDepositFloor(BRIDGE).setMinFundsOutAmount(1_000_000);
+
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.FeeAboveAmountFloor.selector, 1_800_000, 1_000_000));
+        cm.calculateFundsOutCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 5_000_000);
+    }
+
+    /// @dev NATIVE is still unrepresentable on a release, flat fee or not.
+    function test_baseFee_doesNotUnblockNativeOnFundsOut() public {
+        vm.prank(owner);
+        vm.expectRevert(ICommissionManager.NativeCommissionNotAllowedOnFundsOut.selector);
+        cm.setGlobalDefaults(100, 1000, 100, CommissionSide.FUNDS_OUT, CommissionCurrency.NATIVE);
+    }
+
+    function test_releaseFloor_readsBridge() public view {
+        assertEq(cm.releaseFloor(), RELEASE_FLOOR);
+    }
+
+    // --- Deposit-floor bound ---
+
+    function test_depositFloor_readsBridge() public view {
+        assertEq(cm.depositFloor(), DEPOSIT_FLOOR);
+    }
+
+    function test_baseFee_rejectedWhenItConsumesTheWholeFloor() public {
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(ICommissionManager.FeeAboveAmountFloor.selector, DEPOSIT_FLOOR, DEPOSIT_FLOOR)
+        );
+        cm.setGlobalDefaults(0, DEPOSIT_FLOOR, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    function test_baseFee_acceptedJustBelowTheFloor() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(0, DEPOSIT_FLOOR - 1, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        assertEq(cm.globalBaseFee(), DEPOSIT_FLOOR - 1);
+    }
+
+    /// @dev `baseFee < depositFloor` is NECESSARY but NOT SUFFICIENT: the
+    ///      proportional part consumes some of the floor too, so the bound must
+    ///      be checked on the combined fee.
+    function test_baseFee_belowFloorStillRejectedWhenCombinedFeeExceedsIt() public {
+        // 10% of the floor = 100_000, and a flat fee 1 below the floor.
+        // Individually fine, together 1_099_999 >= 1_000_000.
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICommissionManager.FeeAboveAmountFloor.selector, DEPOSIT_FLOOR - 1 + 100_000, DEPOSIT_FLOOR
+            )
+        );
+        cm.setGlobalDefaults(1000, DEPOSIT_FLOOR - 1, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+    }
+
+    /// @dev The whole point of re-reading the floor on every quote: a rule that
+    ///      was valid when written must stop quoting once the Bridge lowers the
+    ///      floor beneath it.
+    function test_baseFee_quoteRevertsAfterFloorIsLowered() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(0, 900_000, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+
+        // Valid at the original floor.
+        (uint256 tok,,) = cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 5_000_000);
+        assertEq(tok, 900_000);
+
+        // Bridge governance lowers the floor under the already-stored rule.
+        MockDepositFloor(BRIDGE).setMinFundsInAmount(500_000);
+
+        vm.expectRevert(abi.encodeWithSelector(ICommissionManager.FeeAboveAmountFloor.selector, 900_000, 500_000));
+        cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 5_000_000);
+    }
+
+    /// @dev A zero-fee rule is unaffected by the floor moving, so a fee-free
+    ///      route can never be bricked by this coupling.
+    function test_zeroFeeRouteUnaffectedByFloorChanges() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(0, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        MockDepositFloor(BRIDGE).setMinFundsInAmount(1);
+
+        (uint256 tok,, uint256 net) = cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 10);
+        assertEq(tok, 0);
+        assertEq(net, 10);
+    }
+
+    /// @dev The Bridge read is scoped to routes that actually charge a flat fee.
+    ///      A percentage-only route keeps quoting even with the floor
+    ///      unreadable, so the new coupling cannot brick today's routes.
+    function test_percentageOnlyRouteQuotesWithoutReadableFloor() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+
+        vm.prank(owner);
+        cm.setBridgeAddress(makeAddr("floorless-bridge"));
+
+        (uint256 tok,, uint256 net) =
+            cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 10_000_000);
+        assertEq(tok, 400_000, "percentage still quoted");
+        assertEq(net, 9_600_000);
+    }
+
+    /// @dev …and configuring a percentage-only rule does not require the floor either.
+    function test_percentageOnlyConfigAcceptedWithoutReadableFloor() public {
+        vm.prank(owner);
+        cm.setBridgeAddress(makeAddr("floorless-bridge-2"));
+
+        vm.prank(owner);
+        cm.setGlobalDefaults(400, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+        assertEq(cm.globalStablePercent(), 400);
+    }
+
+    function test_depositFloor_revertsWhenBridgeHasNoCode() public {
+        vm.prank(owner);
+        cm.setBridgeAddress(makeAddr("not-a-contract"));
+
+        vm.expectRevert(ICommissionManager.AmountFloorUnavailable.selector);
+        cm.depositFloor();
+    }
+
+    function test_depositFloor_revertsWhenFloorIsZero() public {
+        MockDepositFloor(BRIDGE).setMinFundsInAmount(0);
+
+        vm.expectRevert(ICommissionManager.AmountFloorUnavailable.selector);
+        cm.depositFloor();
+    }
+
+    /// @dev Fail-closed: with the floor unreadable, a fee-bearing quote must not
+    ///      fall through to an unbounded flat fee.
+    function test_quoteFailsClosedWhenFloorUnavailable() public {
+        vm.prank(owner);
+        cm.setGlobalDefaults(400, 1000, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
+
+        vm.prank(owner);
+        cm.setBridgeAddress(makeAddr("not-a-contract-either"));
+
+        vm.expectRevert(ICommissionManager.AmountFloorUnavailable.selector);
+        cm.calculateFundsInCommission(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), 10_000_000);
+    }
+
+    // --- Event/state consistency ---
+
+    /// @dev `setCommissionRule` forces `isSet` true in storage; the log must say
+    ///      the same, even when the caller passed `isSet: false`.
+    function test_setCommissionRule_logsStoredConfigNotCallerStruct() public {
+        CommissionConfig memory passed = CommissionConfig({
+            stablePercent: 1000,
+            baseFee: 0,
+            multiplier: 100,
+            side: CommissionSide.FUNDS_IN,
+            currency: CommissionCurrency.TOKEN,
+            isSet: false
+        });
+
+        vm.recordLogs();
+        vm.prank(owner);
+        cm.setCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token), passed);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1, "one rule event");
+        // `token` is indexed, so the data carries (sourceChainId, destChainId, config).
+        (,, CommissionConfig memory logged) = abi.decode(logs[0].data, (uint256, uint256, CommissionConfig));
+        assertTrue(logged.isSet, "logged config reflects stored isSet");
+        assertEq(logged.stablePercent, 1000);
+        assertTrue(cm.getCommissionRule(SRC_CHAIN_ID, DST_CHAIN_ID, address(token)).isSet);
     }
 }

--- a/ethereum/test/CommissionManager.t.sol
+++ b/ethereum/test/CommissionManager.t.sol
@@ -196,8 +196,9 @@ contract CommissionManagerTest is Test {
     // --- Global defaults ---
 
     function test_getGlobalDefaults_initial() public view {
-        (uint256 sp, uint8 m, CommissionSide side, CommissionCurrency cur) = cm.getGlobalDefaults();
+        (uint256 sp, uint256 baseFee, uint8 m, CommissionSide side, CommissionCurrency cur) = cm.getGlobalDefaults();
         assertEq(sp, 0);
+        assertEq(baseFee, 0);
         assertEq(m, 100);
         assertEq(uint8(side), uint8(CommissionSide.FUNDS_IN));
         assertEq(uint8(cur), uint8(CommissionCurrency.TOKEN));
@@ -208,11 +209,12 @@ contract CommissionManagerTest is Test {
         // deposit). NATIVE + FUNDS_OUT is rejected by the setter and is covered
         // by a dedicated revert test.
         vm.expectEmit(true, true, true, true);
-        emit GlobalDefaultsUpdated(200, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
+        emit GlobalDefaultsUpdated(200, 50_000, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
         vm.prank(owner);
-        cm.setGlobalDefaults(200, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
-        (uint256 sp, uint8 m, CommissionSide side, CommissionCurrency cur) = cm.getGlobalDefaults();
+        cm.setGlobalDefaults(200, 50_000, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
+        (uint256 sp, uint256 baseFee, uint8 m, CommissionSide side, CommissionCurrency cur) = cm.getGlobalDefaults();
         assertEq(sp, 200);
+        assertEq(baseFee, 50_000);
         assertEq(m, 100);
         assertEq(uint8(side), uint8(CommissionSide.FUNDS_IN));
         assertEq(uint8(cur), uint8(CommissionCurrency.NATIVE));
@@ -236,7 +238,7 @@ contract CommissionManagerTest is Test {
         assertEq(cm.globalStablePercent(), 100);
         vm.prank(owner);
         cm.setGlobalDefaults(0, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
-        (uint256 sp,,,) = cm.getGlobalDefaults();
+        (uint256 sp,,,,) = cm.getGlobalDefaults();
         assertEq(sp, 0);
     }
 
@@ -257,7 +259,7 @@ contract CommissionManagerTest is Test {
     function test_setGlobalDefaults_acceptsNativeFundsIn() public {
         vm.prank(owner);
         cm.setGlobalDefaults(100, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.NATIVE);
-        (,, CommissionSide side, CommissionCurrency cur) = cm.getGlobalDefaults();
+        (,,, CommissionSide side, CommissionCurrency cur) = cm.getGlobalDefaults();
         assertEq(uint8(side), uint8(CommissionSide.FUNDS_IN));
         assertEq(uint8(cur), uint8(CommissionCurrency.NATIVE));
     }
@@ -538,7 +540,7 @@ contract CommissionManagerTest is Test {
     function test_setGlobalDefaults_acceptsHighPercentWithDefaultMultiplier() public {
         vm.prank(owner);
         cm.setGlobalDefaults(9000, 0, 100, CommissionSide.FUNDS_IN, CommissionCurrency.TOKEN);
-        (uint256 sp, uint8 m,,) = cm.getGlobalDefaults();
+        (uint256 sp,, uint8 m,,) = cm.getGlobalDefaults();
         assertEq(sp, 9000);
         assertEq(m, 100);
     }

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -166,6 +166,10 @@ contract IntegrationTest is Test {
 
         token = new MockERC20("Mock USDT0", "USDT0");
         btcRelay = new MockBtcRelay();
+        // The real relay never stores a header below its initialisation
+        // checkpoint; mirror that here so a proof this suite accepts is one
+        // the deployed relay would also accept.
+        btcRelay.setCheckpointHeight(BLOCK_HEIGHT);
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, BTC_CONFIRMATIONS);
         btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONFIRMATIONS);
 

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -193,7 +193,8 @@ contract IntegrationTest is Test {
             address(routeRegistry),
             payable(address(cm)),
             address(0),
-            1 // minFundsInAmount: smallest non-zero floor for tests
+            1, // minFundsInAmount: smallest non-zero floor for tests
+            1 // minFundsOutAmount: smallest non-zero floor for tests
         );
 
         rgbVerifier = new RGBVerifier(address(btcRelay), 6, 1, 5);
@@ -266,6 +267,7 @@ contract IntegrationTest is Test {
                 address(token),
                 CommissionConfig({
                     stablePercent: FUNDS_IN_PERCENT,
+                    baseFee: 0,
                     multiplier: FUNDS_IN_MULT,
                     side: CommissionSide.FUNDS_IN,
                     currency: CommissionCurrency.TOKEN,
@@ -282,6 +284,7 @@ contract IntegrationTest is Test {
                 address(token),
                 CommissionConfig({
                     stablePercent: FUNDS_OUT_PERCENT,
+                    baseFee: 0,
                     multiplier: FUNDS_OUT_MULT,
                     side: CommissionSide.FUNDS_OUT,
                     currency: CommissionCurrency.TOKEN,
@@ -446,6 +449,7 @@ contract IntegrationTest is Test {
                 address(token),
                 CommissionConfig({
                     stablePercent: FUNDS_IN_PERCENT,
+                    baseFee: 0,
                     multiplier: FUNDS_IN_MULT,
                     side: CommissionSide.FUNDS_IN,
                     currency: CommissionCurrency.NATIVE,

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -221,6 +221,10 @@ contract MultisigProxyTest is Test {
 
         token = new MockERC20("Mock USDT0", "USDT0");
         btcRelay = new MockBtcRelay();
+        // The real relay never stores a header below its initialisation
+        // checkpoint; mirror that here so a proof this suite accepts is one
+        // the deployed relay would also accept.
+        btcRelay.setCheckpointHeight(BLOCK_HEIGHT);
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, BTC_CONFIRMATIONS);
         btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONFIRMATIONS);
 
@@ -1698,28 +1702,36 @@ contract MultisigProxyTest is Test {
         _assertGenericPathsRejectSelector(callData, IMultisigProxy.ForbiddenBridgeReleaseSelector.selector);
     }
 
+    function test_federationGenericPathsCannotDesyncCommissionManager() public {
+        bytes memory callData = abi.encodeCall(IBridge.setCommissionManager, (makeAddr("genericCm")));
+        _assertGenericPathsRejectSelector(callData, IMultisigProxy.ForbiddenCommissionManagerSelector.selector);
+    }
+
     // ========================================================================
     // Propose + Execute — UpdateCommissionManager
     // ========================================================================
 
     function test_proposeUpdateCommissionManager_execute() public {
-        address newCm = makeAddr("newCm");
+        CommissionManager newCm = new CommissionManager(address(bridge), commissionReceiver);
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
 
-        bytes32 digest = MultisigHelper.digestProposeUpdateCommissionManager(domainSep, newCm, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestProposeUpdateCommissionManager(domainSep, address(newCm), nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateCommissionManager(newCm, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateCommissionManager(address(newCm), nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
 
-        vm.expectEmit(true, true, false, false);
-        emit CommissionManagerUpdated(address(cm), newCm);
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit CommissionManagerUpdated(address(cm), address(newCm));
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit CommissionManagerUpdated(address(cm), address(newCm));
 
-        proxy.executeProposal(id, abi.encode(newCm));
-        assertEq(proxy.commissionManager(), newCm);
+        proxy.executeProposal(id, abi.encode(address(newCm)));
+        assertEq(proxy.commissionManager(), address(newCm));
+        assertEq(address(bridge.commissionManager()), address(newCm));
     }
 
     // ========================================================================
@@ -1790,16 +1802,17 @@ contract MultisigProxyTest is Test {
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         bytes32 id = proxy.proposeUpdateBridge(newBridge, nonce, deadline, bitmap, sigs);
+        uint256 proposalNonceAfterPropose = proxy.proposalNonce();
 
-        uint256 cNonce = proxy.proposalNonce();
         uint256 cDeadline = block.timestamp + 1 hours;
-        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cNonce, cDeadline);
+        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cDeadline);
         bytes[] memory cSigs = MultisigHelper.signAll(vm, cDigest, pks);
 
         vm.expectEmit(true, false, false, false);
         emit ProposalCancelled(id);
-        proxy.cancelProposal(id, cNonce, cDeadline, bitmap, cSigs);
+        proxy.cancelProposal(id, cDeadline, bitmap, cSigs);
 
+        assertEq(proxy.proposalNonce(), proposalNonceAfterPropose, "cancel does not consume proposal nonce");
         IMultisigProxy.Proposal memory p = proxy.getProposal(id);
         assertEq(uint8(p.status), uint8(IMultisigProxy.ProposalStatus.Cancelled));
 
@@ -1810,14 +1823,74 @@ contract MultisigProxyTest is Test {
 
     function test_cancelProposal_revertsOnNotPending() public {
         bytes32 id = keccak256("ghost");
-        uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 hours;
-        bytes32 digest = MultisigHelper.digestCancelProposal(domainSep, id, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestCancelProposal(domainSep, id, deadline);
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.NotPending.selector);
-        proxy.cancelProposal(id, nonce, deadline, bitmap, sigs);
+        proxy.cancelProposal(id, deadline, bitmap, sigs);
+    }
+
+    /// @dev Regression for the shared-nonce veto-starvation finding. Once a
+    ///      cancel is signed for a concrete proposal, unrelated proposal
+    ///      traffic cannot invalidate it by advancing `proposalNonce`.
+    function test_cancelProposal_survivesUnrelatedProposalNonceAdvance() public {
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+
+        uint256 targetNonce = proxy.proposalNonce();
+        uint256 targetDeadline = block.timestamp + 1 days;
+        address targetBridge = makeAddr("targetBridge");
+        bytes32 targetDigest =
+            MultisigHelper.digestProposeUpdateBridge(domainSep, targetBridge, targetNonce, targetDeadline);
+        bytes32 targetId = proxy.proposeUpdateBridge(
+            targetBridge, targetNonce, targetDeadline, bitmap, MultisigHelper.signAll(vm, targetDigest, pks)
+        );
+
+        uint256 cancelDeadline = block.timestamp + 1 hours;
+        bytes32 cancelDigest = MultisigHelper.digestCancelProposal(domainSep, targetId, cancelDeadline);
+        bytes[] memory cancelSigs = MultisigHelper.signAll(vm, cancelDigest, pks);
+
+        // A different, valid federation proposal advances the sequential
+        // proposal lane after the cancel bundle has already been collected.
+        uint256 unrelatedNonce = proxy.proposalNonce();
+        address unrelatedBridge = makeAddr("unrelatedBridge");
+        bytes32 unrelatedDigest =
+            MultisigHelper.digestProposeUpdateBridge(domainSep, unrelatedBridge, unrelatedNonce, targetDeadline);
+        proxy.proposeUpdateBridge(
+            unrelatedBridge, unrelatedNonce, targetDeadline, bitmap, MultisigHelper.signAll(vm, unrelatedDigest, pks)
+        );
+        uint256 nonceAfterUnrelatedProposal = proxy.proposalNonce();
+        assertEq(nonceAfterUnrelatedProposal, targetNonce + 2, "unrelated proposal advances its own lane");
+
+        proxy.cancelProposal(targetId, cancelDeadline, bitmap, cancelSigs);
+
+        assertEq(proxy.proposalNonce(), nonceAfterUnrelatedProposal, "cancel leaves proposal lane untouched");
+        assertEq(
+            uint256(proxy.getProposal(targetId).status),
+            uint256(IMultisigProxy.ProposalStatus.Cancelled),
+            "original cancel remains executable"
+        );
+    }
+
+    function test_cancelProposal_replayRevertsOnCancelledStatus() public {
+        address newBridge = makeAddr("cancelReplayBridge");
+        uint256 nonce = proxy.proposalNonce();
+        uint256 proposalDeadline = block.timestamp + 1 days;
+        bytes32 proposalDigest = MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, nonce, proposalDeadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes32 id = proxy.proposeUpdateBridge(
+            newBridge, nonce, proposalDeadline, bitmap, MultisigHelper.signAll(vm, proposalDigest, pks)
+        );
+
+        uint256 cancelDeadline = block.timestamp + 1 hours;
+        bytes32 cancelDigest = MultisigHelper.digestCancelProposal(domainSep, id, cancelDeadline);
+        bytes[] memory cancelSigs = MultisigHelper.signAll(vm, cancelDigest, pks);
+
+        proxy.cancelProposal(id, cancelDeadline, bitmap, cancelSigs);
+
+        vm.expectRevert(IMultisigProxy.NotPending.selector);
+        proxy.cancelProposal(id, cancelDeadline, bitmap, cancelSigs);
     }
 
     // ========================================================================
@@ -1958,15 +2031,14 @@ contract MultisigProxyTest is Test {
         address newAdapter = makeAddr("lzAdapter");
         bytes32 id = _proposeUpdateLZAdapter(newAdapter);
 
-        uint256 cNonce = proxy.proposalNonce();
         uint256 cDeadline = block.timestamp + 1 hours;
-        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cNonce, cDeadline);
+        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cDeadline);
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory cSigs = MultisigHelper.signAll(vm, cDigest, pks);
 
         vm.expectEmit(true, false, false, false);
         emit ProposalCancelled(id);
-        proxy.cancelProposal(id, cNonce, cDeadline, bitmap, cSigs);
+        proxy.cancelProposal(id, cDeadline, bitmap, cSigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
         vm.expectRevert(IMultisigProxy.NotPending.selector);
@@ -2922,29 +2994,29 @@ contract MultisigProxyTest is Test {
         assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), hardLimit / 2, "half the allowance left");
         assertEq(bridge.availableGlobalSafetyOutflow(), hardLimit / 2);
 
-        // At 24h + 1s the conservatively rounded share bucket is fully refilled,
-        // while the rolling limiter deliberately still counts the first release.
+        // At 24h + 1s the share bucket is fully refilled against the lower
+        // current liquidity, while the rolling limiter still counts the first
+        // release against its original reference.
         vm.warp(block.timestamp + bridge.BUCKET_REFILL_WINDOW() + 1);
-        _signedRelease(makeAddr("split-recipient-2"), hardLimit / 2, BURN_ID + 1);
-        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), 0, "immutable chain allowance exhausted");
-        assertEq(bridge.availableGlobalSafetyOutflow(), 0, "immutable global allowance exhausted");
+        uint256 secondPart = bridge.effectiveAvailableOutflow(RGB_CHAIN_ID) - 1;
+        _signedRelease(makeAddr("split-recipient-2"), secondPart, BURN_ID + 1);
+        uint256 totalReleased = hardLimit / 2 + secondPart;
+        assertLe(totalReleased, hardLimit, "split releases stay within the immutable ceiling");
+        assertEq(bridge.availableChainSafetyOutflow(RGB_CHAIN_ID), hardLimit - totalReleased);
+        assertEq(bridge.availableGlobalSafetyOutflow(), hardLimit - totalReleased);
 
-        // One second of bucket refill makes the immutable limiter the failing
-        // layer, and `effectiveAvailableOutflow` reports the truth: nothing.
+        // One second of refill cannot make the effective allowance exceed the
+        // remaining immutable allowance.
         vm.warp(block.timestamp + 1);
         assertGt(bridge.availableOutflow(RGB_CHAIN_ID), 0, "bucket has accrued allowance");
-        assertEq(bridge.effectiveAvailableOutflow(RGB_CHAIN_ID), 0, "but nothing may leave");
-
-        (IBridge.FundsOutParams memory third, uint256 nonce, uint256 deadline, uint256 bitmap, bytes[] memory sigs) =
-            _prepareRelease(makeAddr("split-recipient-3"), 1, BURN_ID + 2);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IBridge.ChainSafetyLimitExceeded.selector, RGB_CHAIN_ID, uint256(1), hardLimit, hardLimit
-            )
+        assertLe(
+            bridge.effectiveAvailableOutflow(RGB_CHAIN_ID),
+            hardLimit - totalReleased,
+            "rolling ceiling remains authoritative"
         );
-        proxy.fundsOutCall(third, nonce, deadline, bitmap, sigs);
 
-        assertEq(token.balanceOf(address(bridge)), tvl - hardLimit, "at most 20% left during the window");
+        assertEq(token.balanceOf(address(bridge)), tvl - totalReleased);
+        assertGe(token.balanceOf(address(bridge)), tvl - hardLimit, "at most 20% leaves during the window");
 
         // Liveness: once the oldest usage expires the next tranche is releasable.
         // The ring retains for 24-25h, so 25h past the aligned start clears it.
@@ -3096,6 +3168,65 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.bridge(), newBridge, "snapshotted proposal executes despite the live timelock raise");
     }
 
+    function test_federationRotationInvalidatesPendingProposals() public {
+        assertEq(proxy.federationSignerSetVersion(), 1, "initial federation version");
+
+        // This proposal is valid under the original federation, but remains
+        // pending while a signer rotation is proposed and executed.
+        address staleBridge = makeAddr("staleBridge");
+        uint256 staleNonce = proxy.proposalNonce();
+        uint256 commonDeadline = block.timestamp + 1 days;
+        bytes32 staleDigest =
+            MultisigHelper.digestProposeUpdateBridge(domainSep, staleBridge, staleNonce, commonDeadline);
+        (uint256[] memory oldPks, uint256 oldBitmap) = _fedSigSet2of3();
+        bytes32 staleId = proxy.proposeUpdateBridge(
+            staleBridge, staleNonce, commonDeadline, oldBitmap, MultisigHelper.signAll(vm, staleDigest, oldPks)
+        );
+        assertEq(proxy.getProposal(staleId).federationVersion, 1, "proposal snapshots version one");
+
+        uint256[] memory newPks = new uint256[](3);
+        address[] memory newSigners = new address[](3);
+        for (uint256 i = 0; i < 3; i++) {
+            newPks[i] = 0xFA1 + i;
+            newSigners[i] = vm.addr(newPks[i]);
+        }
+
+        uint256 rotationNonce = proxy.proposalNonce();
+        bytes32 rotationDigest = MultisigHelper.digestProposeUpdateFederationSigners(
+            domainSep, newSigners, 2, rotationNonce, commonDeadline
+        );
+        bytes32 rotationId = proxy.proposeUpdateFederationSigners(
+            newSigners, 2, rotationNonce, commonDeadline, oldBitmap, MultisigHelper.signAll(vm, rotationDigest, oldPks)
+        );
+        assertEq(proxy.getProposal(rotationId).federationVersion, 1, "rotation uses current version");
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(rotationId, abi.encode(newSigners, uint256(2)));
+        assertEq(proxy.federationSignerSetVersion(), 2, "rotation advances version");
+
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.StaleFederationProposal.selector, uint256(1), uint256(2)));
+        proxy.executeProposal(staleId, abi.encode(staleBridge));
+        assertEq(
+            uint256(proxy.getProposal(staleId).status),
+            uint256(IMultisigProxy.ProposalStatus.Pending),
+            "stale proposal cannot execute"
+        );
+
+        // The live federation can still cancel stale records for operational
+        // cleanup; cancellation intentionally has no version restriction.
+        uint256 cancelDeadline = block.timestamp + 1 days;
+        bytes32 cancelDigest = MultisigHelper.digestCancelProposal(domainSep, staleId, cancelDeadline);
+        uint256[] memory cancellingPks = new uint256[](2);
+        cancellingPks[0] = newPks[0];
+        cancellingPks[1] = newPks[1];
+        proxy.cancelProposal(staleId, cancelDeadline, 3, MultisigHelper.signAll(vm, cancelDigest, cancellingPks));
+        assertEq(
+            uint256(proxy.getProposal(staleId).status),
+            uint256(IMultisigProxy.ProposalStatus.Cancelled),
+            "live federation cleans up stale proposal"
+        );
+    }
+
     // Emergency actions run on a separate `emergencyNonce`, so an emergency
     // pause does NOT stale an already-signed regular proposal.
     function test_emergencyDoesNotStaleRegularProposal() public {
@@ -3128,90 +3259,31 @@ contract MultisigProxyTest is Test {
         assertEq(proxy.proposalNonce(), regularNonce + 1, "regular proposal consumed its lane nonce");
     }
 
-    // Generic Bridge admin execution can still call
-    // transferOwnership, but Ownable2Step only records a pendingOwner. A wrong
-    // non-zero address never becomes owner, so governance is not orphaned and
-    // the proxy keeps driving owner-only operations.
-    function test_ownershipTransferToWrongAddressDoesNotOrphanGovernance() public {
-        address wrongOwner = makeAddr("wrongBridgeOwner");
-        uint256 startTime = block.timestamp;
-
-        bytes memory transferCallData = abi.encodeWithSignature("transferOwnership(address)", wrongOwner);
-        uint256 transferNonce = proxy.proposalNonce();
-        uint256 transferDeadline = startTime + 1 days;
-        bytes32 transferDigest = MultisigHelper.digestProposeAdminExecute(
-            domainSep, bytes4(transferCallData), transferCallData, transferNonce, transferDeadline
-        );
-        (uint256[] memory transferPks, uint256 transferBitmap) = _fedSigSet2of3();
-        bytes[] memory transferSigs = MultisigHelper.signAll(vm, transferDigest, transferPks);
-
-        address routeRegistryBefore = bridge.routeRegistry();
-
-        assertEq(bridge.owner(), address(proxy), "pre bridge owner");
-        assertFalse(bridge.paused(), "pre bridge active");
-        assertEq(routeRegistryBefore, address(routeRegistry), "pre route registry");
-
-        bytes32 transferProposalId =
-            proxy.proposeAdminExecute(transferCallData, transferNonce, transferDeadline, transferBitmap, transferSigs);
-
-        uint256 transferReadyAt = startTime + TIMELOCK + 1;
-        vm.warp(transferReadyAt);
-
-        vm.expectEmit(true, true, false, true, address(proxy));
-        emit ProposalExecuted(transferProposalId, IMultisigProxy.OperationType.AdminExecute);
-
-        proxy.executeProposal(transferProposalId, transferCallData);
-
-        // Ownable2Step: ownership did NOT move; the wrong address is only pending.
-        assertEq(bridge.owner(), address(proxy), "owner unchanged (two-step)");
-        assertEq(bridge.pendingOwner(), wrongOwner, "wrong address only pending");
-
-        address replacementRegistry = makeAddr("replacementRouteRegistry");
-        bytes memory registryCallData = abi.encodeWithSignature("setRouteRegistry(address)", replacementRegistry);
-        uint256 registryNonce = proxy.proposalNonce();
-        uint256 registryDeadline = transferReadyAt + 1 days;
-        bytes32 registryDigest = MultisigHelper.digestProposeAdminExecute(
-            domainSep, bytes4(registryCallData), registryCallData, registryNonce, registryDeadline
-        );
-        (uint256[] memory registryPks, uint256 registryBitmap) = _fedSigSet2of3();
-        bytes[] memory registrySigs = MultisigHelper.signAll(vm, registryDigest, registryPks);
-
-        bytes32 registryProposalId =
-            proxy.proposeAdminExecute(registryCallData, registryNonce, registryDeadline, registryBitmap, registrySigs);
-
-        vm.warp(transferReadyAt + TIMELOCK + 1);
-
-        // Governance is NOT orphaned: the proxy still owns Bridge, so the
-        // setRouteRegistry op executes and takes effect.
-        proxy.executeProposal(registryProposalId, registryCallData);
-
-        assertEq(bridge.owner(), address(proxy), "proxy remains owner");
-        assertEq(bridge.routeRegistry(), replacementRegistry, "proxy still governs bridge config");
+    function test_genericPathsRejectTransferOwnershipSelector() public {
+        bytes memory callData = abi.encodeWithSignature("transferOwnership(address)", user);
+        _assertGenericPathsRejectSelector(callData, IMultisigProxy.ForbiddenOwnershipSelector.selector);
     }
 
-    // The new AdminExecuteRouteRegistry op gives the proxy a call path
-    // into RouteRegistry (which previously had only the typed SetRoute op), so
-    // it can drive RouteRegistry's Ownable2Step transferOwnership on migration.
-    function test_adminExecuteRouteRegistry_initiatesRouteRegistryOwnershipTransfer() public {
-        address newOwner = makeAddr("newRouteRegistryOwner");
-        bytes memory callData = abi.encodeWithSignature("transferOwnership(address)", newOwner);
-        uint256 nonce = proxy.proposalNonce();
-        uint256 deadline = block.timestamp + 1 days;
-        bytes32 digest = MultisigHelper.digestProposeAdminExecuteRouteRegistry(
-            domainSep, bytes4(callData), callData, nonce, deadline
-        );
-        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+    function test_transferManagedOwnership_initiatesBridgeOwnershipTransfer() public {
+        address newOwner = makeAddr("newBridgeOwner");
+        (bytes32 id, bytes memory opData) = _proposeManagedOwnership(address(bridge), newOwner);
 
-        assertEq(routeRegistry.owner(), address(proxy), "pre RR owner");
-
-        bytes32 id = proxy.proposeAdminExecuteRouteRegistry(callData, nonce, deadline, bitmap, sigs);
         vm.warp(block.timestamp + TIMELOCK + 1);
-        proxy.executeProposal(id, callData);
+        proxy.executeProposal(id, opData);
 
-        // Ownable2Step: RR ownership is only pending until the new owner accepts.
+        assertEq(bridge.owner(), address(proxy), "two-step owner unchanged");
+        assertEq(bridge.pendingOwner(), newOwner, "typed transfer started");
+    }
+
+    function test_transferManagedOwnership_initiatesRouteRegistryOwnershipTransfer() public {
+        address newOwner = makeAddr("newRouteRegistryOwner");
+        (bytes32 id, bytes memory opData) = _proposeManagedOwnership(address(routeRegistry), newOwner);
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(id, opData);
+
         assertEq(routeRegistry.owner(), address(proxy), "RR owner unchanged (two-step)");
-        assertEq(routeRegistry.pendingOwner(), newOwner, "RR transfer started via new op");
+        assertEq(routeRegistry.pendingOwner(), newOwner, "typed RR transfer started");
     }
 
     // Standard CM withdrawals stay on the dedicated typed operations. Recipient
@@ -3228,33 +3300,22 @@ contract MultisigProxyTest is Test {
         }
     }
 
-    // Alternate-target regression: even if governance aliases the LZ adapter
-    // target to CM and transfers CM ownership through that unfiltered
-    // raw-call path, the new owner cannot choose a withdrawal recipient. The
-    // asset layer always sends commission to CM's immutable recipient.
-    function test_adapterAliasTransferredOwnerCannotRedirectCommission() public {
-        _setLzAdapter(address(cm));
-
+    // CommissionManager ownership migration remains available through the
+    // typed lane, while its immutable recipient still pins all withdrawals.
+    function test_transferManagedOwnership_commissionRecipientRemainsPinned() public {
         uint256 amount = 10 ether;
         token.mint(address(cm), amount);
         vm.prank(address(bridge));
         cm.receiveTokenCommission(address(token), amount);
 
-        bytes memory callData = abi.encodeWithSignature("transferOwnership(address)", user);
-        uint256 nonce = proxy.proposalNonce();
-        uint256 deadline = block.timestamp + 1 days;
-        bytes32 digest =
-            MultisigHelper.digestProposeAdminExecuteAdapter(domainSep, bytes4(callData), callData, nonce, deadline);
-        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+        (bytes32 id, bytes memory opData) = _proposeManagedOwnership(address(cm), user);
 
-        bytes32 id = proxy.proposeAdminExecuteAdapter(callData, nonce, deadline, bitmap, sigs);
         vm.warp(block.timestamp + TIMELOCK + 1);
-        proxy.executeProposal(id, callData);
+        proxy.executeProposal(id, opData);
 
         vm.prank(user);
         cm.acceptOwnership();
-        assertEq(cm.owner(), user, "governed CM ownership migration still works");
+        assertEq(cm.owner(), user, "typed CM ownership migration works");
 
         uint256 pinnedBefore = token.balanceOf(commissionReceiver);
         uint256 attackerBefore = token.balanceOf(user);
@@ -3264,6 +3325,74 @@ contract MultisigProxyTest is Test {
         assertEq(token.balanceOf(commissionReceiver), pinnedBefore + amount, "immutable recipient paid");
         assertEq(token.balanceOf(user), attackerBefore, "new owner cannot redirect commission to itself");
         assertEq(proxy.commissionRecipient(), commissionReceiver, "proxy reports CM's immutable recipient");
+    }
+
+    function test_transferManagedOwnership_rejectsUnmanagedTarget() public {
+        address unmanaged = makeAddr("unmanaged");
+        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.InvalidManagedOwnershipTarget.selector, unmanaged));
+        proxy.proposeTransferManagedOwnership(unmanaged, user, 0, block.timestamp + 1 days, 0, new bytes[](0));
+    }
+
+    function test_transferManagedOwnership_rejectsZeroNewOwner() public {
+        vm.expectRevert(IMultisigProxy.ZeroNewOwner.selector);
+        proxy.proposeTransferManagedOwnership(
+            address(bridge), address(0), 0, block.timestamp + 1 days, 0, new bytes[](0)
+        );
+    }
+
+    function test_transferManagedOwnership_signatureBindsTargetAndNewOwner() public {
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest =
+            MultisigHelper.digestProposeTransferManagedOwnership(domainSep, address(bridge), user, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
+
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.proposeTransferManagedOwnership(address(cm), user, nonce, deadline, bitmap, sigs);
+
+        vm.expectRevert(IMultisigProxy.InvalidSignature.selector);
+        proxy.proposeTransferManagedOwnership(
+            address(bridge), makeAddr("differentOwner"), nonce, deadline, bitmap, sigs
+        );
+    }
+
+    function test_transferManagedOwnership_rechecksTargetAtExecution() public {
+        (bytes32 transferId, bytes memory transferData) =
+            _proposeManagedOwnership(address(routeRegistry), makeAddr("newOwner"));
+
+        RouteRegistry replacement = new RouteRegistry(address(bridge), address(proxy));
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest =
+            MultisigHelper.digestProposeUpdateRouteRegistry(domainSep, address(replacement), nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes32 updateId = proxy.proposeUpdateRouteRegistry(
+            address(replacement), nonce, deadline, bitmap, MultisigHelper.signAll(vm, digest, pks)
+        );
+
+        vm.warp(block.timestamp + TIMELOCK + 1);
+        proxy.executeProposal(updateId, abi.encode(address(replacement)));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IMultisigProxy.InvalidManagedOwnershipTarget.selector, address(routeRegistry))
+        );
+        proxy.executeProposal(transferId, transferData);
+    }
+
+    function _proposeManagedOwnership(address target, address newOwner)
+        internal
+        returns (bytes32 id, bytes memory opData)
+    {
+        uint256 nonce = proxy.proposalNonce();
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 digest =
+            MultisigHelper.digestProposeTransferManagedOwnership(domainSep, target, newOwner, nonce, deadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        id = proxy.proposeTransferManagedOwnership(
+            target, newOwner, nonce, deadline, bitmap, MultisigHelper.signAll(vm, digest, pks)
+        );
+        opData = abi.encode(target, newOwner);
     }
 
     // The generic path stays open for permitted CommissionManager setters.
@@ -3482,31 +3611,26 @@ contract MultisigProxyTest is Test {
         proxy.executeProposal(id, abi.encode(newFed, 2));
     }
 
-    /// @dev An enclave rotation for chain C must be disjoint from other enclave
-    ///      chains (here chain B).
-    function test_perSourceChain_enclaveRotationRejectsOtherChainOverlap() public {
+    /// @dev Different source chains may intentionally reuse the same enclave
+    ///      keys. Each set remains internally unique and signatures stay bound
+    ///      to their sourceChainId-specific digest and nonce lane.
+    function test_perSourceChain_enclaveSetsMayReuseSameSigners() public {
         uint256 chainB = 8_000_003;
         address[] memory sB = _encSetFor(chainB, 3);
         _govUpdateEnclave(chainB, sB, 2);
 
         uint256 chainC = 8_000_004;
-        address[] memory sC = _encSetFor(chainC, 3);
-        sC[1] = sB[2]; // inject overlap with chainB
+        _govUpdateEnclave(chainC, sB, 2);
 
-        uint256 nonce = proxy.proposalNonce();
-        uint256 deadline = vm.getBlockTimestamp() + TIMELOCK + 1 days;
-        bytes32 digest = MultisigHelper.digestProposeUpdateEnclaveSigners(domainSep, chainC, sC, 2, nonce, deadline);
-        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
-        bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
-        bytes32 id = proxy.proposeUpdateEnclaveSigners(chainC, sC, 2, nonce, deadline, bitmap, sigs);
-        vm.warp(vm.getBlockTimestamp() + TIMELOCK + 1);
-
-        vm.expectRevert(abi.encodeWithSelector(IMultisigProxy.SignerSetsOverlap.selector, sB[2]));
-        proxy.executeProposal(id, abi.encode(chainC, sC, 2));
+        address[] memory gotB = proxy.getEnclaveSigners(chainB);
+        address[] memory gotC = proxy.getEnclaveSigners(chainC);
+        assertEq(gotB, sB, "chain B signer set");
+        assertEq(gotC, sB, "chain C reuses signer set");
+        assertEq(proxy.enclaveThreshold(chainB), 2, "chain B threshold");
+        assertEq(proxy.enclaveThreshold(chainC), 2, "chain C threshold");
     }
 
-    /// @dev A partial rotation may keep some of the chain's own keys — the
-    ///      disjoint check self-excludes the chain being rotated.
+    /// @dev A partial rotation may keep some of the chain's own keys.
     function test_perSourceChain_partialRotationSelfExclusionAllowed() public {
         address[] memory newRgb = new address[](2);
         newRgb[0] = encA1; // keep an existing RGB signer

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -246,7 +246,8 @@ contract MultisigProxyTest is Test {
             address(routeRegistry),
             payable(address(cm)),
             address(0),
-            1 // minFundsInAmount: smallest non-zero floor for tests
+            1, // minFundsInAmount: smallest non-zero floor for tests
+            1 // minFundsOutAmount: smallest non-zero floor for tests
         );
 
         rgbVerifier = new RGBVerifier(address(btcRelay), 6, 1, 5);
@@ -1734,6 +1735,7 @@ contract MultisigProxyTest is Test {
             address(token),
             CommissionConfig({
                 stablePercent: 400, // 4%
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_IN,
                 currency: CommissionCurrency.TOKEN,
@@ -2253,6 +2255,7 @@ contract MultisigProxyTest is Test {
             address(token),
             CommissionConfig({
                 stablePercent: percent,
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_OUT,
                 currency: CommissionCurrency.TOKEN,
@@ -2327,6 +2330,7 @@ contract MultisigProxyTest is Test {
             address(token),
             CommissionConfig({
                 stablePercent: percent,
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_OUT,
                 currency: CommissionCurrency.TOKEN,
@@ -2414,6 +2418,7 @@ contract MultisigProxyTest is Test {
             address(token),
             CommissionConfig({
                 stablePercent: percent,
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_OUT,
                 currency: CommissionCurrency.TOKEN,
@@ -2488,6 +2493,7 @@ contract MultisigProxyTest is Test {
             address(token),
             CommissionConfig({
                 stablePercent: percent,
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_OUT,
                 currency: CommissionCurrency.TOKEN,
@@ -2574,6 +2580,7 @@ contract MultisigProxyTest is Test {
             address(token),
             CommissionConfig({
                 stablePercent: percent,
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_OUT,
                 currency: CommissionCurrency.TOKEN,
@@ -2668,6 +2675,7 @@ contract MultisigProxyTest is Test {
             address(token),
             CommissionConfig({
                 stablePercent: percent,
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_OUT,
                 currency: CommissionCurrency.TOKEN,
@@ -2797,6 +2805,7 @@ contract MultisigProxyTest is Test {
             address(token),
             CommissionConfig({
                 stablePercent: 500, // 5%
+                baseFee: 0,
                 multiplier: 100,
                 side: CommissionSide.FUNDS_OUT,
                 currency: CommissionCurrency.TOKEN,
@@ -3260,7 +3269,12 @@ contract MultisigProxyTest is Test {
     // The generic path stays open for permitted CommissionManager setters.
     function test_adminExecuteCommissionManager_allowsConfigSelector() public {
         bytes memory callData = abi.encodeWithSignature(
-            "setGlobalDefaults(uint256,uint8,uint8,uint8)", uint256(0), uint8(100), uint8(0), uint8(0)
+            "setGlobalDefaults(uint256,uint256,uint8,uint8,uint8)",
+            uint256(0),
+            uint256(0),
+            uint8(100),
+            uint8(0),
+            uint8(0)
         );
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;

--- a/ethereum/test/RGBVerifier.t.sol
+++ b/ethereum/test/RGBVerifier.t.sol
@@ -35,6 +35,10 @@ contract RGBVerifierTest is Test {
 
     function setUp() public {
         btcRelay = new MockBtcRelay();
+        // The real relay never stores a header below its initialisation
+        // checkpoint; mirror that here so a proof this suite accepts is one
+        // the deployed relay would also accept.
+        btcRelay.setCheckpointHeight(SOURCE_HEIGHT);
         btcRelay.setBlock(SOURCE_HEIGHT, SOURCE_COMMIT, SOURCE_CONF);
         btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONF);
         verifier = new RGBVerifier(address(btcRelay), MIN_SOURCE_CONF, MAX_LATEST_CONF, MIN_GAP);

--- a/ethereum/test/RgbPoolSettlementModule.t.sol
+++ b/ethereum/test/RgbPoolSettlementModule.t.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import {Test} from "forge-std/Test.sol";
+
+import {FundsInContext, FundsOutContext} from "../src/interfaces/RouteTypes.sol";
+import {RgbPoolSettlementModule} from "../src/settlement/RgbPoolSettlementModule.sol";
+import {RgbSettlementModule} from "../src/settlement/RgbSettlementModule.sol";
+
+contract RgbPoolSettlementModuleTest is Test {
+    address private routeRegistry = makeAddr("routeRegistry");
+    address private attacker = makeAddr("attacker");
+    address private token = makeAddr("token");
+    address private user = makeAddr("user");
+    address private recipient = makeAddr("recipient");
+
+    uint256 private constant ARBITRUM_CHAIN_ID = 42161;
+    uint256 private constant RGB_MINT_BURN_CHAIN_ID = 96;
+    uint256 private constant RGB_POOL_CHAIN_ID = 97;
+    uint256 private constant OTHER_RGB_CHAIN_ID = 98;
+    uint256 private constant AMOUNT = 100e6;
+    uint256 private constant RGB_OP_ID = 0xABCDEF;
+    bytes32 private constant OPERATION_ID = keccak256("canonical bridge operation");
+
+    RgbSettlementModule private rgbModule;
+    RgbPoolSettlementModule private poolModule;
+
+    function setUp() public {
+        rgbModule = new RgbSettlementModule(routeRegistry);
+        poolModule =
+            new RgbPoolSettlementModule(routeRegistry, address(rgbModule), RGB_POOL_CHAIN_ID, RGB_MINT_BURN_CHAIN_ID);
+    }
+
+    function _fundsInContext(uint256 destinationChainId, bytes32 operationId, uint256 amount)
+        private
+        view
+        returns (FundsInContext memory)
+    {
+        return FundsInContext({
+            token: token,
+            sender: user,
+            sourceSender: bytes32(uint256(uint160(user))),
+            grossAmount: amount,
+            netAmount: amount,
+            operationId: operationId,
+            senderNonce: 0,
+            sourceChainId: ARBITRUM_CHAIN_ID,
+            destChainId: destinationChainId,
+            destAddress: "rgb:destination"
+        });
+    }
+
+    function _fundsOutContext(uint256 sourceChainId) private view returns (FundsOutContext memory) {
+        return FundsOutContext({
+            token: token,
+            recipient: recipient,
+            amount: AMOUNT,
+            burnId: 1,
+            sourceChainId: sourceChainId,
+            destChainId: ARBITRUM_CHAIN_ID,
+            sourceAddress: "rgb:source",
+            isRebalance: false
+        });
+    }
+
+    function _singleSettlement(bytes32 operationId, uint256 amount) private pure returns (bytes memory) {
+        bytes32[] memory operationIds = new bytes32[](1);
+        operationIds[0] = operationId;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+        return abi.encode(operationIds, amounts);
+    }
+
+    function _recordCanonical(bytes32 operationId, uint256 amount, uint256 chainId) private {
+        vm.prank(routeRegistry);
+        rgbModule.onFundsIn(_fundsInContext(chainId, operationId, amount), abi.encode(RGB_OP_ID));
+    }
+
+    function test_constructor_setsImmutablePairing() public view {
+        assertEq(poolModule.routeRegistry(), routeRegistry);
+        assertEq(address(poolModule.rgbModule()), address(rgbModule));
+        assertEq(poolModule.poolChainId(), RGB_POOL_CHAIN_ID);
+        assertEq(poolModule.backingRecordChainId(), RGB_MINT_BURN_CHAIN_ID);
+    }
+
+    function test_constructor_rejectsInvalidArguments() public {
+        vm.expectRevert(RgbPoolSettlementModule.InvalidRouteRegistry.selector);
+        new RgbPoolSettlementModule(address(0), address(rgbModule), RGB_POOL_CHAIN_ID, RGB_MINT_BURN_CHAIN_ID);
+
+        vm.expectRevert(RgbPoolSettlementModule.InvalidRgbModule.selector);
+        new RgbPoolSettlementModule(routeRegistry, address(0), RGB_POOL_CHAIN_ID, RGB_MINT_BURN_CHAIN_ID);
+
+        vm.expectRevert(RgbPoolSettlementModule.InvalidPoolChainId.selector);
+        new RgbPoolSettlementModule(routeRegistry, address(rgbModule), 0, RGB_MINT_BURN_CHAIN_ID);
+
+        vm.expectRevert(RgbPoolSettlementModule.InvalidBackingRecordChainId.selector);
+        new RgbPoolSettlementModule(routeRegistry, address(rgbModule), RGB_POOL_CHAIN_ID, 0);
+
+        vm.expectRevert(RgbPoolSettlementModule.IdenticalChainIds.selector);
+        new RgbPoolSettlementModule(routeRegistry, address(rgbModule), RGB_POOL_CHAIN_ID, RGB_POOL_CHAIN_ID);
+    }
+
+    function test_onFundsIn_returnsZeroAndWritesNoCanonicalRecord() public {
+        FundsInContext memory ctx = _fundsInContext(RGB_POOL_CHAIN_ID, OPERATION_ID, AMOUNT);
+
+        vm.prank(routeRegistry);
+        uint256 externalId = poolModule.onFundsIn(ctx, abi.encode(RGB_OP_ID));
+
+        assertEq(externalId, 0, "pool credit suppresses RGB FundsIn event");
+        assertEq(rgbModule.fundsInRecords(OPERATION_ID), 0, "pool credit does not write canonical ledger");
+        assertEq(rgbModule.fundsInRecordChainIds(OPERATION_ID), 0, "no pool network tag is created");
+    }
+
+    function test_onFundsIn_ignoresSettlementData() public {
+        vm.prank(routeRegistry);
+        uint256 externalId = poolModule.onFundsIn(_fundsInContext(RGB_POOL_CHAIN_ID, OPERATION_ID, AMOUNT), "");
+        assertEq(externalId, 0);
+    }
+
+    function test_onFundsIn_revertsForWrongDestination() public {
+        vm.prank(routeRegistry);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RgbPoolSettlementModule.UnexpectedPoolDestination.selector, RGB_POOL_CHAIN_ID, RGB_MINT_BURN_CHAIN_ID
+            )
+        );
+        poolModule.onFundsIn(_fundsInContext(RGB_MINT_BURN_CHAIN_ID, OPERATION_ID, AMOUNT), "");
+    }
+
+    function test_onFundsIn_revertsForUnauthorizedCaller() public {
+        vm.prank(attacker);
+        vm.expectRevert(RgbPoolSettlementModule.NotRouteRegistry.selector);
+        poolModule.onFundsIn(_fundsInContext(RGB_POOL_CHAIN_ID, OPERATION_ID, AMOUNT), "");
+    }
+
+    function test_beforeFundsOut_acceptsMintBurnBackingRecord() public {
+        _recordCanonical(OPERATION_ID, AMOUNT, RGB_MINT_BURN_CHAIN_ID);
+
+        vm.prank(routeRegistry);
+        poolModule.beforeFundsOut(_fundsOutContext(RGB_POOL_CHAIN_ID), _singleSettlement(OPERATION_ID, AMOUNT));
+
+        assertEq(rgbModule.fundsInRecords(OPERATION_ID), AMOUNT, "canonical record remains permanent");
+    }
+
+    function test_beforeFundsOut_revertsForWrongSource() public {
+        _recordCanonical(OPERATION_ID, AMOUNT, RGB_MINT_BURN_CHAIN_ID);
+
+        vm.prank(routeRegistry);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RgbPoolSettlementModule.UnexpectedPoolSource.selector, RGB_POOL_CHAIN_ID, RGB_MINT_BURN_CHAIN_ID
+            )
+        );
+        poolModule.beforeFundsOut(_fundsOutContext(RGB_MINT_BURN_CHAIN_ID), _singleSettlement(OPERATION_ID, AMOUNT));
+    }
+
+    function test_beforeFundsOut_revertsForUnknownRecord() public {
+        vm.prank(routeRegistry);
+        vm.expectRevert(abi.encodeWithSelector(RgbPoolSettlementModule.FundsInNotFound.selector, OPERATION_ID));
+        poolModule.beforeFundsOut(_fundsOutContext(RGB_POOL_CHAIN_ID), _singleSettlement(OPERATION_ID, AMOUNT));
+    }
+
+    function test_beforeFundsOut_revertsForAmountMismatch() public {
+        _recordCanonical(OPERATION_ID, AMOUNT, RGB_MINT_BURN_CHAIN_ID);
+
+        vm.prank(routeRegistry);
+        vm.expectRevert(
+            abi.encodeWithSelector(RgbPoolSettlementModule.AmountMismatch.selector, OPERATION_ID, AMOUNT - 1, AMOUNT)
+        );
+        poolModule.beforeFundsOut(_fundsOutContext(RGB_POOL_CHAIN_ID), _singleSettlement(OPERATION_ID, AMOUNT - 1));
+    }
+
+    function test_beforeFundsOut_revertsForRecordFromWrongNetwork() public {
+        _recordCanonical(OPERATION_ID, AMOUNT, OTHER_RGB_CHAIN_ID);
+
+        vm.prank(routeRegistry);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RgbPoolSettlementModule.FundsInRecordChainMismatch.selector,
+                OPERATION_ID,
+                RGB_MINT_BURN_CHAIN_ID,
+                OTHER_RGB_CHAIN_ID
+            )
+        );
+        poolModule.beforeFundsOut(_fundsOutContext(RGB_POOL_CHAIN_ID), _singleSettlement(OPERATION_ID, AMOUNT));
+    }
+
+    function test_beforeFundsOut_revertsForEmptyRecords() public {
+        vm.prank(routeRegistry);
+        vm.expectRevert(RgbPoolSettlementModule.EmptySettlementRecords.selector);
+        poolModule.beforeFundsOut(_fundsOutContext(RGB_POOL_CHAIN_ID), abi.encode(new bytes32[](0), new uint256[](0)));
+    }
+
+    function test_beforeFundsOut_revertsForLengthMismatch() public {
+        bytes32[] memory operationIds = new bytes32[](1);
+        operationIds[0] = OPERATION_ID;
+
+        vm.prank(routeRegistry);
+        vm.expectRevert(RgbPoolSettlementModule.SettlementDataLengthMismatch.selector);
+        poolModule.beforeFundsOut(_fundsOutContext(RGB_POOL_CHAIN_ID), abi.encode(operationIds, new uint256[](0)));
+    }
+
+    function test_beforeFundsOut_revertsForUnauthorizedCaller() public {
+        vm.prank(attacker);
+        vm.expectRevert(RgbPoolSettlementModule.NotRouteRegistry.selector);
+        poolModule.beforeFundsOut(_fundsOutContext(RGB_POOL_CHAIN_ID), _singleSettlement(OPERATION_ID, AMOUNT));
+    }
+}

--- a/ethereum/test/mocks/MockBtcRelay.sol
+++ b/ethereum/test/mocks/MockBtcRelay.sol
@@ -6,10 +6,26 @@ import {IBtcRelayView} from "../../src/interfaces/IBtcRelayView.sol";
 /// @title MockBtcRelay
 /// @notice Minimal mock of the Atomiq BtcRelay for testing.
 ///         Stores (height, commitmentHash) => confirmations.
+/// @dev The rejection rules of `verifyBlockheaderHash` mirror the real
+///      `BtcRelay._verifyBlockheaderHash` so an integration test cannot pass a
+///      proof here that the deployed relay would reject.
 contract MockBtcRelay is IBtcRelayView {
     mapping(bytes32 => uint256) private _blocks;
     uint32 private _blockHeight;
     uint224 private _chainwork;
+
+    /// @notice Lowest height this relay knows about, mirroring the real relay's
+    ///         immutable initialisation checkpoint. Headers below it are never
+    ///         stored and must not be treated as part of the main chain.
+    /// @dev Defaults to 0, so a suite that does not exercise the checkpoint
+    ///      keeps the previous mock behaviour.
+    uint256 public checkpointHeight;
+
+    /// @notice Set the initialisation checkpoint. Call it in `setUp` with the
+    ///         same height the suite registers its blocks at.
+    function setCheckpointHeight(uint256 height) external {
+        checkpointHeight = height;
+    }
 
     /// @notice Register a block so verifyBlockheaderHash returns the given confirmations.
     function setBlock(uint256 height, bytes32 commitmentHash, uint256 confirmations) external {
@@ -36,6 +52,13 @@ contract MockBtcRelay is IBtcRelayView {
         override
         returns (uint256 confirmations)
     {
+        // Mirrors BtcRelay._verifyBlockheaderHash: a height below the checkpoint
+        // is outside this relay's chain, and an unwritten entry reads back as the
+        // default zero — both are rejected before the lookup so the default value
+        // can never be presented as a real block commitment.
+        require(height >= checkpointHeight, "verify: before checkpoint");
+        require(commitmentHash != bytes32(0), "verify: zero commitment");
+
         confirmations = _blocks[_key(height, commitmentHash)];
         require(confirmations > 0, "verify: block commitment");
     }

--- a/ethereum/test/mocks/MockDepositFloor.sol
+++ b/ethereum/test/mocks/MockDepositFloor.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+/// @notice Minimal stand-in for the Bridge's `minFundsInAmount` /
+///         `minFundsOutAmount` getters, which `CommissionManager` reads to bound
+///         a route's flat `baseFee` on its respective side. Used by the
+///         CommissionManager unit tests, which exercise the manager in isolation
+///         and have no real Bridge deployment.
+/// @dev Intended to be installed with `vm.etch` at the address the manager was
+///      constructed with, so the existing `vm.prank(BRIDGE)` call sites keep
+///      working unchanged.
+contract MockDepositFloor {
+    uint256 public minFundsInAmount;
+    uint256 public minFundsOutAmount;
+
+    function setMinFundsInAmount(uint256 value) external {
+        minFundsInAmount = value;
+    }
+
+    function setMinFundsOutAmount(uint256 value) external {
+        minFundsOutAmount = value;
+    }
+}

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -52,8 +52,11 @@ library MultisigHelper {
     bytes32 internal constant PROPOSE_SET_TIMELOCK_DURATION_TYPEHASH =
         keccak256("ProposeSetTimelockDuration(uint256 newDuration,uint256 nonce,uint256 deadline)");
 
+    bytes32 internal constant PROPOSE_TRANSFER_MANAGED_OWNERSHIP_TYPEHASH =
+        keccak256("ProposeTransferManagedOwnership(address target,address newOwner,uint256 nonce,uint256 deadline)");
+
     bytes32 internal constant CANCEL_PROPOSAL_TYPEHASH =
-        keccak256("CancelProposal(bytes32 proposalId,uint256 nonce,uint256 deadline)");
+        keccak256("CancelProposal(bytes32 proposalId,uint256 deadline)");
 
     bytes32 internal constant PROPOSE_ADMIN_EXECUTE_CM_TYPEHASH = keccak256(
         "ProposeAdminExecuteCommissionManager(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)"
@@ -320,6 +323,19 @@ library MultisigHelper {
         );
     }
 
+    function digestProposeTransferManagedOwnership(
+        bytes32 domainSep,
+        address target,
+        address newOwner,
+        uint256 nonce,
+        uint256 deadline
+    ) internal pure returns (bytes32) {
+        return toTypedDataHash(
+            domainSep,
+            keccak256(abi.encode(PROPOSE_TRANSFER_MANAGED_OWNERSHIP_TYPEHASH, target, newOwner, nonce, deadline))
+        );
+    }
+
     function digestProposeAdminExecuteCM(
         bytes32 domainSep,
         bytes4 selector,
@@ -446,12 +462,12 @@ library MultisigHelper {
         );
     }
 
-    function digestCancelProposal(bytes32 domainSep, bytes32 proposalId, uint256 nonce, uint256 deadline)
+    function digestCancelProposal(bytes32 domainSep, bytes32 proposalId, uint256 deadline)
         internal
         pure
         returns (bytes32)
     {
-        return toTypedDataHash(domainSep, keccak256(abi.encode(CANCEL_PROPOSAL_TYPEHASH, proposalId, nonce, deadline)));
+        return toTypedDataHash(domainSep, keccak256(abi.encode(CANCEL_PROPOSAL_TYPEHASH, proposalId, deadline)));
     }
 
     // ========================================================================


### PR DESCRIPTION
### Summary
Commissions previously supported only a proportional component. This could not reliably cover fixed per-operation costs, such as a Bitcoin transaction fee, especially for small transfers.
Commission rules now support an optional flat baseFee:
`fee = amount × stablePercent / multiplier² + baseFee`

### Changes
Added `baseFee` to global defaults and per-route commission configurations. It applies to both `fundsIn` and `fundsOut`; either the proportional or flat component may be zero, and setting both to zero disables the commission.

Added separate configurable `minFundsInAmount` and `minFundsOutAmount` limits. Bridge rejects operations below the corresponding minimum.

**CommissionManager** validates that the combined fee at the applicable minimum leaves a positive net amount:
`percentageFee(minAmount) + baseFee < minAmount`

This is checked during configuration and again during quoting because Bridge minimums can be changed later.

`FUNDS_IN` supports token or native commission; for native commission, the complete proportional plus flat fee is converted through the ETH/USD feed. `FUNDS_OUT` remains token-only.

Also: added `calculateTotalFee`, exposed the Bridge deposit/release floors, included `baseFee` in `getGlobalDefaults`, and updated deployment scripts, environment variables, tests, interfaces, and README documentation.