### PR TITLE
fix: reject phantom Bitcoin relay commitments

### DIFF
--- a/ethereum/.env.deploy.example
+++ b/ethereum/.env.deploy.example
@@ -109,8 +109,8 @@ ENCLAVE_THRESHOLD=2
 FEDERATION_THRESHOLD=2
 
 # Immutable CommissionManager withdrawal destination. Changing it requires a
-# new CommissionManager deployment (and, because Bridge pins CM immutably, a
-# coordinated Bridge migration).
+# new CommissionManager deployment, followed by the typed, timelocked
+# UpdateCommissionManager operation that atomically updates Bridge and proxy.
 COMMISSION_RECIPIENT=
 
 # Timelock between propose and execute for federation proposals (seconds).

--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -27,14 +27,15 @@ No TEE verification, no destination chain field, **no commission integration**, 
 
 Production bridge for UTEXO. Inherits `BridgeBase`, implements `IBridge`. Route-agnostic: all per-route logic (finality verification, settlement bookkeeping) is delegated to plugins registered in `RouteRegistry`.
 
-Constructor takes four addresses — the accepted ERC-20 token (immutable), the `RouteRegistry` (mutable — federation can rotate via `UpdateRouteRegistry`), the `CommissionManager` (immutable), and the initial LayerZero adapter (mutable; `address(0)` is allowed) — plus non-zero `minFundsInAmount` and `minFundsOutAmount` values in token smallest units. Federation may retune either minimum through the timelocked owner path. The bridge's own chain identifier is `block.chainid` — chain IDs are `uint256` throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
+Constructor takes four addresses — the accepted ERC-20 token (immutable), the `RouteRegistry` (mutable — federation can rotate via `UpdateRouteRegistry`), the initial `CommissionManager` (mutable — federation can rotate it via `UpdateCommissionManager`), and the initial LayerZero adapter (mutable; `address(0)` is allowed) — plus non-zero `minFundsInAmount` and `minFundsOutAmount` values in token smallest units. Federation may retune either minimum through the timelocked owner path. The bridge's own chain identifier is `block.chainid` — chain IDs are `uint256` throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
 
 - `fundsIn(amount, destinationChainId, destinationAddress, settlementData)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Requires `amount >= minFundsInAmount`. Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must be between the fresh quote and 5% above it. Exactly the fresh quote is collected and any surplus is refunded to the caller. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and dispatches to the route's `SettlementModule.onFundsIn(...)` via `RouteRegistry`. The `settlementData` blob is opaque to the bridge — its layout is dictated by the destination route's settlement module (empty for routes that don't consume extra data on inbound, e.g. RGB). Emits two events:
-  - `FundsIn` (from `BridgeBase`) — minimal, uses `netAmount`.
+  - `FundsIn` — RGB-only compatibility event using `netAmount`; `sender` is indexed while `rgbOpId` is carried in event data.
   - `BridgeFundsIn` (from `IBridge`) — full, consumed by the UTEXO backend.
 - `fundsIn(amount, sourceChainId, sourceSender, destinationChainId, destinationAddress, settlementData)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating sender on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` and `sourceSender` to the bridge. For NATIVE commission routes, the source-agreed `msg.value` must remain within the immutable ±5% band around the fresh destination quote. Cross-domain refunds are deliberately unsupported, so the complete accepted value is collected as commission.
 - `setLZAdapter(adapter)` — `onlyOwner`. Rotates the address authorized to call the adapter overload. Set to `address(0)` to close the adapter path entirely.
 - `setRouteRegistry(newRouteRegistry)` — `onlyOwner`. Rotates the `RouteRegistry` Bridge talks to. Used to migrate to a redeployed registry (the registry's `bridge` is immutable, so a new registry deploy is the only way to rotate). Reverts on `address(0)`.
+- `setCommissionManager(newCommissionManager)` — `onlyOwner`. Rotates the manager used for fee quotes and custody. Production migration uses the typed `UpdateCommissionManager` operation so the Bridge and `MultisigProxy` pointers change atomically. Reverts on `address(0)`.
 - `fundsOut(FundsOutParams)` — `onlyOwner`, called only by the typed `MultisigProxy.fundsOutCall` / `lzFundsOutCall` enclave paths. The params bind recipient, amount, burn id, source/destination chains, source address, finality proof, and settlement data. The Bridge checks replay protection and isolated liquidity/rate limits, dispatches route verification and settlement bookkeeping, charges any token commission, and releases the net amount. NATIVE commission is disallowed because the release has no native-currency payer.
 
 Owner **must** be `MultisigProxy`. `fundsOut` is reachable only through the purpose-built `fundsOutCall` or `lzFundsOutCall` entrypoints, and `rebalanceLiquidity` only through `rebalanceCall`; all require the registered source chain's M-of-N enclave signatures. These Bridge selectors are blocked from every federation generic-call lane.
@@ -117,7 +118,7 @@ Federation-controlled operations (`OperationType`):
 | `AdminExecuteCommissionManager` | CommissionManager | Permitted generic call into CM (route rules, global defaults, ETH/USD feed, …) |
 | `WithdrawTokenCommissionCM` | CommissionManager | Withdraw ERC-20 commission to CM's immutable `commissionRecipient` |
 | `WithdrawNativeCommissionCM` | CommissionManager | Withdraw native commission to CM's immutable `commissionRecipient` |
-| `UpdateCommissionManager` | self | Migrate to a redeployed CommissionManager |
+| `UpdateCommissionManager` | Bridge + self | Atomically migrate Bridge and proxy to a redeployed CommissionManager |
 | `AdminExecuteAdapter` | LZAdapter | Generic call into the registered LayerZero adapter (`setTrustedEntrypoint`, `refundStuckFunds`, …). Reverts `ZeroTarget` if `MultisigProxy.lzAdapter` is unset. |
 | `UpdateLZAdapter` | self | Rotate `MultisigProxy.lzAdapter` — the routing target for `AdminExecuteAdapter`. Setting to `address(0)` closes the adapter-admin path. |
 | `SetRoute` | RouteRegistry | Register, update, pause, or re-enable a single `(sourceChainId, destChainId)` route on the registry. The opData encodes `(src, dst, enabled, verifier, module)`. |
@@ -128,6 +129,13 @@ Federation-controlled operations (`OperationType`):
 | `DisableLZAdapter` | self | Explicitly clear the adapter governance target. |
 
 Note: `MultisigProxy.lzAdapter` and `Bridge.lzAdapter` are **separate** fields with different roles. `Bridge.lzAdapter` gates the adapter `fundsIn` overload (data path); `MultisigProxy.lzAdapter` is the target of `AdminExecuteAdapter` proposals (governance path). Both default to `address(0)` and are wired in by federation after the adapter is deployed.
+
+For a CommissionManager migration, deploy and configure the replacement with
+the current Bridge as `bridgeAddress`, start its two-step ownership transfer to
+`MultisigProxy`, and prepare both `UpdateCommissionManager` and a subsequent
+`AdminExecuteCommissionManager(acceptOwnership())` proposal. After their
+timelocks, execute the update first and the ownership acceptance immediately
+after it. The update changes the Bridge and proxy pointers atomically.
 
 ## How it works
 

--- a/ethereum/script/deploy/DeployBtcRelay.s.sol
+++ b/ethereum/script/deploy/DeployBtcRelay.s.sol
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import {Script, console2} from "forge-std/Script.sol";
+
+import {BtcRelay} from "../../src/btc_relay/BtcRelay.sol";
+import {BtcRelayTestnet} from "../../src/btc_relay/BtcRelayTestnet.sol";
+import {
+    StoredBlockHeader as MainnetHeader,
+    StoredBlockHeaderImpl as MainnetHeaderImpl,
+    StoredBlockHeaderByteLength as MAINNET_HEADER_BYTES
+} from "../../src/btc_relay/structs/StoredBlockHeader.sol";
+import {
+    StoredBlockHeader as TestnetHeader,
+    StoredBlockHeaderByteLength as TESTNET_HEADER_BYTES
+} from "../../src/btc_relay/structs/StoredBlockHeaderTestnet.sol";
+import {Endianness} from "../../src/btc_relay/btc_utils/Endianness.sol";
+import {IBtcRelayView} from "../../src/interfaces/IBtcRelayView.sol";
+
+/// @title DeployBtcRelay
+/// @notice Deploys the Atomiq Bitcoin SPV header relay at a fixed, pre-reviewed
+///         initialisation checkpoint, then hands its address to
+///         `DeployRGBVerifier` / `DeployAll` via `BTC_RELAY_ADDRESS`.
+///
+///      Choose the checkpoint DEEP. Six blocks is not enough: a reorg deeper
+///      than the checkpoint is unrecoverable, because all three header-submit
+///      paths can only extend a height already committed in `_mainChain`, so
+///      the relay would stay pinned to the orphaned branch forever and the fix
+///      is a new relay + a new (immutable) RGBVerifier + a route rotation.
+///      Depth is nearly free: catch-up costs 48 bytes of calldata per block, so
+///      a full day of margin (~144 blocks) is ~7 KB — one transaction.
+///
+/// Env (required):
+///   PRIVATE_KEY                — deployer private key
+///   BTC_CHECKPOINT_HEADER      — the 160-byte `StoredBlockHeader` blob, hex:
+///                                  [0..79]    raw 80-byte Bitcoin block header
+///                                  [80..111]  cumulative chainWork (big-endian uint256)
+///                                  [112..115] block height (uint32)
+///                                  [116..119] lastDiffAdjustment (uint32)
+///                                  [120..159] uint32[10] previous block timestamps
+///   BTC_CHECKPOINT_HEIGHT      — expected height, asserted against the blob
+///   BTC_CHECKPOINT_BLOCKHASH   — expected block hash in DISPLAY order, i.e. exactly
+///                                as a block explorer or `getblockhash` shows it
+///   BTC_CHECKPOINT_CHAINWORK   — expected cumulative chainwork, as the 32-byte
+///                                `chainwork` field of `getblockheader`
+///
+/// Env (optional, defaults in parens):
+///   BTC_CLAMP_BLOCK_TARGET (true)  — enforce the maximum PoW target; immutable after deploy
+///   BTC_RELAY_TESTNET      (false) — deploy `BtcRelayTestnet` instead of `BtcRelay`
+///
+/// Usage:
+///   forge script script/deploy/DeployBtcRelay.s.sol \
+///     --rpc-url $RPC_URL --broadcast --verify
+contract DeployBtcRelay is Script {
+    using MainnetHeaderImpl for MainnetHeader;
+
+    /// @dev Chainwork is masked to 224 bits by the relay constructor. Bitcoin is
+    ///      nowhere near this, so exceeding it means a malformed blob rather
+    ///      than a real chain — reject instead of silently truncating.
+    uint256 private constant MAX_CHAINWORK = type(uint224).max;
+
+    function run() external returns (address relay) {
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        bytes memory blob = vm.envBytes("BTC_CHECKPOINT_HEADER");
+        uint256 expectedHeight = vm.envUint("BTC_CHECKPOINT_HEIGHT");
+        bytes32 expectedBlockhash = vm.envBytes32("BTC_CHECKPOINT_BLOCKHASH");
+        uint256 expectedChainwork = uint256(vm.envBytes32("BTC_CHECKPOINT_CHAINWORK"));
+        bool clampBlockTarget = vm.envOr("BTC_CLAMP_BLOCK_TARGET", true);
+        bool testnet = vm.envOr("BTC_RELAY_TESTNET", false);
+
+        bytes32[5] memory words = _toWords(blob);
+
+        // Mainnet and testnet headers are the same 160-byte layout at the same
+        // offsets, so one decoder validates both. Guarded rather than assumed,
+        // in case the vendored copies ever diverge upstream.
+        require(MAINNET_HEADER_BYTES == TESTNET_HEADER_BYTES, "checkpoint: header layouts diverged");
+
+        MainnetHeader memory header;
+        header.data = words;
+
+        _reportAndVerifyHeader(header, expectedHeight, expectedBlockhash, expectedChainwork);
+
+        console2.log("");
+        console2.log("clampBlockTarget (immutable):", clampBlockTarget);
+        console2.log("network:                     ", testnet ? "testnet" : "mainnet");
+
+        vm.startBroadcast(pk);
+        if (testnet) {
+            TestnetHeader memory testnetHeader;
+            testnetHeader.data = words;
+            relay = address(new BtcRelayTestnet(testnetHeader, clampBlockTarget));
+        } else {
+            relay = address(new BtcRelay(header, clampBlockTarget));
+        }
+        vm.stopBroadcast();
+
+        _verifyDeployment(relay, expectedHeight, expectedChainwork);
+        _reportNextSteps(relay, expectedHeight);
+    }
+
+    // =========================================================================
+    // Header decoding
+    // =========================================================================
+
+    /// @dev Split the 160-byte blob into the five words of `bytes32[5]`. Written
+    ///      as plain loads rather than `mcopy` because the project targets the
+    ///      shanghai EVM.
+    function _toWords(bytes memory blob) private pure returns (bytes32[5] memory words) {
+        require(blob.length == MAINNET_HEADER_BYTES, "checkpoint: header must be exactly 160 bytes");
+
+        for (uint256 i = 0; i < 5; i++) {
+            bytes32 word;
+            assembly ("memory-safe") {
+                word := mload(add(add(blob, 32), mul(i, 32)))
+            }
+            words[i] = word;
+        }
+    }
+
+    /// @dev Re-derive every field from the blob, print it for a final human
+    ///      read, and assert the three independently supplied expectations.
+    ///      The three fields NOT asserted here — `lastDiffAdjustment` and the
+    ///      ten previous timestamps — cannot be checked from the blob alone;
+    ///      they are printed instead, and are the fields most worth verifying
+    ///      by hand, because a mistake in them surfaces weeks later in the
+    ///      retarget and median-time-past rules rather than at deploy.
+    function _reportAndVerifyHeader(
+        MainnetHeader memory header,
+        uint256 expectedHeight,
+        bytes32 expectedBlockhash,
+        uint256 expectedChainwork
+    ) private view {
+        uint256 height = uint256(header.blockHeight());
+        uint256 chainWork = header.chainWork();
+        // `header_blockhash` returns the raw double-SHA256 in Bitcoin's internal
+        // byte order; explorers show it reversed. Compare in display order so the
+        // configured value is a straight copy-paste.
+        bytes32 displayHash = Endianness.reverseBytes32(header.header_blockhash());
+
+        console2.log("=== Checkpoint header (decoded from BTC_CHECKPOINT_HEADER) ===");
+        console2.log("blockHeight:        ", height);
+        console2.log("blockhash (display):", vm.toString(displayHash));
+        console2.log("chainWork:          ", chainWork);
+        console2.log("version:            ", uint256(header.header_version()));
+        console2.log("previousBlockhash:  ", vm.toString(Endianness.reverseBytes32(header.header_previousBlockhash())));
+        console2.log("merkleRoot:         ", vm.toString(Endianness.reverseBytes32(header.header_merkleRoot())));
+        console2.log("timestamp:          ", uint256(header.header_timestamp()));
+        console2.log("nBits (LE):         ", uint256(header.header_nBitsLE()));
+        console2.log("nonce:              ", uint256(header.header_nonce()));
+        console2.log("lastDiffAdjustment: ", uint256(header.lastDiffAdjustment()));
+
+        uint32[10] memory prevTimestamps = header.previousBlockTimestamps();
+        console2.log("previousBlockTimestamps (oldest first):");
+        for (uint256 i = 0; i < 10; i++) {
+            console2.log("  -", uint256(prevTimestamps[i]));
+        }
+
+        require(height == expectedHeight, "checkpoint: height does not match BTC_CHECKPOINT_HEIGHT");
+        require(height <= type(uint32).max, "checkpoint: height overflows uint32");
+        require(displayHash == expectedBlockhash, "checkpoint: blockhash does not match BTC_CHECKPOINT_BLOCKHASH");
+        require(chainWork == expectedChainwork, "checkpoint: chainwork does not match BTC_CHECKPOINT_CHAINWORK");
+        require(chainWork <= MAX_CHAINWORK, "checkpoint: chainwork exceeds the relay's 224-bit field");
+        require(header.header_timestamp() != 0, "checkpoint: zero header timestamp");
+        require(header.header_nBitsLE() != 0, "checkpoint: zero nBits");
+    }
+
+    // =========================================================================
+    // Post-deploy verification
+    // =========================================================================
+
+    /// @dev Read the deployed relay back through the same interface `RGBVerifier`
+    ///      uses, so a mis-initialised relay fails here rather than silently
+    ///      serving a bogus chain.
+    function _verifyDeployment(address relay, uint256 expectedHeight, uint256 expectedChainwork) private view {
+        IBtcRelayView view_ = IBtcRelayView(relay);
+
+        require(uint256(view_.getBlockheight()) == expectedHeight, "deployed: tip height mismatch");
+
+        bytes32 tipCommit = view_.getTipCommitHash();
+        require(tipCommit != bytes32(0), "deployed: zero tip commitment");
+        require(view_.getCommitHash(expectedHeight) == tipCommit, "deployed: checkpoint is not the tip");
+        require(uint256(view_.getChainwork()) == expectedChainwork, "deployed: chainwork mismatch");
+
+        // End-to-end read on the exact call `RGBVerifier` makes.
+        require(view_.verifyBlockheaderHash(expectedHeight, tipCommit) == 1, "deployed: checkpoint does not verify");
+
+        console2.log("");
+        console2.log("=== Post-deploy verification ===");
+        console2.log("BtcRelay deployed at:", relay);
+        console2.log("tip height:          ", uint256(view_.getBlockheight()));
+        console2.log("tip commitment:      ", vm.toString(tipCommit));
+        console2.log("chainwork:           ", uint256(view_.getChainwork()));
+    }
+
+    function _reportNextSteps(address relay, uint256 expectedHeight) private pure {
+        console2.log("");
+        console2.log("=== Next steps ===");
+        console2.log("1. The relay sits at the checkpoint and is NOT usable yet. Submit headers");
+        console2.log("   from this height up to the Bitcoin tip via submitMainBlockheaders");
+        console2.log("   (160-byte stored header + 48 bytes per block, chunked across txs).");
+        console2.log("   RGBVerifier enforces maxLatestConfirmations, so it rejects everything");
+        console2.log("   until the relay reaches the chain head - and keeping it there is a");
+        console2.log("   standing operational duty, not a one-off.");
+        console2.log("2. Export BTC_RELAY_ADDRESS for DeployRGBVerifier / DeployAll:");
+        console2.log("   BTC_RELAY_ADDRESS=", relay);
+        console2.log("3. Checkpoint height, now the immutable floor of the finality gate:");
+        console2.log("   ", expectedHeight);
+    }
+}

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -157,8 +157,10 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         "UtexoRebalanceBurnId(address bridge,uint256 chainId,address token,uint256 amount,uint256 sourceChainId,uint256 destinationChainId,bytes32 sourceAddressHash,bytes32 destinationAddressHash,bytes32 proofHash,bytes32 settlementDataOutHash,bytes32 settlementDataInHash)"
     );
 
-    /// @notice CommissionManager that receives and custodies protocol fees.
-    ICommissionManager public immutable commissionManager;
+    /// @inheritdoc IBridge
+    /// @dev Mutable so federation can migrate to a redeployed manager through
+    ///      the typed, timelocked `UpdateCommissionManager` governance op.
+    ICommissionManager public override commissionManager;
 
     /// @inheritdoc IBridge
     /// @dev Mutable so federation can rotate registry deployments via
@@ -315,6 +317,16 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         address old = routeRegistry;
         routeRegistry = newRouteRegistry;
         emit RouteRegistryUpdated(old, newRouteRegistry);
+    }
+
+    /// @inheritdoc IBridge
+    /// @dev Owner is `MultisigProxy`; its typed `UpdateCommissionManager`
+    ///      operation updates this pointer and the proxy's own target atomically.
+    function setCommissionManager(address newCommissionManager) external override onlyOwner {
+        if (newCommissionManager == address(0)) revert InvalidCommissionManagerAddress();
+        address old = address(commissionManager);
+        commissionManager = ICommissionManager(payable(newCommissionManager));
+        emit CommissionManagerUpdated(old, newCommissionManager);
     }
 
     /// @inheritdoc IBridge

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -75,8 +75,8 @@ contract MultisigProxy is IMultisigProxy {
     /// @notice Federation proposals.
     mapping(bytes32 => Proposal) private _proposals;
 
-    /// @notice Sequential nonce for the regular federation lane: `_propose`
-    ///         (all typed proposals) and `cancelProposal`.
+    /// @notice Sequential nonce for the regular federation proposal lane
+    ///         (`_propose` and all typed proposal entrypoints).
     uint256 public proposalNonce;
 
     /// @notice Sequential nonce for the emergency lane: `emergencyPause` /
@@ -145,6 +145,10 @@ contract MultisigProxy is IMultisigProxy {
     bytes4 private constant _SEL_FUNDS_OUT = IBridge.fundsOut.selector;
     bytes4 private constant _SEL_REBALANCE_LIQUIDITY = IBridge.rebalanceLiquidity.selector;
 
+    /// @notice CommissionManager rotation is reserved for the typed operation,
+    ///         which keeps the Bridge and proxy targets synchronized atomically.
+    bytes4 private constant _SEL_SET_COMMISSION_MANAGER = IBridge.setCommissionManager.selector;
+
     /// @notice Ownership transfer is reserved for the typed managed-target
     ///         operation and rejected from every generic raw-call lane.
     bytes4 private constant _SEL_TRANSFER_OWNERSHIP = bytes4(keccak256("transferOwnership(address)"));
@@ -212,7 +216,7 @@ contract MultisigProxy is IMultisigProxy {
 
     // Cancel
     bytes32 private constant _CANCEL_PROPOSAL_TYPEHASH =
-        keccak256("CancelProposal(bytes32 proposalId,uint256 nonce,uint256 deadline)");
+        keccak256("CancelProposal(bytes32 proposalId,uint256 deadline)");
 
     // Emergency
     bytes32 private constant _EMERGENCY_PAUSE_TYPEHASH = keccak256("EmergencyPause(uint256 nonce,uint256 deadline)");
@@ -963,23 +967,17 @@ contract MultisigProxy is IMultisigProxy {
     // =========================================================================
 
     /// @inheritdoc IMultisigProxy
-    function cancelProposal(
-        bytes32 proposalId,
-        uint256 nonce,
-        uint256 deadline,
-        uint256 fedBitmap,
-        bytes[] calldata fedSigs
-    ) external {
+    function cancelProposal(bytes32 proposalId, uint256 deadline, uint256 fedBitmap, bytes[] calldata fedSigs)
+        external
+    {
         if (block.timestamp > deadline) revert Expired();
-        if (nonce != proposalNonce) revert InvalidNonce();
 
         Proposal storage p = _proposals[proposalId];
         if (p.status != ProposalStatus.Pending) revert NotPending();
 
-        bytes32 digest = _hashTypedData(keccak256(abi.encode(_CANCEL_PROPOSAL_TYPEHASH, proposalId, nonce, deadline)));
+        bytes32 digest = _hashTypedData(keccak256(abi.encode(_CANCEL_PROPOSAL_TYPEHASH, proposalId, deadline)));
         _verifySignatures(digest, fedBitmap, fedSigs, _federationSigners, federationThreshold);
 
-        proposalNonce++;
         p.status = ProposalStatus.Cancelled;
 
         emit ProposalCancelled(proposalId);
@@ -1186,6 +1184,7 @@ contract MultisigProxy is IMultisigProxy {
             address newCm = abi.decode(opData, (address));
             if (newCm == address(0)) revert ZeroCommissionManager();
             address old = commissionManager;
+            IBridge(bridge).setCommissionManager(newCm);
             commissionManager = newCm;
             emit CommissionManagerUpdated(old, newCm);
         } else if (opType == OperationType.AdminExecuteAdapter) {
@@ -1418,6 +1417,7 @@ contract MultisigProxy is IMultisigProxy {
     function _requireAllowedGenericSelector(bytes4 selector) private pure {
         _requireNotCommissionWithdrawSelector(selector);
         _requireNotBridgeReleaseSelector(selector);
+        if (selector == _SEL_SET_COMMISSION_MANAGER) revert ForbiddenCommissionManagerSelector(selector);
         if (selector == _SEL_TRANSFER_OWNERSHIP) revert ForbiddenOwnershipSelector(selector);
     }
 

--- a/ethereum/src/btc_relay/BtcRelay.sol
+++ b/ethereum/src/btc_relay/BtcRelay.sol
@@ -38,6 +38,10 @@ contract BtcRelay is IBtcRelay, IBtcRelayView {
     // only used during testing
     bool immutable _clampBlockTarget;
 
+    // The trusted initialization height. Headers below this checkpoint are not
+    // stored by this relay and must never be treated as part of its main chain.
+    uint32 immutable _checkpointHeight;
+
     //Initialize the btc relay with the provided stored_header
     constructor(StoredBlockHeader memory storedHeader, bool clampBlockTarget) {
         _clampBlockTarget = clampBlockTarget;
@@ -45,6 +49,7 @@ contract BtcRelay is IBtcRelay, IBtcRelayView {
         //Save the initial stored header
         bytes32 commitHash = storedHeader.hash();
         uint32 blockHeight = storedHeader.blockHeight();
+        _checkpointHeight = blockHeight;
         _mainChain[blockHeight] = commitHash;
         _relayState.write(
             blockHeight, uint224(storedHeader.chainWork() & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
@@ -63,8 +68,12 @@ contract BtcRelay is IBtcRelay, IBtcRelayView {
         uint256 mainBlockheight = _relayState.blockHeight;
         //Check that the block height isn't past the tip, this can happen if there is a reorg, where a shorter
         // chain becomes the cannonical one, this can happen due to the heaviest work rule (and not lonest chain rule)
+        require(height >= _checkpointHeight, "verify: before checkpoint");
         require(height <= mainBlockheight, "verify: future block");
 
+        // An unwritten mapping entry has the default zero value. Reject zero
+        // explicitly so it can never be presented as a real block commitment.
+        require(commitmentHash != bytes32(0), "verify: zero commitment");
         require(_mainChain[height] == commitmentHash, "verify: block commitment");
 
         confirmations = mainBlockheight - height + 1;

--- a/ethereum/src/btc_relay/BtcRelayTestnet.sol
+++ b/ethereum/src/btc_relay/BtcRelayTestnet.sol
@@ -42,6 +42,10 @@ contract BtcRelayTestnet is IBtcRelay, IBtcRelayView {
     // only used during testing
     bool immutable _clampBlockTarget;
 
+    // The trusted initialization height. Headers below this checkpoint are not
+    // stored by this relay and must never be treated as part of its main chain.
+    uint32 immutable _checkpointHeight;
+
     //Initialize the btc relay with the provided stored_header
     constructor(StoredBlockHeader memory storedHeader, bool clampBlockTarget) {
         _clampBlockTarget = clampBlockTarget;
@@ -49,6 +53,7 @@ contract BtcRelayTestnet is IBtcRelay, IBtcRelayView {
         //Save the initial stored header
         bytes32 commitHash = storedHeader.hash();
         uint32 blockHeight = storedHeader.blockHeight();
+        _checkpointHeight = blockHeight;
         _mainChain[blockHeight] = commitHash;
         _relayState.write(
             blockHeight, uint224(storedHeader.chainWork() & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
@@ -67,8 +72,12 @@ contract BtcRelayTestnet is IBtcRelay, IBtcRelayView {
         uint256 mainBlockheight = _relayState.blockHeight;
         //Check that the block height isn't past the tip, this can happen if there is a reorg, where a shorter
         // chain becomes the cannonical one, this can happen due to the heaviest work rule (and not lonest chain rule)
+        require(height >= _checkpointHeight, "verify: before checkpoint");
         require(height <= mainBlockheight, "verify: future block");
 
+        // An unwritten mapping entry has the default zero value. Reject zero
+        // explicitly so it can never be presented as a real block commitment.
+        require(commitmentHash != bytes32(0), "verify: zero commitment");
         require(_mainChain[height] == commitmentHash, "verify: block commitment");
 
         confirmations = mainBlockheight - height + 1;

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.35;
 
+import {ICommissionManager} from "./ICommissionManager.sol";
+
 interface IBridge {
     // =========================================================================
     // Errors
@@ -55,6 +57,11 @@ interface IBridge {
     /// @param newRegistry New registry (non-zero by `setRouteRegistry` guard).
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
 
+    /// @notice Emitted on every successful `setCommissionManager`.
+    /// @param oldCommissionManager Previous CommissionManager address.
+    /// @param newCommissionManager New non-zero CommissionManager address.
+    event CommissionManagerUpdated(address indexed oldCommissionManager, address indexed newCommissionManager);
+
     /// @notice Emitted on every successful `setMinFundsInAmount`.
     /// @param oldMinimum Previous minimum (constructor value before first update).
     /// @param newMinimum New minimum (in token smallest units; always non-zero).
@@ -100,7 +107,7 @@ interface IBridge {
     /// @param rgbOpId RGB operation id, decoded by the route module from its
     ///                `settlementData`. Not an on-chain dedup key.
     /// @param amount  Net amount bridged (post-commission).
-    event FundsIn(address indexed sender, uint256 indexed rgbOpId, uint256 amount);
+    event FundsIn(address indexed sender, uint256 rgbOpId, uint256 amount);
 
     /// @param operationId        Canonical bridge-side operation id, derived
     ///                           on-chain by Bridge and unpredictable by third
@@ -342,6 +349,11 @@ interface IBridge {
     ///         `onFundsIn` / `beforeFundsOut` through. Owner-only.
     function setRouteRegistry(address newRouteRegistry) external;
 
+    /// @notice Updates the `CommissionManager` used for fee quotes and custody.
+    ///         Owner-only (MultisigProxy via the typed, timelocked
+    ///         `UpdateCommissionManager` operation). Must be non-zero.
+    function setCommissionManager(address newCommissionManager) external;
+
     /// @notice Updates the minimum accepted `fundsIn` deposit (token smallest
     ///         units). Owner-only (MultisigProxy via the federation
     ///         propose -> timelock -> execute flow). Must be non-zero; reverts
@@ -442,6 +454,9 @@ interface IBridge {
 
     /// @notice Current `RouteRegistry` Bridge uses for route dispatch.
     function routeRegistry() external view returns (address);
+
+    /// @notice Current `CommissionManager` Bridge uses for fee quotes and custody.
+    function commissionManager() external view returns (ICommissionManager);
 
     /// @notice Permanently blocked — ownership cannot be renounced.
     function renounceOwnership() external view;

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -356,7 +356,8 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose migrating to a new CommissionManager address.
+    /// @notice Propose migrating Bridge and this proxy to a new
+    ///         CommissionManager address atomically.
     /// @dev opData = abi.encode(address newCommissionManager)
     function proposeUpdateCommissionManager(
         address newCommissionManager,
@@ -470,13 +471,8 @@ interface IMultisigProxy {
     // =========================================================================
 
     /// @notice Cancel a pending proposal. Requires M-of-N federation signatures.
-    function cancelProposal(
-        bytes32 proposalId,
-        uint256 nonce,
-        uint256 deadline,
-        uint256 fedBitmap,
-        bytes[] calldata fedSigs
-    ) external;
+    /// @dev The authorization is bound directly to `proposalId`;
+    function cancelProposal(bytes32 proposalId, uint256 deadline, uint256 fedBitmap, bytes[] calldata fedSigs) external;
 
     /// @notice Execute a proposal after the timelock has elapsed. Permissionless.
     /// @param proposalId The proposal to execute.

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -109,6 +109,10 @@ contract BridgeTest is Test {
 
         usdt0 = new MockERC20("Mock USDT0", "USDT0");
         btcRelay = new MockBtcRelay();
+        // The real relay never stores a header below its initialisation
+        // checkpoint; mirror that here so a proof this suite accepts is one
+        // the deployed relay would also accept.
+        btcRelay.setCheckpointHeight(BLOCK_HEIGHT);
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, CONFIRMATIONS);
         btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONFIRMATIONS);
 

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.35;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 
 import {Bridge} from "../src/Bridge.sol";
 import {IBridge} from "../src/interfaces/IBridge.sol";
@@ -32,7 +32,7 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract BridgeTest is Test {
     // Events re-declared locally for vm.expectEmit
-    event FundsIn(address indexed sender, uint256 indexed rgbOpId, uint256 amount);
+    event FundsIn(address indexed sender, uint256 rgbOpId, uint256 amount);
     event BridgeFundsIn(
         bytes32 indexed operationId,
         bytes32 indexed sourceSender,
@@ -59,6 +59,7 @@ contract BridgeTest is Test {
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event LZAdapterDisabled(address indexed oldAdapter);
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+    event CommissionManagerUpdated(address indexed oldCommissionManager, address indexed newCommissionManager);
     event MinFundsInAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
     event MinFundsOutAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
     event OutflowLimitUpdated(uint256 indexed chainId, uint256 capacity, uint256 refillRate, uint256 available);
@@ -583,6 +584,62 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
+    // setCommissionManager
+    // ========================================================================
+
+    function test_setCommissionManager_ownerCanRotate() public {
+        CommissionManager newCm = new CommissionManager(address(bridge), recipient);
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit CommissionManagerUpdated(address(cm), address(newCm));
+
+        vm.prank(multisig);
+        bridge.setCommissionManager(address(newCm));
+        assertEq(address(bridge.commissionManager()), address(newCm));
+    }
+
+    function test_setCommissionManager_revertsOnZero() public {
+        vm.prank(multisig);
+        vm.expectRevert(IBridge.InvalidCommissionManagerAddress.selector);
+        bridge.setCommissionManager(address(0));
+    }
+
+    function test_setCommissionManager_revertsIfNotOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.setCommissionManager(makeAddr("newCm"));
+    }
+
+    function test_setCommissionManager_routesNewFeesToReplacement() public {
+        CommissionManager newCm = new CommissionManager(address(bridge), recipient);
+        uint256 percent = 400; // 4%
+        newCm.setCommissionRule(
+            SOURCE_CHAIN_ID,
+            RGB_CHAIN_ID,
+            address(usdt0),
+            CommissionConfig({
+                stablePercent: percent,
+                baseFee: 0,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_IN,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        vm.prank(multisig);
+        bridge.setCommissionManager(address(newCm));
+
+        uint256 oldPoolBefore = cm.tokenCommissionPool(address(usdt0));
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        uint256 expectedCommission = AMOUNT * percent / 100 / 100;
+        assertEq(newCm.tokenCommissionPool(address(usdt0)), expectedCommission, "replacement receives fees");
+        assertEq(cm.tokenCommissionPool(address(usdt0)), oldPoolBefore, "old manager receives nothing");
+    }
+
+    // ========================================================================
     // Minimum fundsIn amount + zero-amount guards
     //
     // `minFundsInAmount` is a non-zero floor enforced on the inbound path: it
@@ -1051,7 +1108,7 @@ contract BridgeTest is Test {
         // Drop the emitter filter so Forge's expectEmit scans past the token's
         // Transfer event (emitter = usdt0) and matches BridgeFundsIn by topic0.
         // FundsIn (RGB route) carries the rgbOpId; sender = the adapter.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(mockAdapter, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -1090,7 +1147,7 @@ contract BridgeTest is Test {
         bytes32 sourceSender = bytes32(uint256(uint160(user)));
         bytes32 expectedOpId = _deriveOpId(SOURCE_CHAIN_ID, sourceSender, 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -2943,7 +3000,7 @@ contract BridgeTest is Test {
         assertEq(nativePoolBefore, 0, "pre native pool");
         assertEq(recordBefore, 0, "pre record");
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -3015,7 +3072,7 @@ contract BridgeTest is Test {
         assertEq(nativePoolBefore, 0, "pre native pool");
         assertEq(recordBefore, 0, "pre record");
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -3455,7 +3512,7 @@ contract BridgeTest is Test {
         assertEq(cm.nativeCommissionPool(), nativePoolBefore, "native pool unchanged");
         assertEq(rgbModule.fundsInRecords(expectedOpId), recordBefore, "record not created");
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3499,7 +3556,7 @@ contract BridgeTest is Test {
         assertEq(bridgeBefore, 0, "pre bridge token");
         assertEq(recordBefore, 0, "pre record");
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3556,7 +3613,7 @@ contract BridgeTest is Test {
             SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
         );
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3716,7 +3773,7 @@ contract BridgeTest is Test {
             SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, amount, RGB_CHAIN_ID, DST_ADDR, _rgbData()
         );
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3860,10 +3917,30 @@ contract BridgeTest is Test {
 
     /// @dev The RGB route emits FundsIn carrying the rgbOpId and net amount.
     function test_fundsIn_rgbRouteEmitsFundsInWithRgbOpId() public {
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, AMOUNT); // no commission → net == gross == AMOUNT
         vm.prank(user);
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+    }
+
+    function test_fundsIn_rgbOpIdIsNonIndexedEventData() public {
+        bytes32 fundsInTopic = keccak256("FundsIn(address,uint256,uint256)");
+        vm.recordLogs();
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter == address(bridge) && logs[i].topics[0] == fundsInTopic) {
+                assertEq(logs[i].topics.length, 2, "only signature and sender are indexed");
+                assertEq(address(uint160(uint256(logs[i].topics[1]))), user, "sender topic");
+                (uint256 rgbOpId, uint256 amount) = abi.decode(logs[i].data, (uint256, uint256));
+                assertEq(rgbOpId, RGB_OP_ID, "rgb op id is event data");
+                assertEq(amount, AMOUNT, "amount is event data");
+                return;
+            }
+        }
+        fail("FundsIn event not found");
     }
 
     /// @dev The returned bytes32 is the key under which the module records net.
@@ -4011,7 +4088,7 @@ contract BridgeTest is Test {
         bytes32 sourceSender = bytes32(uint256(uint160(user)));
 
         // BridgeFundsIn must carry gross `amount == AMOUNT` and `netAmount == received`.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, received);
         vm.expectEmit(false, true, true, true);
         emit BridgeFundsIn(

--- a/ethereum/test/BridgeRebalance.t.sol
+++ b/ethereum/test/BridgeRebalance.t.sol
@@ -101,6 +101,10 @@ contract BridgeRebalanceTest is Test {
     function setUp() public {
         usdt0 = new MockERC20("Mock USDT0", "USDT0");
         btcRelay = new MockBtcRelay();
+        // The real relay never stores a header below its initialisation
+        // checkpoint; mirror that here so a proof this suite accepts is one
+        // the deployed relay would also accept.
+        btcRelay.setCheckpointHeight(BLOCK_HEIGHT);
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, CONFIRMATIONS);
         btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONFIRMATIONS);
 

--- a/ethereum/test/BridgeRebalance.t.sol
+++ b/ethereum/test/BridgeRebalance.t.sol
@@ -37,7 +37,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 ///                    (burn-backed: BtcRelay proof + record check; credit leg
 ///                     writes nothing and emits no FundsIn)
 contract BridgeRebalanceTest is Test {
-    event FundsIn(address indexed sender, uint256 indexed rgbOpId, uint256 amount);
+    event FundsIn(address indexed sender, uint256 rgbOpId, uint256 amount);
     event BridgeRebalance(
         bytes32 indexed operationId,
         uint256 indexed burnId,
@@ -532,7 +532,7 @@ contract BridgeRebalanceTest is Test {
         IBridge.RebalanceParams memory p = _productionPoolToMintBurnParams(AMOUNT, rgbOpId);
         bytes32 rebalanceOperationId = _deriveRebalanceOpId(p);
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(multisig, rgbOpId, AMOUNT);
         _rebalance(p);
 
@@ -554,7 +554,7 @@ contract BridgeRebalanceTest is Test {
 
         // Credit-RGB rebalance emits the standard FundsIn (the RGB side needs
         // no rebalance awareness) plus the canonical BridgeRebalance.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(multisig, mintOpId, AMOUNT);
         vm.expectEmit(true, true, false, true);
         emit BridgeRebalance(expectedOpId, p.burnId, ARCH_CHAIN_ID, RGB_CHAIN_ID, AMOUNT, ARCH_SRC_ADDR, RGB_DST_ADDR);
@@ -609,7 +609,7 @@ contract BridgeRebalanceTest is Test {
         // Both sides are RGB: the debit leg verifies the mint/burn record and the
         // credit leg writes a NEW pool record + emits FundsIn — all on the one
         // shared module, no composite module or privileged writer.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(multisig, poolOpId, AMOUNT);
         _rebalance(p);
 
@@ -630,7 +630,7 @@ contract BridgeRebalanceTest is Test {
         // Scenario A: operational, no external burn → NullVerifier, empty proof
         // and empty debit settlement. The credit leg writes the mint/burn record
         // (tagged with the mint/burn network) and emits the inflate FundsIn.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(multisig, inflateOpId, AMOUNT);
         _rebalance(p);
 

--- a/ethereum/test/BtcRelayCheckpoint.t.sol
+++ b/ethereum/test/BtcRelayCheckpoint.t.sol
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.35;
+
+import {Test} from "forge-std/Test.sol";
+
+import {BtcRelay} from "../src/btc_relay/BtcRelay.sol";
+import {BtcRelayTestnet} from "../src/btc_relay/BtcRelayTestnet.sol";
+import {StoredBlockHeader as MainnetStoredBlockHeader} from "../src/btc_relay/structs/StoredBlockHeader.sol";
+import {StoredBlockHeader as TestnetStoredBlockHeader} from "../src/btc_relay/structs/StoredBlockHeaderTestnet.sol";
+import {RGBVerifier} from "../src/verifiers/RGBVerifier.sol";
+import {MockBtcRelay} from "./mocks/MockBtcRelay.sol";
+import {FundsOutContext} from "../src/interfaces/RouteTypes.sol";
+
+contract BtcRelayCheckpointTest is Test {
+    uint32 internal constant CHECKPOINT_HEIGHT = 850_000;
+    uint32 internal constant BELOW_CHECKPOINT_HEIGHT = 849_000;
+
+    BtcRelay internal relay;
+    RGBVerifier internal verifier;
+    bytes32 internal checkpointCommitment;
+
+    function setUp() public {
+        relay = new BtcRelay(_headerAtHeight(CHECKPOINT_HEIGHT), true);
+        checkpointCommitment = relay.getTipCommitHash();
+        verifier = new RGBVerifier(address(relay), 6, 1, 5);
+    }
+
+    function test_verifyBlockheaderHash_rejectsZeroCommitmentBelowCheckpoint() public {
+        assertEq(relay.getCommitHash(BELOW_CHECKPOINT_HEIGHT), bytes32(0));
+
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    function test_verifyBlockheaderHash_rejectsNonZeroCommitmentBelowCheckpoint() public {
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, keccak256("phantom-block"));
+    }
+
+    function test_verifyBlockheaderHash_rejectsZeroCommitmentAtCheckpoint() public {
+        vm.expectRevert(bytes("verify: zero commitment"));
+        relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    function test_verifyBlockheaderHash_acceptsStoredCheckpointCommitment() public view {
+        assertTrue(checkpointCommitment != bytes32(0));
+        assertEq(relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, checkpointCommitment), 1);
+    }
+
+    function test_verifyBlockheaderHash_preservesFutureHeightRevert() public {
+        vm.expectRevert(bytes("verify: future block"));
+        relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT + 1, bytes32(0));
+    }
+
+    function test_rgbVerifier_rejectsPhantomSourceBelowCheckpoint() public {
+        bytes memory proof = abi.encode(BELOW_CHECKPOINT_HEIGHT, bytes32(0), CHECKPOINT_HEIGHT, checkpointCommitment);
+        FundsOutContext memory context;
+
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        verifier.verify(context, proof);
+    }
+
+    function _headerAtHeight(uint32 height) private pure returns (MainnetStoredBlockHeader memory header) {
+        // blockHeight() reads a big-endian uint32 at byte offset 112, i.e.
+        // bytes 16..19 of data[3].
+        header.data[3] = bytes32(uint256(height) << 96);
+    }
+}
+
+contract BtcRelayTestnetCheckpointTest is Test {
+    uint32 internal constant CHECKPOINT_HEIGHT = 2_500_000;
+    uint32 internal constant BELOW_CHECKPOINT_HEIGHT = 2_499_000;
+
+    BtcRelayTestnet internal relay;
+    bytes32 internal checkpointCommitment;
+
+    function setUp() public {
+        relay = new BtcRelayTestnet(_headerAtHeight(CHECKPOINT_HEIGHT), true);
+        checkpointCommitment = relay.getTipCommitHash();
+    }
+
+    function test_verifyBlockheaderHash_rejectsZeroCommitmentBelowCheckpoint() public {
+        assertEq(relay.getCommitHash(BELOW_CHECKPOINT_HEIGHT), bytes32(0));
+
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    function test_verifyBlockheaderHash_rejectsZeroCommitmentAtCheckpoint() public {
+        vm.expectRevert(bytes("verify: zero commitment"));
+        relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    function test_verifyBlockheaderHash_acceptsStoredCheckpointCommitment() public view {
+        assertTrue(checkpointCommitment != bytes32(0));
+        assertEq(relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, checkpointCommitment), 1);
+    }
+
+    function test_verifyBlockheaderHash_preservesFutureHeightRevert() public {
+        vm.expectRevert(bytes("verify: future block"));
+        relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT + 1, bytes32(0));
+    }
+
+    function _headerAtHeight(uint32 height) private pure returns (TestnetStoredBlockHeader memory header) {
+        header.data[3] = bytes32(uint256(height) << 96);
+    }
+}
+
+/// @notice `MockBtcRelay` stands in for the relay across the Bridge, MultisigProxy
+///         and RGBVerifier suites. It must reject exactly what the real relay
+///         rejects, otherwise an integration test could accept a proof the
+///         deployed relay would refuse.
+contract MockBtcRelayCheckpointTest is Test {
+    uint256 internal constant CHECKPOINT_HEIGHT = 850_000;
+    uint256 internal constant BELOW_CHECKPOINT_HEIGHT = 849_000;
+    uint256 internal constant LATEST_HEIGHT = 850_005;
+
+    bytes32 internal constant SOURCE_COMMIT = keccak256("mock-source-block");
+    bytes32 internal constant LATEST_COMMIT = keccak256("mock-latest-block");
+
+    MockBtcRelay internal relay;
+    RGBVerifier internal verifier;
+
+    function setUp() public {
+        relay = new MockBtcRelay();
+        relay.setCheckpointHeight(CHECKPOINT_HEIGHT);
+        relay.setBlock(CHECKPOINT_HEIGHT, SOURCE_COMMIT, 6);
+        relay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, 1);
+        verifier = new RGBVerifier(address(relay), 6, 1, 5);
+    }
+
+    /// Contrast: with no checkpoint configured (the previous mock behaviour) a
+    /// block registered below the real relay's checkpoint is served happily.
+    /// Setting the checkpoint is what closes that divergence.
+    function test_withoutCheckpointBelowHeightIsServed() public {
+        MockBtcRelay fresh = new MockBtcRelay();
+        assertEq(fresh.checkpointHeight(), 0, "default keeps the pre-existing behaviour");
+
+        bytes32 belowCommit = keccak256("registered-below-checkpoint");
+        fresh.setBlock(BELOW_CHECKPOINT_HEIGHT, belowCommit, 1000);
+        assertEq(
+            fresh.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, belowCommit),
+            1000,
+            "un-checkpointed mock serves a height the real relay rejects"
+        );
+
+        fresh.setCheckpointHeight(CHECKPOINT_HEIGHT);
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        fresh.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, belowCommit);
+    }
+
+    function test_rejectsZeroCommitmentBelowCheckpoint() public {
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    /// The divergence that actually mattered: before the checkpoint existed the
+    /// mock happily served a block registered below it, which the real relay
+    /// rejects outright. A suite could therefore green-light a proof the
+    /// deployed relay would refuse.
+    function test_rejectsRegisteredBlockBelowCheckpoint() public {
+        bytes32 belowCommit = keccak256("registered-below-checkpoint");
+        relay.setBlock(BELOW_CHECKPOINT_HEIGHT, belowCommit, 1000);
+
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, belowCommit);
+    }
+
+    function test_rejectsUnregisteredCommitmentBelowCheckpoint() public {
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        relay.verifyBlockheaderHash(BELOW_CHECKPOINT_HEIGHT, keccak256("phantom-block"));
+    }
+
+    function test_rejectsZeroCommitmentAtRegisteredHeight() public {
+        vm.expectRevert(bytes("verify: zero commitment"));
+        relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, bytes32(0));
+    }
+
+    function test_preservesUnknownBlockRevert() public {
+        vm.expectRevert(bytes("verify: block commitment"));
+        relay.verifyBlockheaderHash(LATEST_HEIGHT + 999, keccak256("unknown"));
+    }
+
+    function test_acceptsRegisteredBlock() public view {
+        assertEq(relay.verifyBlockheaderHash(CHECKPOINT_HEIGHT, SOURCE_COMMIT), 6);
+    }
+
+    /// The exact proof shape from the audit finding, driven through the mock the
+    /// integration suites use.
+    function test_rgbVerifier_rejectsPhantomSourceOverMock() public {
+        bytes memory proof = abi.encode(BELOW_CHECKPOINT_HEIGHT, bytes32(0), LATEST_HEIGHT, LATEST_COMMIT);
+        FundsOutContext memory context;
+
+        vm.expectRevert(bytes("verify: before checkpoint"));
+        verifier.verify(context, proof);
+    }
+}

--- a/ethereum/test/Integration.t.sol
+++ b/ethereum/test/Integration.t.sol
@@ -166,6 +166,10 @@ contract IntegrationTest is Test {
 
         token = new MockERC20("Mock USDT0", "USDT0");
         btcRelay = new MockBtcRelay();
+        // The real relay never stores a header below its initialisation
+        // checkpoint; mirror that here so a proof this suite accepts is one
+        // the deployed relay would also accept.
+        btcRelay.setCheckpointHeight(BLOCK_HEIGHT);
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, BTC_CONFIRMATIONS);
         btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONFIRMATIONS);
 

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -1702,28 +1702,36 @@ contract MultisigProxyTest is Test {
         _assertGenericPathsRejectSelector(callData, IMultisigProxy.ForbiddenBridgeReleaseSelector.selector);
     }
 
+    function test_federationGenericPathsCannotDesyncCommissionManager() public {
+        bytes memory callData = abi.encodeCall(IBridge.setCommissionManager, (makeAddr("genericCm")));
+        _assertGenericPathsRejectSelector(callData, IMultisigProxy.ForbiddenCommissionManagerSelector.selector);
+    }
+
     // ========================================================================
     // Propose + Execute — UpdateCommissionManager
     // ========================================================================
 
     function test_proposeUpdateCommissionManager_execute() public {
-        address newCm = makeAddr("newCm");
+        CommissionManager newCm = new CommissionManager(address(bridge), commissionReceiver);
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
 
-        bytes32 digest = MultisigHelper.digestProposeUpdateCommissionManager(domainSep, newCm, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestProposeUpdateCommissionManager(domainSep, address(newCm), nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateCommissionManager(newCm, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateCommissionManager(address(newCm), nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
 
-        vm.expectEmit(true, true, false, false);
-        emit CommissionManagerUpdated(address(cm), newCm);
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit CommissionManagerUpdated(address(cm), address(newCm));
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit CommissionManagerUpdated(address(cm), address(newCm));
 
-        proxy.executeProposal(id, abi.encode(newCm));
-        assertEq(proxy.commissionManager(), newCm);
+        proxy.executeProposal(id, abi.encode(address(newCm)));
+        assertEq(proxy.commissionManager(), address(newCm));
+        assertEq(address(bridge.commissionManager()), address(newCm));
     }
 
     // ========================================================================
@@ -1794,16 +1802,17 @@ contract MultisigProxyTest is Test {
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         bytes32 id = proxy.proposeUpdateBridge(newBridge, nonce, deadline, bitmap, sigs);
+        uint256 proposalNonceAfterPropose = proxy.proposalNonce();
 
-        uint256 cNonce = proxy.proposalNonce();
         uint256 cDeadline = block.timestamp + 1 hours;
-        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cNonce, cDeadline);
+        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cDeadline);
         bytes[] memory cSigs = MultisigHelper.signAll(vm, cDigest, pks);
 
         vm.expectEmit(true, false, false, false);
         emit ProposalCancelled(id);
-        proxy.cancelProposal(id, cNonce, cDeadline, bitmap, cSigs);
+        proxy.cancelProposal(id, cDeadline, bitmap, cSigs);
 
+        assertEq(proxy.proposalNonce(), proposalNonceAfterPropose, "cancel does not consume proposal nonce");
         IMultisigProxy.Proposal memory p = proxy.getProposal(id);
         assertEq(uint8(p.status), uint8(IMultisigProxy.ProposalStatus.Cancelled));
 
@@ -1814,14 +1823,74 @@ contract MultisigProxyTest is Test {
 
     function test_cancelProposal_revertsOnNotPending() public {
         bytes32 id = keccak256("ghost");
-        uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 hours;
-        bytes32 digest = MultisigHelper.digestCancelProposal(domainSep, id, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestCancelProposal(domainSep, id, deadline);
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
         vm.expectRevert(IMultisigProxy.NotPending.selector);
-        proxy.cancelProposal(id, nonce, deadline, bitmap, sigs);
+        proxy.cancelProposal(id, deadline, bitmap, sigs);
+    }
+
+    /// @dev Regression for the shared-nonce veto-starvation finding. Once a
+    ///      cancel is signed for a concrete proposal, unrelated proposal
+    ///      traffic cannot invalidate it by advancing `proposalNonce`.
+    function test_cancelProposal_survivesUnrelatedProposalNonceAdvance() public {
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+
+        uint256 targetNonce = proxy.proposalNonce();
+        uint256 targetDeadline = block.timestamp + 1 days;
+        address targetBridge = makeAddr("targetBridge");
+        bytes32 targetDigest =
+            MultisigHelper.digestProposeUpdateBridge(domainSep, targetBridge, targetNonce, targetDeadline);
+        bytes32 targetId = proxy.proposeUpdateBridge(
+            targetBridge, targetNonce, targetDeadline, bitmap, MultisigHelper.signAll(vm, targetDigest, pks)
+        );
+
+        uint256 cancelDeadline = block.timestamp + 1 hours;
+        bytes32 cancelDigest = MultisigHelper.digestCancelProposal(domainSep, targetId, cancelDeadline);
+        bytes[] memory cancelSigs = MultisigHelper.signAll(vm, cancelDigest, pks);
+
+        // A different, valid federation proposal advances the sequential
+        // proposal lane after the cancel bundle has already been collected.
+        uint256 unrelatedNonce = proxy.proposalNonce();
+        address unrelatedBridge = makeAddr("unrelatedBridge");
+        bytes32 unrelatedDigest =
+            MultisigHelper.digestProposeUpdateBridge(domainSep, unrelatedBridge, unrelatedNonce, targetDeadline);
+        proxy.proposeUpdateBridge(
+            unrelatedBridge, unrelatedNonce, targetDeadline, bitmap, MultisigHelper.signAll(vm, unrelatedDigest, pks)
+        );
+        uint256 nonceAfterUnrelatedProposal = proxy.proposalNonce();
+        assertEq(nonceAfterUnrelatedProposal, targetNonce + 2, "unrelated proposal advances its own lane");
+
+        proxy.cancelProposal(targetId, cancelDeadline, bitmap, cancelSigs);
+
+        assertEq(proxy.proposalNonce(), nonceAfterUnrelatedProposal, "cancel leaves proposal lane untouched");
+        assertEq(
+            uint256(proxy.getProposal(targetId).status),
+            uint256(IMultisigProxy.ProposalStatus.Cancelled),
+            "original cancel remains executable"
+        );
+    }
+
+    function test_cancelProposal_replayRevertsOnCancelledStatus() public {
+        address newBridge = makeAddr("cancelReplayBridge");
+        uint256 nonce = proxy.proposalNonce();
+        uint256 proposalDeadline = block.timestamp + 1 days;
+        bytes32 proposalDigest = MultisigHelper.digestProposeUpdateBridge(domainSep, newBridge, nonce, proposalDeadline);
+        (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
+        bytes32 id = proxy.proposeUpdateBridge(
+            newBridge, nonce, proposalDeadline, bitmap, MultisigHelper.signAll(vm, proposalDigest, pks)
+        );
+
+        uint256 cancelDeadline = block.timestamp + 1 hours;
+        bytes32 cancelDigest = MultisigHelper.digestCancelProposal(domainSep, id, cancelDeadline);
+        bytes[] memory cancelSigs = MultisigHelper.signAll(vm, cancelDigest, pks);
+
+        proxy.cancelProposal(id, cancelDeadline, bitmap, cancelSigs);
+
+        vm.expectRevert(IMultisigProxy.NotPending.selector);
+        proxy.cancelProposal(id, cancelDeadline, bitmap, cancelSigs);
     }
 
     // ========================================================================
@@ -1962,15 +2031,14 @@ contract MultisigProxyTest is Test {
         address newAdapter = makeAddr("lzAdapter");
         bytes32 id = _proposeUpdateLZAdapter(newAdapter);
 
-        uint256 cNonce = proxy.proposalNonce();
         uint256 cDeadline = block.timestamp + 1 hours;
-        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cNonce, cDeadline);
+        bytes32 cDigest = MultisigHelper.digestCancelProposal(domainSep, id, cDeadline);
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory cSigs = MultisigHelper.signAll(vm, cDigest, pks);
 
         vm.expectEmit(true, false, false, false);
         emit ProposalCancelled(id);
-        proxy.cancelProposal(id, cNonce, cDeadline, bitmap, cSigs);
+        proxy.cancelProposal(id, cDeadline, bitmap, cSigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
         vm.expectRevert(IMultisigProxy.NotPending.selector);
@@ -3146,15 +3214,12 @@ contract MultisigProxyTest is Test {
 
         // The live federation can still cancel stale records for operational
         // cleanup; cancellation intentionally has no version restriction.
-        uint256 cancelNonce = proxy.proposalNonce();
         uint256 cancelDeadline = block.timestamp + 1 days;
-        bytes32 cancelDigest = MultisigHelper.digestCancelProposal(domainSep, staleId, cancelNonce, cancelDeadline);
+        bytes32 cancelDigest = MultisigHelper.digestCancelProposal(domainSep, staleId, cancelDeadline);
         uint256[] memory cancellingPks = new uint256[](2);
         cancellingPks[0] = newPks[0];
         cancellingPks[1] = newPks[1];
-        proxy.cancelProposal(
-            staleId, cancelNonce, cancelDeadline, 3, MultisigHelper.signAll(vm, cancelDigest, cancellingPks)
-        );
+        proxy.cancelProposal(staleId, cancelDeadline, 3, MultisigHelper.signAll(vm, cancelDigest, cancellingPks));
         assertEq(
             uint256(proxy.getProposal(staleId).status),
             uint256(IMultisigProxy.ProposalStatus.Cancelled),

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -221,6 +221,10 @@ contract MultisigProxyTest is Test {
 
         token = new MockERC20("Mock USDT0", "USDT0");
         btcRelay = new MockBtcRelay();
+        // The real relay never stores a header below its initialisation
+        // checkpoint; mirror that here so a proof this suite accepts is one
+        // the deployed relay would also accept.
+        btcRelay.setCheckpointHeight(BLOCK_HEIGHT);
         btcRelay.setBlock(BLOCK_HEIGHT, COMMITMENT_HASH, BTC_CONFIRMATIONS);
         btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONFIRMATIONS);
 

--- a/ethereum/test/RGBVerifier.t.sol
+++ b/ethereum/test/RGBVerifier.t.sol
@@ -35,6 +35,10 @@ contract RGBVerifierTest is Test {
 
     function setUp() public {
         btcRelay = new MockBtcRelay();
+        // The real relay never stores a header below its initialisation
+        // checkpoint; mirror that here so a proof this suite accepts is one
+        // the deployed relay would also accept.
+        btcRelay.setCheckpointHeight(SOURCE_HEIGHT);
         btcRelay.setBlock(SOURCE_HEIGHT, SOURCE_COMMIT, SOURCE_CONF);
         btcRelay.setBlock(LATEST_HEIGHT, LATEST_COMMIT, LATEST_CONF);
         verifier = new RGBVerifier(address(btcRelay), MIN_SOURCE_CONF, MAX_LATEST_CONF, MIN_GAP);

--- a/ethereum/test/mocks/MockBtcRelay.sol
+++ b/ethereum/test/mocks/MockBtcRelay.sol
@@ -6,10 +6,26 @@ import {IBtcRelayView} from "../../src/interfaces/IBtcRelayView.sol";
 /// @title MockBtcRelay
 /// @notice Minimal mock of the Atomiq BtcRelay for testing.
 ///         Stores (height, commitmentHash) => confirmations.
+/// @dev The rejection rules of `verifyBlockheaderHash` mirror the real
+///      `BtcRelay._verifyBlockheaderHash` so an integration test cannot pass a
+///      proof here that the deployed relay would reject.
 contract MockBtcRelay is IBtcRelayView {
     mapping(bytes32 => uint256) private _blocks;
     uint32 private _blockHeight;
     uint224 private _chainwork;
+
+    /// @notice Lowest height this relay knows about, mirroring the real relay's
+    ///         immutable initialisation checkpoint. Headers below it are never
+    ///         stored and must not be treated as part of the main chain.
+    /// @dev Defaults to 0, so a suite that does not exercise the checkpoint
+    ///      keeps the previous mock behaviour.
+    uint256 public checkpointHeight;
+
+    /// @notice Set the initialisation checkpoint. Call it in `setUp` with the
+    ///         same height the suite registers its blocks at.
+    function setCheckpointHeight(uint256 height) external {
+        checkpointHeight = height;
+    }
 
     /// @notice Register a block so verifyBlockheaderHash returns the given confirmations.
     function setBlock(uint256 height, bytes32 commitmentHash, uint256 confirmations) external {
@@ -36,6 +52,13 @@ contract MockBtcRelay is IBtcRelayView {
         override
         returns (uint256 confirmations)
     {
+        // Mirrors BtcRelay._verifyBlockheaderHash: a height below the checkpoint
+        // is outside this relay's chain, and an unwritten entry reads back as the
+        // default zero — both are rejected before the lookup so the default value
+        // can never be presented as a real block commitment.
+        require(height >= checkpointHeight, "verify: before checkpoint");
+        require(commitmentHash != bytes32(0), "verify: zero commitment");
+
         confirmations = _blocks[_key(height, commitmentHash)];
         require(confirmations > 0, "verify: block commitment");
     }

--- a/ethereum/test/mocks/MultisigHelper.sol
+++ b/ethereum/test/mocks/MultisigHelper.sol
@@ -56,7 +56,7 @@ library MultisigHelper {
         keccak256("ProposeTransferManagedOwnership(address target,address newOwner,uint256 nonce,uint256 deadline)");
 
     bytes32 internal constant CANCEL_PROPOSAL_TYPEHASH =
-        keccak256("CancelProposal(bytes32 proposalId,uint256 nonce,uint256 deadline)");
+        keccak256("CancelProposal(bytes32 proposalId,uint256 deadline)");
 
     bytes32 internal constant PROPOSE_ADMIN_EXECUTE_CM_TYPEHASH = keccak256(
         "ProposeAdminExecuteCommissionManager(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)"
@@ -462,12 +462,12 @@ library MultisigHelper {
         );
     }
 
-    function digestCancelProposal(bytes32 domainSep, bytes32 proposalId, uint256 nonce, uint256 deadline)
+    function digestCancelProposal(bytes32 domainSep, bytes32 proposalId, uint256 deadline)
         internal
         pure
         returns (bytes32)
     {
-        return toTypedDataHash(domainSep, keccak256(abi.encode(CANCEL_PROPOSAL_TYPEHASH, proposalId, nonce, deadline)));
+        return toTypedDataHash(domainSep, keccak256(abi.encode(CANCEL_PROPOSAL_TYPEHASH, proposalId, deadline)));
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Fixes the Bitcoin relay verification issue where an unwritten height below the
deployment checkpoint could be verified using the mapping's default
`bytes32(0)` commitment.

Both `BtcRelay` and `BtcRelayTestnet` now:

- store the trusted initialization height as an immutable checkpoint;
- reject heights below that checkpoint;
- reject zero commitment hashes explicitly;
- preserve verification of legitimate stored commitments.