### PR TITLE
fix: support CommissionManager rotation and update RGB FundsIn event

### DIFF
--- a/ethereum/.env.deploy.example
+++ b/ethereum/.env.deploy.example
@@ -109,8 +109,8 @@ ENCLAVE_THRESHOLD=2
 FEDERATION_THRESHOLD=2
 
 # Immutable CommissionManager withdrawal destination. Changing it requires a
-# new CommissionManager deployment (and, because Bridge pins CM immutably, a
-# coordinated Bridge migration).
+# new CommissionManager deployment, followed by the typed, timelocked
+# UpdateCommissionManager operation that atomically updates Bridge and proxy.
 COMMISSION_RECIPIENT=
 
 # Timelock between propose and execute for federation proposals (seconds).

--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -27,14 +27,15 @@ No TEE verification, no destination chain field, **no commission integration**, 
 
 Production bridge for UTEXO. Inherits `BridgeBase`, implements `IBridge`. Route-agnostic: all per-route logic (finality verification, settlement bookkeeping) is delegated to plugins registered in `RouteRegistry`.
 
-Constructor takes four addresses — the accepted ERC-20 token (immutable), the `RouteRegistry` (mutable — federation can rotate via `UpdateRouteRegistry`), the `CommissionManager` (immutable), and the initial LayerZero adapter (mutable; `address(0)` is allowed) — plus non-zero `minFundsInAmount` and `minFundsOutAmount` values in token smallest units. Federation may retune either minimum through the timelocked owner path. The bridge's own chain identifier is `block.chainid` — chain IDs are `uint256` throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
+Constructor takes four addresses — the accepted ERC-20 token (immutable), the `RouteRegistry` (mutable — federation can rotate via `UpdateRouteRegistry`), the initial `CommissionManager` (mutable — federation can rotate it via `UpdateCommissionManager`), and the initial LayerZero adapter (mutable; `address(0)` is allowed) — plus non-zero `minFundsInAmount` and `minFundsOutAmount` values in token smallest units. Federation may retune either minimum through the timelocked owner path. The bridge's own chain identifier is `block.chainid` — chain IDs are `uint256` throughout the stack (real EVM chain IDs for EVM legs; backend-assigned IDs in a reserved namespace above `2^32` for non-EVM endpoints, e.g. RGB = `1_000_001`).
 
 - `fundsIn(amount, destinationChainId, destinationAddress, settlementData)` — open, **`payable`**. Direct entry point for EVM users; the source chain is implicit (`block.chainid`). Requires `amount >= minFundsInAmount`. Quotes commission from `CommissionManager` using route key `(block.chainid, destinationChainId, TOKEN)`; if the route uses NATIVE currency, `msg.value` must be between the fresh quote and 5% above it. Exactly the fresh quote is collected and any surplus is refunded to the caller. Pulls the full `amount` in tokens from the sender, forwards any token/native commission to `CommissionManager`, and dispatches to the route's `SettlementModule.onFundsIn(...)` via `RouteRegistry`. The `settlementData` blob is opaque to the bridge — its layout is dictated by the destination route's settlement module (empty for routes that don't consume extra data on inbound, e.g. RGB). Emits two events:
-  - `FundsIn` (from `BridgeBase`) — minimal, uses `netAmount`.
+  - `FundsIn` — RGB-only compatibility event using `netAmount`; `sender` is indexed while `rgbOpId` is carried in event data.
   - `BridgeFundsIn` (from `IBridge`) — full, consumed by the UTEXO backend.
 - `fundsIn(amount, sourceChainId, sourceSender, destinationChainId, destinationAddress, settlementData)` — `onlyLZAdapter` overload used by `LZAdapter` after a cross-chain `OFT.send` compose lands. The adapter has already authenticated the originating sender on the source chain via LayerZero's `OFTComposeMsgCodec.composeFrom`, so it forwards the non-spoofable `sourceChainId` and `sourceSender` to the bridge. For NATIVE commission routes, the source-agreed `msg.value` must remain within the immutable ±5% band around the fresh destination quote. Cross-domain refunds are deliberately unsupported, so the complete accepted value is collected as commission.
 - `setLZAdapter(adapter)` — `onlyOwner`. Rotates the address authorized to call the adapter overload. Set to `address(0)` to close the adapter path entirely.
 - `setRouteRegistry(newRouteRegistry)` — `onlyOwner`. Rotates the `RouteRegistry` Bridge talks to. Used to migrate to a redeployed registry (the registry's `bridge` is immutable, so a new registry deploy is the only way to rotate). Reverts on `address(0)`.
+- `setCommissionManager(newCommissionManager)` — `onlyOwner`. Rotates the manager used for fee quotes and custody. Production migration uses the typed `UpdateCommissionManager` operation so the Bridge and `MultisigProxy` pointers change atomically. Reverts on `address(0)`.
 - `fundsOut(FundsOutParams)` — `onlyOwner`, called only by the typed `MultisigProxy.fundsOutCall` / `lzFundsOutCall` enclave paths. The params bind recipient, amount, burn id, source/destination chains, source address, finality proof, and settlement data. The Bridge checks replay protection and isolated liquidity/rate limits, dispatches route verification and settlement bookkeeping, charges any token commission, and releases the net amount. NATIVE commission is disallowed because the release has no native-currency payer.
 
 Owner **must** be `MultisigProxy`. `fundsOut` is reachable only through the purpose-built `fundsOutCall` or `lzFundsOutCall` entrypoints, and `rebalanceLiquidity` only through `rebalanceCall`; all require the registered source chain's M-of-N enclave signatures. These Bridge selectors are blocked from every federation generic-call lane.
@@ -117,7 +118,7 @@ Federation-controlled operations (`OperationType`):
 | `AdminExecuteCommissionManager` | CommissionManager | Permitted generic call into CM (route rules, global defaults, ETH/USD feed, …) |
 | `WithdrawTokenCommissionCM` | CommissionManager | Withdraw ERC-20 commission to CM's immutable `commissionRecipient` |
 | `WithdrawNativeCommissionCM` | CommissionManager | Withdraw native commission to CM's immutable `commissionRecipient` |
-| `UpdateCommissionManager` | self | Migrate to a redeployed CommissionManager |
+| `UpdateCommissionManager` | Bridge + self | Atomically migrate Bridge and proxy to a redeployed CommissionManager |
 | `AdminExecuteAdapter` | LZAdapter | Generic call into the registered LayerZero adapter (`setTrustedEntrypoint`, `refundStuckFunds`, …). Reverts `ZeroTarget` if `MultisigProxy.lzAdapter` is unset. |
 | `UpdateLZAdapter` | self | Rotate `MultisigProxy.lzAdapter` — the routing target for `AdminExecuteAdapter`. Setting to `address(0)` closes the adapter-admin path. |
 | `SetRoute` | RouteRegistry | Register, update, pause, or re-enable a single `(sourceChainId, destChainId)` route on the registry. The opData encodes `(src, dst, enabled, verifier, module)`. |
@@ -128,6 +129,13 @@ Federation-controlled operations (`OperationType`):
 | `DisableLZAdapter` | self | Explicitly clear the adapter governance target. |
 
 Note: `MultisigProxy.lzAdapter` and `Bridge.lzAdapter` are **separate** fields with different roles. `Bridge.lzAdapter` gates the adapter `fundsIn` overload (data path); `MultisigProxy.lzAdapter` is the target of `AdminExecuteAdapter` proposals (governance path). Both default to `address(0)` and are wired in by federation after the adapter is deployed.
+
+For a CommissionManager migration, deploy and configure the replacement with
+the current Bridge as `bridgeAddress`, start its two-step ownership transfer to
+`MultisigProxy`, and prepare both `UpdateCommissionManager` and a subsequent
+`AdminExecuteCommissionManager(acceptOwnership())` proposal. After their
+timelocks, execute the update first and the ownership acceptance immediately
+after it. The update changes the Bridge and proxy pointers atomically.
 
 ## How it works
 

--- a/ethereum/src/Bridge.sol
+++ b/ethereum/src/Bridge.sol
@@ -157,8 +157,10 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         "UtexoRebalanceBurnId(address bridge,uint256 chainId,address token,uint256 amount,uint256 sourceChainId,uint256 destinationChainId,bytes32 sourceAddressHash,bytes32 destinationAddressHash,bytes32 proofHash,bytes32 settlementDataOutHash,bytes32 settlementDataInHash)"
     );
 
-    /// @notice CommissionManager that receives and custodies protocol fees.
-    ICommissionManager public immutable commissionManager;
+    /// @inheritdoc IBridge
+    /// @dev Mutable so federation can migrate to a redeployed manager through
+    ///      the typed, timelocked `UpdateCommissionManager` governance op.
+    ICommissionManager public override commissionManager;
 
     /// @inheritdoc IBridge
     /// @dev Mutable so federation can rotate registry deployments via
@@ -315,6 +317,16 @@ contract Bridge is BridgeBase, IBridge, ReentrancyGuard {
         address old = routeRegistry;
         routeRegistry = newRouteRegistry;
         emit RouteRegistryUpdated(old, newRouteRegistry);
+    }
+
+    /// @inheritdoc IBridge
+    /// @dev Owner is `MultisigProxy`; its typed `UpdateCommissionManager`
+    ///      operation updates this pointer and the proxy's own target atomically.
+    function setCommissionManager(address newCommissionManager) external override onlyOwner {
+        if (newCommissionManager == address(0)) revert InvalidCommissionManagerAddress();
+        address old = address(commissionManager);
+        commissionManager = ICommissionManager(payable(newCommissionManager));
+        emit CommissionManagerUpdated(old, newCommissionManager);
     }
 
     /// @inheritdoc IBridge

--- a/ethereum/src/MultisigProxy.sol
+++ b/ethereum/src/MultisigProxy.sol
@@ -145,6 +145,10 @@ contract MultisigProxy is IMultisigProxy {
     bytes4 private constant _SEL_FUNDS_OUT = IBridge.fundsOut.selector;
     bytes4 private constant _SEL_REBALANCE_LIQUIDITY = IBridge.rebalanceLiquidity.selector;
 
+    /// @notice CommissionManager rotation is reserved for the typed operation,
+    ///         which keeps the Bridge and proxy targets synchronized atomically.
+    bytes4 private constant _SEL_SET_COMMISSION_MANAGER = IBridge.setCommissionManager.selector;
+
     /// @notice Ownership transfer is reserved for the typed managed-target
     ///         operation and rejected from every generic raw-call lane.
     bytes4 private constant _SEL_TRANSFER_OWNERSHIP = bytes4(keccak256("transferOwnership(address)"));
@@ -1180,6 +1184,7 @@ contract MultisigProxy is IMultisigProxy {
             address newCm = abi.decode(opData, (address));
             if (newCm == address(0)) revert ZeroCommissionManager();
             address old = commissionManager;
+            IBridge(bridge).setCommissionManager(newCm);
             commissionManager = newCm;
             emit CommissionManagerUpdated(old, newCm);
         } else if (opType == OperationType.AdminExecuteAdapter) {
@@ -1412,6 +1417,7 @@ contract MultisigProxy is IMultisigProxy {
     function _requireAllowedGenericSelector(bytes4 selector) private pure {
         _requireNotCommissionWithdrawSelector(selector);
         _requireNotBridgeReleaseSelector(selector);
+        if (selector == _SEL_SET_COMMISSION_MANAGER) revert ForbiddenCommissionManagerSelector(selector);
         if (selector == _SEL_TRANSFER_OWNERSHIP) revert ForbiddenOwnershipSelector(selector);
     }
 

--- a/ethereum/src/interfaces/IBridge.sol
+++ b/ethereum/src/interfaces/IBridge.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.35;
 
+import {ICommissionManager} from "./ICommissionManager.sol";
+
 interface IBridge {
     // =========================================================================
     // Errors
@@ -55,6 +57,11 @@ interface IBridge {
     /// @param newRegistry New registry (non-zero by `setRouteRegistry` guard).
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
 
+    /// @notice Emitted on every successful `setCommissionManager`.
+    /// @param oldCommissionManager Previous CommissionManager address.
+    /// @param newCommissionManager New non-zero CommissionManager address.
+    event CommissionManagerUpdated(address indexed oldCommissionManager, address indexed newCommissionManager);
+
     /// @notice Emitted on every successful `setMinFundsInAmount`.
     /// @param oldMinimum Previous minimum (constructor value before first update).
     /// @param newMinimum New minimum (in token smallest units; always non-zero).
@@ -100,7 +107,7 @@ interface IBridge {
     /// @param rgbOpId RGB operation id, decoded by the route module from its
     ///                `settlementData`. Not an on-chain dedup key.
     /// @param amount  Net amount bridged (post-commission).
-    event FundsIn(address indexed sender, uint256 indexed rgbOpId, uint256 amount);
+    event FundsIn(address indexed sender, uint256 rgbOpId, uint256 amount);
 
     /// @param operationId        Canonical bridge-side operation id, derived
     ///                           on-chain by Bridge and unpredictable by third
@@ -342,6 +349,11 @@ interface IBridge {
     ///         `onFundsIn` / `beforeFundsOut` through. Owner-only.
     function setRouteRegistry(address newRouteRegistry) external;
 
+    /// @notice Updates the `CommissionManager` used for fee quotes and custody.
+    ///         Owner-only (MultisigProxy via the typed, timelocked
+    ///         `UpdateCommissionManager` operation). Must be non-zero.
+    function setCommissionManager(address newCommissionManager) external;
+
     /// @notice Updates the minimum accepted `fundsIn` deposit (token smallest
     ///         units). Owner-only (MultisigProxy via the federation
     ///         propose -> timelock -> execute flow). Must be non-zero; reverts
@@ -442,6 +454,9 @@ interface IBridge {
 
     /// @notice Current `RouteRegistry` Bridge uses for route dispatch.
     function routeRegistry() external view returns (address);
+
+    /// @notice Current `CommissionManager` Bridge uses for fee quotes and custody.
+    function commissionManager() external view returns (ICommissionManager);
 
     /// @notice Permanently blocked — ownership cannot be renounced.
     function renounceOwnership() external view;

--- a/ethereum/src/interfaces/IMultisigProxy.sol
+++ b/ethereum/src/interfaces/IMultisigProxy.sol
@@ -356,7 +356,8 @@ interface IMultisigProxy {
         bytes[] calldata fedSigs
     ) external returns (bytes32);
 
-    /// @notice Propose migrating to a new CommissionManager address.
+    /// @notice Propose migrating Bridge and this proxy to a new
+    ///         CommissionManager address atomically.
     /// @dev opData = abi.encode(address newCommissionManager)
     function proposeUpdateCommissionManager(
         address newCommissionManager,

--- a/ethereum/test/Bridge.t.sol
+++ b/ethereum/test/Bridge.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.35;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 
 import {Bridge} from "../src/Bridge.sol";
 import {IBridge} from "../src/interfaces/IBridge.sol";
@@ -32,7 +32,7 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract BridgeTest is Test {
     // Events re-declared locally for vm.expectEmit
-    event FundsIn(address indexed sender, uint256 indexed rgbOpId, uint256 amount);
+    event FundsIn(address indexed sender, uint256 rgbOpId, uint256 amount);
     event BridgeFundsIn(
         bytes32 indexed operationId,
         bytes32 indexed sourceSender,
@@ -59,6 +59,7 @@ contract BridgeTest is Test {
     event LZAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event LZAdapterDisabled(address indexed oldAdapter);
     event RouteRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+    event CommissionManagerUpdated(address indexed oldCommissionManager, address indexed newCommissionManager);
     event MinFundsInAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
     event MinFundsOutAmountUpdated(uint256 oldMinimum, uint256 newMinimum);
     event OutflowLimitUpdated(uint256 indexed chainId, uint256 capacity, uint256 refillRate, uint256 available);
@@ -583,6 +584,62 @@ contract BridgeTest is Test {
     }
 
     // ========================================================================
+    // setCommissionManager
+    // ========================================================================
+
+    function test_setCommissionManager_ownerCanRotate() public {
+        CommissionManager newCm = new CommissionManager(address(bridge), recipient);
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit CommissionManagerUpdated(address(cm), address(newCm));
+
+        vm.prank(multisig);
+        bridge.setCommissionManager(address(newCm));
+        assertEq(address(bridge.commissionManager()), address(newCm));
+    }
+
+    function test_setCommissionManager_revertsOnZero() public {
+        vm.prank(multisig);
+        vm.expectRevert(IBridge.InvalidCommissionManagerAddress.selector);
+        bridge.setCommissionManager(address(0));
+    }
+
+    function test_setCommissionManager_revertsIfNotOwner() public {
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        bridge.setCommissionManager(makeAddr("newCm"));
+    }
+
+    function test_setCommissionManager_routesNewFeesToReplacement() public {
+        CommissionManager newCm = new CommissionManager(address(bridge), recipient);
+        uint256 percent = 400; // 4%
+        newCm.setCommissionRule(
+            SOURCE_CHAIN_ID,
+            RGB_CHAIN_ID,
+            address(usdt0),
+            CommissionConfig({
+                stablePercent: percent,
+                baseFee: 0,
+                multiplier: 100,
+                side: CommissionSide.FUNDS_IN,
+                currency: CommissionCurrency.TOKEN,
+                isSet: true
+            })
+        );
+
+        vm.prank(multisig);
+        bridge.setCommissionManager(address(newCm));
+
+        uint256 oldPoolBefore = cm.tokenCommissionPool(address(usdt0));
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        uint256 expectedCommission = AMOUNT * percent / 100 / 100;
+        assertEq(newCm.tokenCommissionPool(address(usdt0)), expectedCommission, "replacement receives fees");
+        assertEq(cm.tokenCommissionPool(address(usdt0)), oldPoolBefore, "old manager receives nothing");
+    }
+
+    // ========================================================================
     // Minimum fundsIn amount + zero-amount guards
     //
     // `minFundsInAmount` is a non-zero floor enforced on the inbound path: it
@@ -1051,7 +1108,7 @@ contract BridgeTest is Test {
         // Drop the emitter filter so Forge's expectEmit scans past the token's
         // Transfer event (emitter = usdt0) and matches BridgeFundsIn by topic0.
         // FundsIn (RGB route) carries the rgbOpId; sender = the adapter.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(mockAdapter, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -1090,7 +1147,7 @@ contract BridgeTest is Test {
         bytes32 sourceSender = bytes32(uint256(uint160(user)));
         bytes32 expectedOpId = _deriveOpId(SOURCE_CHAIN_ID, sourceSender, 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -2943,7 +3000,7 @@ contract BridgeTest is Test {
         assertEq(nativePoolBefore, 0, "pre native pool");
         assertEq(recordBefore, 0, "pre record");
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -3015,7 +3072,7 @@ contract BridgeTest is Test {
         assertEq(nativePoolBefore, 0, "pre native pool");
         assertEq(recordBefore, 0, "pre record");
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true);
         emit BridgeFundsIn(
@@ -3455,7 +3512,7 @@ contract BridgeTest is Test {
         assertEq(cm.nativeCommissionPool(), nativePoolBefore, "native pool unchanged");
         assertEq(rgbModule.fundsInRecords(expectedOpId), recordBefore, "record not created");
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3499,7 +3556,7 @@ contract BridgeTest is Test {
         assertEq(bridgeBefore, 0, "pre bridge token");
         assertEq(recordBefore, 0, "pre record");
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, AMOUNT);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3556,7 +3613,7 @@ contract BridgeTest is Test {
             SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData()
         );
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3716,7 +3773,7 @@ contract BridgeTest is Test {
             SOURCE_CHAIN_ID, bytes32(uint256(uint160(user))), 0, amount, RGB_CHAIN_ID, DST_ADDR, _rgbData()
         );
 
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, netAmount);
         vm.expectEmit(true, true, true, true, address(bridge));
         emit BridgeFundsIn(
@@ -3860,10 +3917,30 @@ contract BridgeTest is Test {
 
     /// @dev The RGB route emits FundsIn carrying the rgbOpId and net amount.
     function test_fundsIn_rgbRouteEmitsFundsInWithRgbOpId() public {
-        vm.expectEmit(true, true, false, true, address(bridge));
+        vm.expectEmit(true, false, false, true, address(bridge));
         emit FundsIn(user, RGB_OP_ID, AMOUNT); // no commission → net == gross == AMOUNT
         vm.prank(user);
         bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+    }
+
+    function test_fundsIn_rgbOpIdIsNonIndexedEventData() public {
+        bytes32 fundsInTopic = keccak256("FundsIn(address,uint256,uint256)");
+        vm.recordLogs();
+        vm.prank(user);
+        bridge.fundsIn(AMOUNT, RGB_CHAIN_ID, DST_ADDR, _rgbData());
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter == address(bridge) && logs[i].topics[0] == fundsInTopic) {
+                assertEq(logs[i].topics.length, 2, "only signature and sender are indexed");
+                assertEq(address(uint160(uint256(logs[i].topics[1]))), user, "sender topic");
+                (uint256 rgbOpId, uint256 amount) = abi.decode(logs[i].data, (uint256, uint256));
+                assertEq(rgbOpId, RGB_OP_ID, "rgb op id is event data");
+                assertEq(amount, AMOUNT, "amount is event data");
+                return;
+            }
+        }
+        fail("FundsIn event not found");
     }
 
     /// @dev The returned bytes32 is the key under which the module records net.
@@ -4011,7 +4088,7 @@ contract BridgeTest is Test {
         bytes32 sourceSender = bytes32(uint256(uint160(user)));
 
         // BridgeFundsIn must carry gross `amount == AMOUNT` and `netAmount == received`.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(user, RGB_OP_ID, received);
         vm.expectEmit(false, true, true, true);
         emit BridgeFundsIn(

--- a/ethereum/test/BridgeRebalance.t.sol
+++ b/ethereum/test/BridgeRebalance.t.sol
@@ -37,7 +37,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 ///                    (burn-backed: BtcRelay proof + record check; credit leg
 ///                     writes nothing and emits no FundsIn)
 contract BridgeRebalanceTest is Test {
-    event FundsIn(address indexed sender, uint256 indexed rgbOpId, uint256 amount);
+    event FundsIn(address indexed sender, uint256 rgbOpId, uint256 amount);
     event BridgeRebalance(
         bytes32 indexed operationId,
         uint256 indexed burnId,
@@ -532,7 +532,7 @@ contract BridgeRebalanceTest is Test {
         IBridge.RebalanceParams memory p = _productionPoolToMintBurnParams(AMOUNT, rgbOpId);
         bytes32 rebalanceOperationId = _deriveRebalanceOpId(p);
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(multisig, rgbOpId, AMOUNT);
         _rebalance(p);
 
@@ -554,7 +554,7 @@ contract BridgeRebalanceTest is Test {
 
         // Credit-RGB rebalance emits the standard FundsIn (the RGB side needs
         // no rebalance awareness) plus the canonical BridgeRebalance.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(multisig, mintOpId, AMOUNT);
         vm.expectEmit(true, true, false, true);
         emit BridgeRebalance(expectedOpId, p.burnId, ARCH_CHAIN_ID, RGB_CHAIN_ID, AMOUNT, ARCH_SRC_ADDR, RGB_DST_ADDR);
@@ -609,7 +609,7 @@ contract BridgeRebalanceTest is Test {
         // Both sides are RGB: the debit leg verifies the mint/burn record and the
         // credit leg writes a NEW pool record + emits FundsIn — all on the one
         // shared module, no composite module or privileged writer.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(multisig, poolOpId, AMOUNT);
         _rebalance(p);
 
@@ -630,7 +630,7 @@ contract BridgeRebalanceTest is Test {
         // Scenario A: operational, no external burn → NullVerifier, empty proof
         // and empty debit settlement. The credit leg writes the mint/burn record
         // (tagged with the mint/burn network) and emits the inflate FundsIn.
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit FundsIn(multisig, inflateOpId, AMOUNT);
         _rebalance(p);
 

--- a/ethereum/test/MultisigProxy.t.sol
+++ b/ethereum/test/MultisigProxy.t.sol
@@ -1702,28 +1702,36 @@ contract MultisigProxyTest is Test {
         _assertGenericPathsRejectSelector(callData, IMultisigProxy.ForbiddenBridgeReleaseSelector.selector);
     }
 
+    function test_federationGenericPathsCannotDesyncCommissionManager() public {
+        bytes memory callData = abi.encodeCall(IBridge.setCommissionManager, (makeAddr("genericCm")));
+        _assertGenericPathsRejectSelector(callData, IMultisigProxy.ForbiddenCommissionManagerSelector.selector);
+    }
+
     // ========================================================================
     // Propose + Execute — UpdateCommissionManager
     // ========================================================================
 
     function test_proposeUpdateCommissionManager_execute() public {
-        address newCm = makeAddr("newCm");
+        CommissionManager newCm = new CommissionManager(address(bridge), commissionReceiver);
         uint256 nonce = proxy.proposalNonce();
         uint256 deadline = block.timestamp + 1 days;
 
-        bytes32 digest = MultisigHelper.digestProposeUpdateCommissionManager(domainSep, newCm, nonce, deadline);
+        bytes32 digest = MultisigHelper.digestProposeUpdateCommissionManager(domainSep, address(newCm), nonce, deadline);
         (uint256[] memory pks, uint256 bitmap) = _fedSigSet2of3();
         bytes[] memory sigs = MultisigHelper.signAll(vm, digest, pks);
 
-        bytes32 id = proxy.proposeUpdateCommissionManager(newCm, nonce, deadline, bitmap, sigs);
+        bytes32 id = proxy.proposeUpdateCommissionManager(address(newCm), nonce, deadline, bitmap, sigs);
 
         vm.warp(block.timestamp + TIMELOCK + 1);
 
-        vm.expectEmit(true, true, false, false);
-        emit CommissionManagerUpdated(address(cm), newCm);
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit CommissionManagerUpdated(address(cm), address(newCm));
+        vm.expectEmit(true, true, false, true, address(proxy));
+        emit CommissionManagerUpdated(address(cm), address(newCm));
 
-        proxy.executeProposal(id, abi.encode(newCm));
-        assertEq(proxy.commissionManager(), newCm);
+        proxy.executeProposal(id, abi.encode(address(newCm)));
+        assertEq(proxy.commissionManager(), address(newCm));
+        assertEq(address(bridge.commissionManager()), address(newCm));
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

- Made `Bridge.commissionManager` mutable.
- Added an owner-only, non-zero `setCommissionManager` setter.
- Updated the typed `UpdateCommissionManager` operation to atomically update
  both Bridge and MultisigProxy.
- Blocked `setCommissionManager` from generic execution lanes to prevent pointer
  desynchronization.
- Removed `indexed` from `rgbOpId` in the RGB-specific `FundsIn` event.
- Updated tests and deployment documentation.

## CommissionManager migration

A replacement CommissionManager must be deployed with the current Bridge as its
`bridgeAddress` and configured before migration.

After initiating its ownership transfer to MultisigProxy:

1. Execute the timelocked `UpdateCommissionManager` proposal.
2. Execute `AdminExecuteCommissionManager(acceptOwnership())`.

The first operation updates the Bridge and proxy pointers atomically.
